### PR TITLE
Read BYOK key presence from the device keychain, and fix the picker portal

### DIFF
--- a/src/agentMode/backends/opencode/opencodeModelResolve.test.ts
+++ b/src/agentMode/backends/opencode/opencodeModelResolve.test.ts
@@ -122,7 +122,7 @@ describe("opencodeModelResolve", () => {
         providers: { p1: byokProvider({ apiKeyKeychainId: null }) },
         configuredModels: [makeModel("cm1", "p1", "qwen/qwen3-max")],
       });
-      const [entry] = opencodeEnabledModelEntries(settings);
+      const [entry] = opencodeEnabledModelEntries(settings, () => false);
       expect(entry.baseModelId).toBe("openrouter/qwen/qwen3-max");
       expect(entry.credentialState).toBe("missing_key");
     });
@@ -140,9 +140,22 @@ describe("opencodeModelResolve", () => {
           },
         ],
       });
-      const [entry] = opencodeEnabledModelEntries(settings);
+      const [entry] = opencodeEnabledModelEntries(settings, () => true);
       expect(entry.credentialState).toBe("ok");
       expect(entry.name).toBe("Big X");
+    });
+
+    it("flags missing_key when the pointer is set but the live presence probe says no key (https://github.com/logancyang/obsidian-copilot-preview/issues/261)", () => {
+      // The Delete All Keys shape: the synced pointer survives while this
+      // device's keychain entry is gone — presence is the probe's answer,
+      // never the pointer's existence.
+      const settings = makeSettings({
+        enabledModels: ["cm1"],
+        providers: { p1: byokProvider() },
+        configuredModels: [makeModel("cm1", "p1", "qwen/qwen3-max")],
+      });
+      const [entry] = opencodeEnabledModelEntries(settings, () => false);
+      expect(entry.credentialState).toBe("missing_key");
     });
 
     it("treats agent-origin (native) models as ok regardless of key", () => {
@@ -192,7 +205,9 @@ describe("opencodeModelResolve", () => {
         },
         configuredModels: [makeModel("cloud", "pc", "gpt-4o"), makeModel("local", "pl", "llama3")],
       });
-      const byId = new Map(opencodeEnabledModelEntries(settings).map((e) => [e.baseModelId, e]));
+      const byId = new Map(
+        opencodeEnabledModelEntries(settings, () => true).map((e) => [e.baseModelId, e])
+      );
       expect(byId.get("openai/gpt-4o")?.needsSelfHostWarning).toBe(true);
       expect(byId.get("ollama/llama3")?.needsSelfHostWarning).toBe(false);
     });
@@ -211,7 +226,7 @@ describe("opencodeModelResolve", () => {
         },
         configuredModels: [makeModel("cloud", "pc", "gpt-4o")],
       });
-      expect(opencodeEnabledModelEntries(settings)[0].needsSelfHostWarning).toBe(false);
+      expect(opencodeEnabledModelEntries(settings, () => true)[0].needsSelfHostWarning).toBe(false);
     });
 
     it("returns the shared frozen empty array when nothing is enabled", () => {
@@ -225,7 +240,12 @@ describe("opencodeModelResolve", () => {
     it("builds the `<provider>/<model>` wire base id for copilot-plus models", () => {
       const settings = makeSettings({
         enabledModels: ["cm1"],
-        providers: { p1: makeProvider("p1", { kind: "copilot-plus" }) },
+        // Reason: production Plus rows carry `requiresApiKey: false`
+        // (`CopilotPlusSetupApi`), so credential projection short-circuits
+        // before any keychain probe.
+        providers: {
+          p1: { ...makeProvider("p1", { kind: "copilot-plus" }), requiresApiKey: false },
+        },
         configuredModels: [makeModel("cm1", "p1", "copilot-plus-flash")],
       });
       expect(opencodeEnabledModelEntries(settings)[0].baseModelId).toBe(

--- a/src/agentMode/backends/opencode/opencodeModelResolve.test.ts
+++ b/src/agentMode/backends/opencode/opencodeModelResolve.test.ts
@@ -1,5 +1,7 @@
+import type { App } from "obsidian";
 import type { CopilotSettings } from "@/settings/model";
 import type { ConfiguredModel, Provider, ProviderOrigin, ProviderType } from "@/modelManagement";
+import { KeychainService } from "@/services/keychainService";
 import { ChatModelProviders } from "@/constants";
 import {
   COPILOT_PLUS_OPENCODE_PROVIDER_ID,
@@ -114,6 +116,37 @@ describe("opencodeModelResolve", () => {
       requiresApiKey: true,
       apiKeyKeychainId: "kc-1",
       ...overrides,
+    });
+
+    it("resolves credential state through the live keychain when no probe is injected (https://github.com/logancyang/obsidian-copilot-preview/issues/261)", () => {
+      // Exercises the production default probe (KeychainService singleton +
+      // live read) that every other case bypasses via injection — a regression
+      // in that wiring must not stay green behind injected predicates.
+      const secrets = new Map<string, string>();
+      const app = {
+        vault: { adapter: {} },
+        secretStorage: {
+          getSecret: (id: string) => secrets.get(id) ?? null,
+        },
+      } as unknown as App;
+      const settings = makeSettings({
+        enabledModels: ["cm1"],
+        providers: { p1: byokProvider() },
+        configuredModels: [makeModel("cm1", "p1", "qwen/qwen3-max")],
+      });
+
+      KeychainService.resetInstance();
+      KeychainService.getInstance(app);
+      try {
+        // The pointer is set but this device's keychain has no entry for it.
+        expect(opencodeEnabledModelEntries(settings)[0].credentialState).toBe("missing_key");
+
+        secrets.set("kc-1", "sk-live");
+        expect(opencodeEnabledModelEntries(settings)[0].credentialState).toBe("ok");
+      } finally {
+        // Only this case owns the singleton; later cases must not inherit it.
+        KeychainService.resetInstance();
+      }
     });
 
     it("flags a required-key provider with no key as missing_key", () => {

--- a/src/agentMode/backends/opencode/opencodeModelResolve.ts
+++ b/src/agentMode/backends/opencode/opencodeModelResolve.ts
@@ -2,9 +2,11 @@ import type { CopilotSettings } from "@/settings/model";
 import type { ConfiguredModel, Provider } from "@/modelManagement";
 import {
   capabilitiesFromConfiguredInfo,
+  providerHasApiKey,
   providerNeedsSelfHostWarning,
   providerRequiresApiKey,
 } from "@/modelManagement";
+import { KeychainService } from "@/services/keychainService";
 import type { EnabledModelCredentialState, EnabledModelEntry } from "@/agentMode/session/types";
 
 export interface OpencodeProviderMapping {
@@ -120,15 +122,34 @@ export function opencodeWireBaseIdFor(
 }
 
 /**
- * Credential health for an enabled opencode model, derived purely from the
- * persisted provider row (sync — no keychain read). Native (agent-hosted)
+ * Credential health for an enabled opencode model. Native (agent-hosted)
  * providers carry their own auth, so they're always `ok`. Otherwise a
- * required-key provider with no key reads `missing_key`.
+ * required-key provider whose key is absent from this device's keychain
+ * reads `missing_key` — presence is `hasKey`'s live local read, never the
+ * synced `apiKeyKeychainId` pointer (see the note on that field).
+ * https://github.com/logancyang/obsidian-copilot-preview/issues/261
  */
-function credentialStateFor(provider: Provider, native: boolean): EnabledModelCredentialState {
+function credentialStateFor(
+  provider: Provider,
+  native: boolean,
+  hasKey: (provider: Provider) => boolean
+): EnabledModelCredentialState {
   if (native) return "ok";
-  if (providerRequiresApiKey(provider) && !provider.apiKeyKeychainId) return "missing_key";
+  if (providerRequiresApiKey(provider) && !hasKey(provider)) return "missing_key";
   return "ok";
+}
+
+/**
+ * Default presence probe: live read against this device's keychain.
+ *
+ * Relies on plugin startup having initialized `KeychainService` before any
+ * model resolution runs — the same contract `loadSettingsWithKeychain` uses.
+ * Keychain read failures are absorbed by `providerHasApiKey`; a missing
+ * service is a wiring error and must surface rather than be reported as
+ * "user has no key".
+ */
+function defaultHasKey(provider: Provider): boolean {
+  return providerHasApiKey(provider, KeychainService.getInstance());
 }
 
 /**
@@ -140,7 +161,8 @@ function credentialStateFor(provider: Provider, native: boolean): EnabledModelCr
  * via `opencodeWireBaseId`; unroutable / missing entries are skipped.
  */
 export function opencodeEnabledModelEntries(
-  settings: CopilotSettings
+  settings: CopilotSettings,
+  hasKey: (provider: Provider) => boolean = defaultHasKey
 ): readonly EnabledModelEntry[] {
   const enabledIds = settings.backends.opencode?.enabledModels ?? [];
   if (enabledIds.length === 0) return EMPTY_ENABLED_ENTRIES;
@@ -164,7 +186,7 @@ export function opencodeEnabledModelEntries(
       baseModelId,
       name: configuredModel.info.displayName || configuredModel.info.id,
       description: configuredModel.info.description,
-      credentialState: credentialStateFor(provider, mapping.native),
+      credentialState: credentialStateFor(provider, mapping.native, hasKey),
       isFree: isOpencodeZenWireId(baseModelId),
       capabilities: capabilitiesFromConfiguredInfo(configuredModel.info),
       needsSelfHostWarning: providerNeedsSelfHostWarning(provider, settings),

--- a/src/components/chat-components/ChatInput.tsx
+++ b/src/components/chat-components/ChatInput.tsx
@@ -884,6 +884,13 @@ const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(function Cha
               lexicalEditorRef={lexicalEditorRef}
             />
           )}
+          {/* All three pickers portal into this pane's own tree via
+              `containerRef`. The wrappers' default host (`activeDocument.body`)
+              tracks window focus, not component ownership: a settings change
+              re-renders this pane while the settings window is focused, the
+              stale host is captured, and once that window closes the menus
+              open into a destroyed document — trigger toggles, nothing shows.
+              https://github.com/logancyang/obsidian-copilot-preview/issues/204 */}
           {modelPickerOverride?.effortOptionsByModelKey && modelPickerOverride.commitSelection ? (
             // Agent Mode: always use the merged picker, even when the active
             // model has no effort dimension — the user can still switch to
@@ -898,6 +905,7 @@ const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(function Cha
                 commitSelection: modelPickerOverride.commitSelection,
               }}
               className="tw-min-w-0 tw-max-w-full tw-truncate"
+              container={containerRef.current}
             />
           ) : (
             <ModelSelector
@@ -909,13 +917,16 @@ const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(function Cha
               apiKeySettings={modelPickerOverride ? undefined : settings}
               onChange={modelPickerOverride?.onChange ?? setCurrentModelKey}
               className="tw-min-w-0 tw-max-w-full tw-truncate"
+              container={containerRef.current}
             />
           )}
         </div>
 
         <div className="tw-flex tw-items-center tw-gap-1">
           {!isGenerating && toolControls}
-          {modePickerOverride && <ModePicker override={modePickerOverride} />}
+          {modePickerOverride && (
+            <ModePicker override={modePickerOverride} container={containerRef.current} />
+          )}
           {isGenerating ? (
             <Button
               size="icon"

--- a/src/components/chat-components/ChatInput.tsx
+++ b/src/components/chat-components/ChatInput.tsx
@@ -265,7 +265,18 @@ const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(function Cha
   const [contextUrls, setContextUrls] = useState<string[]>(initialContext?.urls || []);
   const [contextFolders, setContextFolders] = useState<string[]>(initialContext?.folders || []);
   const [contextWebTabs, setContextWebTabs] = useState<WebTabContext[]>([]);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  // Portal host for the pickers, held in state rather than read from the ref:
+  // the first render passes before the ref attaches, and a ref attachment
+  // alone never re-renders — a pane mounted while another Obsidian window has
+  // focus would hand the pickers a null host for good. The state write on
+  // attach re-renders once and refreshes all three picker props.
+  // https://github.com/logancyang/obsidian-copilot-preview/issues/204
+  const [portalContainer, setPortalContainer] = useState<HTMLDivElement | null>(null);
+  const setContainerEl = useCallback((el: HTMLDivElement | null) => {
+    containerRef.current = el;
+    setPortalContainer(el);
+  }, []);
   const lexicalEditorRef = useRef<LexicalEditorType | null>(null);
   const [currentModelKey, setCurrentModelKey] = useModelKey();
   const settings = useSettingsValue();
@@ -770,7 +781,7 @@ const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(function Cha
         modePickerOverride?.value === "auto" &&
           "tw-shadow-[0_0_10px_rgba(var(--color-red-rgb),0.18)] tw-border-red/60"
       )}
-      ref={containerRef}
+      ref={setContainerEl}
     >
       {/* Two columns: the content stack, and (when provided) a structural
           accessory column. A column, not an overlay, so badges, images,
@@ -905,7 +916,7 @@ const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(function Cha
                 commitSelection: modelPickerOverride.commitSelection,
               }}
               className="tw-min-w-0 tw-max-w-full tw-truncate"
-              container={containerRef.current}
+              container={portalContainer}
             />
           ) : (
             <ModelSelector
@@ -917,7 +928,7 @@ const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(function Cha
               apiKeySettings={modelPickerOverride ? undefined : settings}
               onChange={modelPickerOverride?.onChange ?? setCurrentModelKey}
               className="tw-min-w-0 tw-max-w-full tw-truncate"
-              container={containerRef.current}
+              container={portalContainer}
             />
           )}
         </div>
@@ -925,7 +936,7 @@ const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(function Cha
         <div className="tw-flex tw-items-center tw-gap-1">
           {!isGenerating && toolControls}
           {modePickerOverride && (
-            <ModePicker override={modePickerOverride} container={containerRef.current} />
+            <ModePicker override={modePickerOverride} container={portalContainer} />
           )}
           {isGenerating ? (
             <Button

--- a/src/components/chat-components/useChatModelPicker.test.tsx
+++ b/src/components/chat-components/useChatModelPicker.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * Behavior tests for the chat model picker's credential gating.
+ *
+ * These drive the REAL invalidation chain end to end — `forgetAllSecrets()` /
+ * `ProviderRegistry.setApiKey()` → settings store → `providersAtom` →
+ * `backendPickerAtomFamily("chat")` → the hook's memo → `_disabledReason` —
+ * rather than asserting that a row object was cloned. A future change that
+ * breaks any link in that chain (atom dependency, memo deps, `syncMemory`
+ * wiring) fails here, which identity assertions could not catch.
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import React from "react";
+import type { App } from "obsidian";
+
+import { AppContext } from "@/context";
+import { KeychainService } from "@/services/keychainService";
+import { ProviderAdapterRegistry, ProviderRegistry } from "@/modelManagement";
+import type { Provider } from "@/modelManagement";
+import {
+  getSettings,
+  resetSettings,
+  setSettings,
+  settingsStore,
+  settingsAtom,
+} from "@/settings/model";
+import type { CopilotSettings } from "@/settings/model";
+
+import { useChatModelPicker } from "./useChatModelPicker";
+
+jest.mock("@/logger", () => ({
+  logInfo: jest.fn(),
+  logWarn: jest.fn(),
+  logError: jest.fn(),
+}));
+
+const KEYCHAIN_ID = "copilot-vtest0000-provider-p1";
+
+let secrets: Map<string, string>;
+let app: App;
+
+function makeApp(): App {
+  return {
+    secretStorage: {
+      setSecret: (id: string, value: string) => {
+        secrets.set(id, value);
+      },
+      getSecret: (id: string) => (secrets.has(id) ? secrets.get(id)! : null),
+      listSecrets: () => Array.from(secrets.keys()),
+      deleteSecret: (id: string) => {
+        secrets.delete(id);
+      },
+    },
+    vault: { adapter: {} },
+  } as unknown as App;
+}
+
+function seedConfiguredProvider(): void {
+  const provider: Provider = {
+    providerId: "p1",
+    providerType: "openai-compatible",
+    displayName: "My OpenAI",
+    origin: { kind: "byok", catalogProviderId: "openai" },
+    addedAt: 0,
+    requiresApiKey: true,
+    apiKeyKeychainId: KEYCHAIN_ID,
+  };
+  setSettings({
+    providers: { p1: provider },
+    configuredModels: [
+      {
+        configuredModelId: "cm1",
+        providerId: "p1",
+        info: { id: "gpt-4", displayName: "GPT-4" },
+        configuredAt: 0,
+      },
+    ],
+    backends: { chat: { enabledModels: ["cm1"] } },
+  });
+}
+
+function renderPicker() {
+  return renderHook(() => useChatModelPicker({ value: "cm1", onChange: jest.fn() }), {
+    wrapper: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(AppContext.Provider, { value: app }, children),
+  });
+}
+
+/**
+ * The reason the picker shows for the seeded model, or `undefined`.
+ *
+ * Selected by name because the picker also advertises locked Copilot preview
+ * rows ahead of the configured ones.
+ */
+function disabledReason(result: { current: ReturnType<typeof useChatModelPicker> }) {
+  return result.current.models.find((model) => model.name === "cm1")?._disabledReason;
+}
+
+describe("useChatModelPicker", () => {
+  describe("useChatModelPicker()", () => {
+    beforeEach(() => {
+      secrets = new Map();
+      app = makeApp();
+      resetSettings();
+      KeychainService.resetInstance();
+      KeychainService.getInstance(app).setVaultId("test0000");
+      seedConfiguredProvider();
+    });
+
+    it("leaves a model selectable while its provider's key is in this device's keychain", () => {
+      secrets.set(KEYCHAIN_ID, "sk-live");
+      const { result } = renderPicker();
+      expect(result.current.models.some((model) => model.name === "cm1")).toBe(true);
+      expect(disabledReason(result)).toBeUndefined();
+    });
+
+    it("gates the model behind 'Add API key' once Delete All Keys removes the entry, then clears the gate when the key is re-entered under the same pointer (https://github.com/logancyang/obsidian-copilot-preview/issues/261)", async () => {
+      secrets.set(KEYCHAIN_ID, "sk-live");
+      const { result } = renderPicker();
+      expect(disabledReason(result)).toBeUndefined();
+
+      // Real Delete All Keys: strips secrets, clears this vault's keychain, and
+      // syncs memory. The provider row keeps its pointer, so only the fresh slice
+      // identity can make the picker re-read the keychain.
+      await act(async () => {
+        await KeychainService.getInstance(app).forgetAllSecrets(
+          async () => {},
+          (data: Partial<CopilotSettings>) => setSettings(data)
+        );
+      });
+      expect(secrets.has(KEYCHAIN_ID)).toBe(false);
+      expect(getSettings().providers.p1.apiKeyKeychainId).toBe(KEYCHAIN_ID);
+      expect(disabledReason(result)).toBe("Add API key");
+
+      // Real re-entry: same provider, same derived pointer, keychain-only write.
+      const registry = new ProviderRegistry(app, new ProviderAdapterRegistry());
+      await act(async () => {
+        await registry.setApiKey("p1", "sk-fresh");
+      });
+      expect(disabledReason(result)).toBeUndefined();
+    });
+
+    it("keeps a keyless provider's model selectable — presence is only asked of key-requiring providers", () => {
+      settingsStore.set(settingsAtom, (prev) => ({
+        ...prev,
+        providers: {
+          p1: { ...prev.providers.p1, requiresApiKey: false },
+        },
+      }));
+      const { result } = renderPicker();
+      expect(disabledReason(result)).toBeUndefined();
+    });
+  });
+});

--- a/src/components/chat-components/useChatModelPicker.ts
+++ b/src/components/chat-components/useChatModelPicker.ts
@@ -2,9 +2,12 @@ import {
   backendPickerAtomFamily,
   capabilitiesFromConfiguredInfo,
   mapProviderTypeToChatModelProvider,
+  providerHasApiKey,
   providerRequiresApiKey,
   resolveChatModelSelectionId,
 } from "@/modelManagement";
+import { useApp } from "@/context";
+import { KeychainService } from "@/services/keychainService";
 import { getModelKeyFromModel, settingsStore, useSettingsValue } from "@/settings/model";
 import type { ModelSelectorEntry } from "@/components/ui/ModelSelector";
 import { lockedCopilotEntries, shouldPreviewCopilotModels } from "@/lib/lockedCopilotEntries";
@@ -57,6 +60,7 @@ export function useChatModelPicker(params: {
   onChange: (configuredModelId: string) => void;
 }): ChatModelPickerOverride {
   const { value, onChange } = params;
+  const app = useApp();
   const entries = useAtomValue(backendPickerAtomFamily("chat"), { store: settingsStore });
   const settings = useSettingsValue();
 
@@ -69,6 +73,7 @@ export function useChatModelPicker(params: {
   );
 
   const { models, byModelKey, idToModelKey } = React.useMemo(() => {
+    const keychain = KeychainService.getInstance(app);
     const models: ModelSelectorEntry[] = [];
     const byModelKey = new Map<string, string>();
     const idToModelKey = new Map<string, string>();
@@ -79,7 +84,7 @@ export function useChatModelPicker(params: {
       // data so unknown models stay unblocked; only a populated array (which may
       // be empty) asserts "known". See the image guard in `Chat.tsx`.
       const capabilities = capabilitiesFromConfiguredInfo(configuredModel.info);
-      const needsKey = providerRequiresApiKey(provider) && !provider.apiKeyKeychainId;
+      const needsKey = providerRequiresApiKey(provider) && !providerHasApiKey(provider, keychain);
       const modelEntry: ModelSelectorEntry = {
         name: configuredModelId,
         provider: mapProviderTypeToChatModelProvider(provider),
@@ -95,7 +100,13 @@ export function useChatModelPicker(params: {
       idToModelKey.set(configuredModelId, modelKey);
     }
     return { models, byModelKey, idToModelKey };
-  }, [entries]);
+    // Reason: key presence is read from the local keychain, which React cannot
+    // observe directly. Both credential writers refresh the providers slice
+    // identity (`forgetAllSecrets` after the sweep, `setApiKey` after a
+    // same-pointer rewrite), which flows through `providersAtom` into a new
+    // `entries` array — so `entries` is the invalidation signal for the
+    // keychain reads below.
+  }, [entries, app]);
 
   const resolvedValue = React.useMemo(() => {
     const resolvedId = resolveChatModelSelectionId(entries, value);

--- a/src/components/ui/ModePicker.tsx
+++ b/src/components/ui/ModePicker.tsx
@@ -20,6 +20,12 @@ export interface ModePickerOverride {
 interface ModePickerProps {
   override: ModePickerOverride;
   className?: string;
+  /**
+   * Portal host for the dropdown — an element from the caller's own tree, so
+   * the menu mounts in the picker's document rather than the focused window's.
+   * https://github.com/logancyang/obsidian-copilot-preview/issues/204
+   */
+  container?: HTMLElement | null;
 }
 
 /**
@@ -49,7 +55,7 @@ export function getModeLabel(value: CopilotMode): string {
   return MODE_DISPLAY[value]?.label ?? value;
 }
 
-export function ModePicker({ override, className }: ModePickerProps) {
+export function ModePicker({ override, className, container }: ModePickerProps) {
   const { options, value, onChange, disabled } = override;
   const triggerLabel = value ? getModeLabel(value) : "Mode";
 
@@ -74,7 +80,7 @@ export function ModePicker({ override, className }: ModePickerProps) {
           {!disabled && <ChevronDown className="tw-mt-0.5 tw-size-4 tw-shrink-0" />}
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="tw-w-[320px]">
+      <DropdownMenuContent align="start" className="tw-w-[320px]" container={container}>
         {options.map((opt) => {
           const display = MODE_DISPLAY[opt.value];
           const isActive = value === opt.value;

--- a/src/components/ui/ModelEffortPicker.tsx
+++ b/src/components/ui/ModelEffortPicker.tsx
@@ -35,6 +35,12 @@ export interface ModelEffortPickerOverride {
 interface ModelEffortPickerProps {
   override: ModelEffortPickerOverride;
   className?: string;
+  /**
+   * Portal host for the popover — an element from the caller's own tree, so
+   * the panel mounts in the picker's document rather than the focused window's.
+   * https://github.com/logancyang/obsidian-copilot-preview/issues/204
+   */
+  container?: HTMLElement | null;
 }
 
 interface EffortOpt {
@@ -47,7 +53,7 @@ interface EffortOpt {
  * path swaps the active session mid-interaction, which would collapse the
  * popover before the user could pick an effort.
  */
-export function ModelEffortPicker({ override, className }: ModelEffortPickerProps) {
+export function ModelEffortPicker({ override, className, container }: ModelEffortPickerProps) {
   const { models, value, effort, effortOptionsByModelKey, commitSelection, disabled } = override;
 
   const [open, setOpen] = useState(false);
@@ -236,6 +242,7 @@ export function ModelEffortPicker({ override, className }: ModelEffortPickerProp
         side="top"
         sideOffset={4}
         onKeyDown={handleKeyDown}
+        container={container}
       >
         <div className="tw-max-h-72 tw-overflow-y-auto tw-py-1" role="listbox" aria-label="Model">
           {models.map((entry) => {

--- a/src/components/ui/ModelSelector.test.tsx
+++ b/src/components/ui/ModelSelector.test.tsx
@@ -31,6 +31,42 @@ describe("ModelSelector", () => {
       cloudWarningProps.length = 0;
     });
 
+    it("mounts the dropdown into the caller-provided container instead of the focused window's body (https://github.com/logancyang/obsidian-copilot-preview/issues/204)", async () => {
+      const host = document.createElement("div");
+      document.body.appendChild(host);
+      // Simulate the failure window: another Obsidian window (settings) holds
+      // focus, so the wrappers' `activeDocument` fallback points away from the
+      // document the picker lives in.
+      const otherWindowDoc = document.implementation.createHTMLDocument("settings-window");
+      const globals = window as unknown as { activeDocument: Document };
+      const originalActiveDocument = globals.activeDocument;
+      Object.defineProperty(window, "activeDocument", {
+        configurable: true,
+        value: otherWindowDoc,
+      });
+      try {
+        render(
+          <ModelSelector
+            value="gpt-5|openai"
+            onChange={jest.fn()}
+            models={[model({})]}
+            container={host}
+          />
+        );
+        fireEvent.keyDown(screen.getByRole("button"), { key: "Enter" });
+
+        const menu = await screen.findByRole("menu");
+        expect(host.contains(menu)).toBe(true);
+        expect(otherWindowDoc.querySelector("[role=menu]")).toBeNull();
+      } finally {
+        Object.defineProperty(window, "activeDocument", {
+          configurable: true,
+          value: originalActiveDocument,
+        });
+        host.remove();
+      }
+    });
+
     it("shows the cloud-egress warning on the collapsed trigger when the current model needs it", () => {
       const cloud = model({ _needsSelfHostWarning: true });
       render(<ModelSelector value="gpt-5|openai" onChange={jest.fn()} models={[cloud]} />);

--- a/src/components/ui/ModelSelector.tsx
+++ b/src/components/ui/ModelSelector.tsx
@@ -87,6 +87,14 @@ interface ModelSelectorProps {
    * authentication and `_disabledReason` is the only availability gate.
    */
   apiKeySettings?: Readonly<ModelApiKeySettings>;
+  /**
+   * Portal host for the dropdown. Pass an element from the caller's own tree
+   * so the menu mounts in the document the picker lives in; the default
+   * (`activeDocument.body`) tracks window focus, not component ownership, and
+   * goes stale when the picker re-renders while another Obsidian window is
+   * focused. https://github.com/logancyang/obsidian-copilot-preview/issues/204
+   */
+  container?: HTMLElement | null;
 }
 
 export function ModelSelector({
@@ -98,6 +106,7 @@ export function ModelSelector({
   onChange,
   models,
   apiKeySettings,
+  container,
 }: ModelSelectorProps) {
   const [modelError, setModelError] = useState<string | null>(null);
 
@@ -136,7 +145,11 @@ export function ModelSelector({
         </Button>
       </DropdownMenuTrigger>
 
-      <DropdownMenuContent align="start" className="tw-max-h-64 tw-overflow-y-auto">
+      <DropdownMenuContent
+        align="start"
+        className="tw-max-h-64 tw-overflow-y-auto"
+        container={container}
+      >
         {visible.map((model) => {
           const disabledReason = model._disabledReason;
           const hasApiKey = apiKeySettings

--- a/src/modelManagement/index.ts
+++ b/src/modelManagement/index.ts
@@ -35,6 +35,7 @@ export { ProviderRegistry } from "./providers/ProviderRegistry";
 export { isSelfHostedProvider, isSelfHostedUrl } from "./providers/isSelfHostedProvider";
 export { providerNeedsSelfHostWarning } from "./providers/selfHostPolicy";
 export type { SelfHostPolicyInput } from "./providers/selfHostPolicy";
+export { providerHasApiKey } from "./providers/providerHasApiKey";
 export { providerRequiresApiKey } from "./providers/providerRequiresApiKey";
 export { ConfiguredModelRegistry } from "./models/ConfiguredModelRegistry";
 export { BackendConfigRegistry } from "./backends/BackendConfigRegistry";

--- a/src/modelManagement/providers/ProviderRegistry.test.ts
+++ b/src/modelManagement/providers/ProviderRegistry.test.ts
@@ -288,6 +288,17 @@ describe("ProviderRegistry", () => {
     expect(getSettings().providers[id]).toBeUndefined();
   });
 
+  describe("notifyCredentialStoreChanged()", () => {
+    it("notifies subscribers after an external credential-store mutation (https://github.com/logancyang/obsidian-copilot-preview/issues/261)", () => {
+      const listener = jest.fn();
+      registry.subscribe(listener);
+
+      registry.notifyCredentialStoreChanged();
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("subscribe()", () => {
     it("fires on add/update/remove and on every setApiKey (including key rotation)", async () => {
       const listener = jest.fn();

--- a/src/modelManagement/providers/ProviderRegistry.test.ts
+++ b/src/modelManagement/providers/ProviderRegistry.test.ts
@@ -187,6 +187,24 @@ describe("ProviderRegistry", () => {
     expect(await registry.getApiKey(id)).toBe("sk-rotated");
   });
 
+  it("setApiKey rewrites the key under the same pointer without changing the row's content", async () => {
+    const id = await registry.add({
+      providerType: "anthropic",
+      displayName: "A",
+      origin: { kind: "byok" },
+    });
+    await registry.setApiKey(id, "sk-first");
+    const rowBefore = registry.get(id)!;
+
+    await registry.setApiKey(id, "sk-rotated");
+
+    // Content is untouched: a rotation reuses the pointer, so settings carry
+    // no evidence the key changed. That the UI still re-reads the keychain is
+    // covered end to end by `useChatModelPicker.test.tsx`.
+    expect(registry.get(id)!).toEqual(rowBefore);
+    expect(await registry.getApiKey(id)).toBe("sk-rotated");
+  });
+
   it("update() ignores attempts to overwrite apiKeyKeychainId", async () => {
     const id = await registry.add({
       providerType: "anthropic",

--- a/src/modelManagement/providers/ProviderRegistry.ts
+++ b/src/modelManagement/providers/ProviderRegistry.ts
@@ -88,6 +88,20 @@ export class ProviderRegistry {
     return () => this.#listeners.delete(listener);
   }
 
+  /**
+   * Notify subscribers after provider credentials were mutated outside this
+   * registry (e.g. the "Delete All Keys" keychain sweep). Subprocess agent
+   * backends bake provider keys into spawn-time config and only restart on
+   * registry emissions, so an external credential wipe must be announced here
+   * or a running backend keeps using the deleted key indefinitely. Call only
+   * after the credential-store operation and its in-memory settings projection
+   * have settled, so restarted consumers read final state.
+   * https://github.com/logancyang/obsidian-copilot-preview/issues/261
+   */
+  notifyCredentialStoreChanged(): void {
+    this.#emit();
+  }
+
   #emit(): void {
     for (const listener of [...this.#listeners]) {
       try {

--- a/src/modelManagement/providers/ProviderRegistry.ts
+++ b/src/modelManagement/providers/ProviderRegistry.ts
@@ -284,7 +284,27 @@ export class ProviderRegistry {
       this.#setApiKeyKeychainId(providerId, keychainId);
     }
     keychain.setSecretById(keychainId, apiKey);
+    if (row.apiKeyKeychainId === keychainId) {
+      // Reason: a same-pointer rewrite (e.g. re-entering a key after Delete
+      // All Keys tombstoned the entry) changes only the keychain, which
+      // settings subscribers cannot see. Key badges are a live keychain read
+      // re-run when the row identity changes, so refresh the row — same
+      // content, new reference — or "No key" would stick until restart.
+      // https://github.com/logancyang/obsidian-copilot-preview/issues/261
+      this.#touchProviderRow(providerId);
+    }
     this.#emit();
+  }
+
+  /** Internal: re-issue a provider row with a fresh identity so settings
+   *  subscribers (and the derived picker atoms) re-run keychain-backed
+   *  reads. No fields change. */
+  #touchProviderRow(providerId: string): void {
+    setSettings((cur) => {
+      const current = cur.providers[providerId];
+      if (!current) return {};
+      return { providers: { ...cur.providers, [providerId]: { ...current } } };
+    });
   }
 
   /** Drops the keychain entry and clears `apiKeyKeychainId` on the row. */

--- a/src/modelManagement/providers/providerHasApiKey.test.ts
+++ b/src/modelManagement/providers/providerHasApiKey.test.ts
@@ -1,0 +1,52 @@
+import type { Provider } from "@/modelManagement/types/persisted";
+import { providerHasApiKey } from "./providerHasApiKey";
+
+function provider(overrides: Partial<Provider> = {}): Provider {
+  return {
+    providerId: "p1",
+    providerType: "openai-compatible",
+    displayName: "P",
+    origin: { kind: "byok" },
+    addedAt: 0,
+    apiKeyKeychainId: "kc-p1",
+    ...overrides,
+  };
+}
+
+function keychainWith(value: string | null) {
+  return { getSecretById: jest.fn().mockReturnValue(value) };
+}
+
+describe("providerHasApiKey", () => {
+  describe("providerHasApiKey()", () => {
+    it("returns true only when the pointer's keychain entry holds a value", () => {
+      expect(providerHasApiKey(provider(), keychainWith("sk-live"))).toBe(true);
+    });
+
+    it("returns false without a pointer, and never consults the keychain", () => {
+      const keychain = keychainWith("sk-live");
+      expect(providerHasApiKey(provider({ apiKeyKeychainId: null }), keychain)).toBe(false);
+      expect(providerHasApiKey(provider({ apiKeyKeychainId: undefined }), keychain)).toBe(false);
+      expect(keychain.getSecretById).not.toHaveBeenCalled();
+    });
+
+    it("returns false for a missing entry — the pointer alone is not evidence (https://github.com/logancyang/obsidian-copilot-preview/issues/261)", () => {
+      // The Delete All Keys shape: the synced pointer survives while this
+      // device's entry is gone.
+      expect(providerHasApiKey(provider(), keychainWith(null))).toBe(false);
+    });
+
+    it("returns false for a tombstoned ('') entry (https://github.com/logancyang/obsidian-copilot-preview/issues/261)", () => {
+      expect(providerHasApiKey(provider(), keychainWith(""))).toBe(false);
+    });
+
+    it("returns false when the keychain read throws — rendering must not (https://github.com/logancyang/obsidian-copilot-preview/issues/261)", () => {
+      const keychain = {
+        getSecretById: jest.fn(() => {
+          throw new Error("SecretStorage unavailable");
+        }),
+      };
+      expect(providerHasApiKey(provider(), keychain)).toBe(false);
+    });
+  });
+});

--- a/src/modelManagement/providers/providerHasApiKey.ts
+++ b/src/modelManagement/providers/providerHasApiKey.ts
@@ -1,0 +1,35 @@
+import type { Provider } from "@/modelManagement/types/persisted";
+import type { KeychainService } from "@/services/keychainService";
+
+/**
+ * The single runtime read point for "does this provider have an API key on
+ * THIS device".
+ *
+ * `provider.apiKeyKeychainId` alone cannot answer that question: the pointer
+ * syncs with `data.json`, while the keychain entry it names is device-local.
+ * After "Delete All Keys" the pointer survives on purpose (clearing it would
+ * strand the still-valid entries other devices hold), so a pointer-only check
+ * reports "API key set" for a key this device no longer has. The honest
+ * answer is a live local read: the pointer supplies the address, the keychain
+ * supplies the fact.
+ *
+ * Returns `false` for a tombstoned entry (`""`) and for any keychain failure —
+ * an unreadable key is indistinguishable from an absent one at the "is it
+ * configured?" level, and rendering must never throw.
+ *
+ * https://github.com/logancyang/obsidian-copilot-preview/issues/261
+ *
+ * @param provider - The provider row whose configured state is being asked.
+ * @param keychain - Keychain reader used for the live presence check.
+ */
+export function providerHasApiKey(
+  provider: Provider,
+  keychain: Pick<KeychainService, "getSecretById">
+): boolean {
+  if (!provider.apiKeyKeychainId) return false;
+  try {
+    return !!keychain.getSecretById(provider.apiKeyKeychainId);
+  } catch {
+    return false;
+  }
+}

--- a/src/modelManagement/types/persisted.ts
+++ b/src/modelManagement/types/persisted.ts
@@ -84,6 +84,17 @@ export interface Provider {
   /**
    * Obsidian keychain entry id. `null` for providers that don't take an
    * API key (Ollama, LMStudio, some agent-owned providers).
+   *
+   * DESIGN NOTE — address, never evidence. This field syncs with
+   * `data.json`, but the entry it names is device-local, so it CANNOT state
+   * whether a key exists on this device: "Delete All Keys" deliberately
+   * leaves it set (clearing it would strand other devices' still-valid
+   * entries), leaving it permanently dangling here. Any "is a key
+   * configured?" claim must go through `providerHasApiKey` (live local
+   * keychain read); reset may read it as a conservative cross-device
+   * retention marker. If a future review flags a pointer-only presence
+   * check, point them at this note.
+   * https://github.com/logancyang/obsidian-copilot-preview/issues/261
    */
   apiKeyKeychainId?: string | null;
   /**

--- a/src/modelManagement/ui/components/ByokGlobalTable.test.tsx
+++ b/src/modelManagement/ui/components/ByokGlobalTable.test.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { ByokGlobalTable, type ByokTableGroup } from "./ByokGlobalTable";
 import { ModelManagementProvider } from "@/modelManagement/ui/ModelManagementContext";
 import { createModelManagement } from "@/modelManagement/createModelManagement";
+import { KeychainService } from "@/services/keychainService";
 import { AppContext } from "@/context";
 import type { App } from "obsidian";
 
@@ -11,9 +12,29 @@ beforeAll(() => {
   (window as unknown as { activeDocument: Document }).activeDocument = window.document;
 });
 
+// The status badge is a live keychain read (`providerHasApiKey`), so the fake
+// app carries the same `secretStorage` shim `ProviderRegistry.test.ts` uses.
+const secrets = new Map<string, string>();
 const mockApp = {
+  secretStorage: {
+    setSecret: (id: string, value: string) => {
+      secrets.set(id, value);
+    },
+    getSecret: (id: string) => (secrets.has(id) ? secrets.get(id)! : null),
+    listSecrets: () => Array.from(secrets.keys()),
+    deleteSecret: (id: string) => {
+      secrets.delete(id);
+    },
+  },
   vault: { adapter: { exists: jest.fn() } },
 } as unknown as App;
+
+beforeEach(() => {
+  secrets.clear();
+  secrets.set("key1", "sk-fake-key");
+  KeychainService.resetInstance();
+  KeychainService.getInstance(mockApp);
+});
 
 const api = createModelManagement({ app: mockApp });
 
@@ -96,6 +117,23 @@ describe("ByokGlobalTable", () => {
     );
     const badge = screen.getByText("No key");
     expect(badge.className).not.toContain("tw-bg-success");
+  });
+
+  it("shows 'No key' when the pointer is set but the keychain entry is gone (Delete All Keys) (https://github.com/logancyang/obsidian-copilot-preview/issues/261)", () => {
+    secrets.delete("key1");
+    renderWithProvider(
+      <ByokGlobalTable groups={[group]} onConfigure={jest.fn()} onRemove={jest.fn()} />
+    );
+    expect(screen.getByText("No key")).toBeTruthy();
+    expect(screen.queryByText("API key set")).toBeNull();
+  });
+
+  it("treats a tombstoned ('') keychain entry as no key (https://github.com/logancyang/obsidian-copilot-preview/issues/261)", () => {
+    secrets.set("key1", "");
+    renderWithProvider(
+      <ByokGlobalTable groups={[group]} onConfigure={jest.fn()} onRemove={jest.fn()} />
+    );
+    expect(screen.getByText("No key")).toBeTruthy();
   });
 
   it("uses a clearer sub-line than '0 models' when a key-set provider has no models", () => {

--- a/src/modelManagement/ui/components/ByokGlobalTable.tsx
+++ b/src/modelManagement/ui/components/ByokGlobalTable.tsx
@@ -19,7 +19,9 @@ import { cn } from "@/lib/utils";
 import { SelfHostCloudWarningIcon } from "@/components/ui/SelfHostCloudWarningIcon";
 import type { ConfiguredModel, Provider } from "@/modelManagement/types/persisted";
 import { useModelManagement } from "@/modelManagement/ui/ModelManagementContext";
+import { providerHasApiKey } from "@/modelManagement/providers/providerHasApiKey";
 import { providerRequiresApiKey } from "@/modelManagement/providers/providerRequiresApiKey";
+import { KeychainService } from "@/services/keychainService";
 import { ChevronRight, MoreVertical, Settings2, Trash2, XIcon } from "lucide-react";
 import { Notice } from "obsidian";
 import React, { useRef, useState } from "react";
@@ -123,7 +125,7 @@ const ProviderCard: React.FC<ProviderCardProps> = ({
     if (!requiresKey) {
       return { label: "Running", variant: "default", className: successClassName };
     }
-    if (provider.apiKeyKeychainId) {
+    if (providerHasApiKey(provider, KeychainService.getInstance(app))) {
       return { label: "API key set", variant: "default", className: successClassName };
     }
     return { label: "No key", variant: "secondary", className: "tw-rounded-full" };

--- a/src/modelManagement/ui/tabs/ByokPanel.test.tsx
+++ b/src/modelManagement/ui/tabs/ByokPanel.test.tsx
@@ -22,6 +22,12 @@ jest.mock("@/modelManagement/ui/ModelManagementContext", () => ({
 }));
 // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real `useApp` hook; the name must match the export
 jest.mock("@/context", () => ({ useApp: () => ({}) }));
+// The provider card's key badge is a live keychain read; this panel test drives
+// it with the minimal stub app above, which carries no vault to derive a real
+// service from.
+jest.mock("@/services/keychainService", () => ({
+  KeychainService: { getInstance: () => ({ getSecretById: () => null }) },
+}));
 jest.mock("@/modelManagement/state/atoms", () => {
   const jotai = jest.requireActual<typeof import("jotai")>("jotai");
   const byokProviders = jotai.atom([

--- a/src/services/keychainService.test.ts
+++ b/src/services/keychainService.test.ts
@@ -94,6 +94,7 @@ import { FileSystemAdapter, Notice, type App } from "obsidian";
 import { getSettings } from "@/settings/model";
 import type { CopilotSettings } from "@/settings/model";
 import type { CustomModel } from "@/aiParams";
+import type { Provider } from "@/modelManagement";
 import { KeychainService, isSecretKey } from "./keychainService";
 
 /** Build a lightweight settings object. */
@@ -458,6 +459,40 @@ describe("keychainService", () => {
         expect(Notice).toHaveBeenCalledWith(
           "All API keys for this vault removed. Please re-enter them."
         );
+      });
+
+      it("keeps provider pointers and row contents intact while clearing this device's entries (https://github.com/logancyang/obsidian-copilot-preview/issues/261)", async () => {
+        const secretStorage = makeSecretStorage();
+        const service = KeychainService.getInstance(makeApp({ secretStorage }));
+        secretStorage.listSecrets.mockReturnValue([]);
+
+        const providers: Record<string, Provider> = {
+          p1: {
+            providerId: "p1",
+            providerType: "openai-compatible",
+            displayName: "P",
+            origin: { kind: "byok" },
+            addedAt: 0,
+            requiresApiKey: true,
+            apiKeyKeychainId: "kc-p1",
+          },
+        };
+        (getSettings as jest.Mock).mockReturnValue(makeSettings({ providers }));
+
+        const saveData = jest.fn().mockResolvedValue(undefined);
+        const syncMemory = jest.fn();
+
+        await service.forgetAllSecrets(saveData, syncMemory);
+
+        const synced = syncMemory.mock.calls[0][0] as unknown as {
+          providers: Record<string, Record<string, unknown>>;
+        };
+        // The pointer survives — it addresses entries other devices still
+        // hold — and the row's content is unchanged, so nothing in settings
+        // claims the key is gone. That the UI re-reads the keychain after this
+        // is covered end to end by `useChatModelPicker.test.tsx`.
+        expect(synced.providers.p1.apiKeyKeychainId).toBe("kc-p1");
+        expect(synced.providers.p1).toEqual(providers.p1);
       });
 
       it("handles saveData failure gracefully — keychain NOT cleared", async () => {

--- a/src/services/keychainService.ts
+++ b/src/services/keychainService.ts
@@ -573,6 +573,19 @@ export class KeychainService {
 
     // 1. Build stripped settings — before touching any durable store.
     const stripped = stripKeychainFields(current);
+    // Reason: provider key badges are a live local-keychain read, and React
+    // only re-runs that read when the providers slice identity changes
+    // (`providersAtom` → picker entries → memo). The rows' contents are
+    // untouched on purpose — `apiKeyKeychainId` stays, other devices' entries
+    // stay reachable — so a fresh identity is the only re-render signal this
+    // delete emits. Same-content copies are exactly that signal.
+    // https://github.com/logancyang/obsidian-copilot-preview/issues/261
+    // The empty case keeps its frozen canonical slice (AGENTS.md → referential
+    // stability): nothing addresses a keychain entry, so nothing needs the signal.
+    const providerEntries = Object.entries(stripped.providers ?? {});
+    if (providerEntries.length > 0) {
+      stripped.providers = Object.fromEntries(providerEntries.map(([id, row]) => [id, { ...row }]));
+    }
 
     // 2. Write stripped data.json BEFORE clearing Keychain.
     // Reason: a disk-write failure can then abort without also leaving the

--- a/src/settings/v2/components/AdvancedSettings.test.tsx
+++ b/src/settings/v2/components/AdvancedSettings.test.tsx
@@ -1,0 +1,97 @@
+import { DEFAULT_SETTINGS } from "@/constants";
+import { settingsAtom, settingsStore } from "@/settings/model";
+import type { Provider } from "@/modelManagement";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+// App is threaded via useApp; the destructive flows it powers are not under
+// test here, so a bare object is enough.
+jest.mock("@/context", () => {
+  const app = {};
+  return {
+    // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook; name must match the export
+    useApp: () => app,
+  };
+});
+
+// Keychain read used by the banner's BYOK presence check. Individual tests
+// control what the pointer resolves to.
+const getSecretById = jest.fn<string | null, [string]>().mockReturnValue(null);
+jest.mock("@/services/keychainService", () => ({
+  KeychainService: {
+    getInstance: () => ({
+      isAvailable: () => true,
+      getSecretById: (id: string) => getSecretById(id),
+    }),
+  },
+}));
+
+// The barrel drags provider adapters and agent modules into the test; the
+// banner only needs the leaf presence predicate, so resolve to that module.
+jest.mock("@/modelManagement", () =>
+  jest.requireActual<typeof import("@/modelManagement/providers/providerHasApiKey")>(
+    "@/modelManagement/providers/providerHasApiKey"
+  )
+);
+
+// Peripheral sections with heavy dependency chains — not under test.
+jest.mock("@/settings/v2/components/LegacyChatPromptsNotice", () => ({
+  LegacyChatPromptsNotice: () => null,
+}));
+jest.mock("@/logFileManager", () => ({ logFileManager: { getLogPath: () => "" } }));
+jest.mock("@/LLMProviders/chainRunner/utils/promptPayloadRecorder", () => ({
+  flushRecordedPromptPayloadToLog: jest.fn(),
+}));
+jest.mock("@/settings/copilotSaveData", () => ({ getCopilotSaveData: () => jest.fn() }));
+jest.mock("@/services/settingsPersistence", () => ({
+  refreshLastPersistedSettings: jest.fn(),
+  releaseLegacyCredentialHold: jest.fn(),
+  runPersistenceTransaction: jest.fn(),
+  suppressNextPersistOnce: jest.fn(),
+}));
+// Mobile gate keeps the lazy agentMode import (and its Node-only modules) out.
+jest.mock("@/utils/desktopRuntime", () => ({ isDesktopRuntime: () => false }));
+
+import { AdvancedSettings } from "@/settings/v2/components/AdvancedSettings";
+
+const BYOK_POINTER = "copilot-vtest-provider-p1";
+
+const byokProvider = {
+  id: "p1",
+  displayName: "Test Provider",
+  origin: { kind: "byok" },
+  requiresApiKey: true,
+  apiKeyKeychainId: BYOK_POINTER,
+} as unknown as Provider;
+
+function seedSettings(providers: Record<string, Provider>): void {
+  settingsStore.set(settingsAtom, {
+    ...DEFAULT_SETTINGS,
+    providers,
+  });
+}
+
+describe("AdvancedSettings", () => {
+  describe("AdvancedSettings()", () => {
+    beforeEach(() => {
+      getSecretById.mockReset().mockReturnValue(null);
+    });
+
+    it("counts a BYOK provider's keychain entry so a BYOK-only setup is not reported as keyless (https://github.com/logancyang/obsidian-copilot-preview/issues/261)", () => {
+      getSecretById.mockImplementation((id) => (id === BYOK_POINTER ? "sk-test" : null));
+      seedSettings({ p1: byokProvider });
+
+      render(<AdvancedSettings />);
+
+      expect(screen.queryByText(/No API keys found/)).toBeNull();
+    });
+
+    it("still reports an empty keychain when no legacy field and no BYOK provider holds a key", () => {
+      seedSettings({ p1: byokProvider });
+
+      render(<AdvancedSettings />);
+
+      expect(screen.getByText(/No API keys found/)).toBeTruthy();
+    });
+  });
+});

--- a/src/settings/v2/components/AdvancedSettings.test.tsx
+++ b/src/settings/v2/components/AdvancedSettings.test.tsx
@@ -1,7 +1,7 @@
 import { DEFAULT_SETTINGS } from "@/constants";
 import { settingsAtom, settingsStore } from "@/settings/model";
 import type { Provider } from "@/modelManagement";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 
 // App is threaded via useApp; the destructive flows it powers are not under
@@ -14,31 +14,60 @@ jest.mock("@/context", () => {
   };
 });
 
-// Keychain read used by the banner's BYOK presence check. Individual tests
-// control what the pointer resolves to.
+// Keychain reads/writes used by the banner's BYOK presence check and the
+// Delete All Keys flow. Individual tests control both.
 const getSecretById = jest.fn<string | null, [string]>().mockReturnValue(null);
+type SyncMemoryFn = (data: Record<string, unknown>) => void;
+const forgetAllSecrets = jest.fn<Promise<void>, [unknown, SyncMemoryFn]>();
 jest.mock("@/services/keychainService", () => ({
   KeychainService: {
     getInstance: () => ({
       isAvailable: () => true,
       getSecretById: (id: string) => getSecretById(id),
+      forgetAllSecrets: (saveData: unknown, syncMemory: SyncMemoryFn) =>
+        forgetAllSecrets(saveData, syncMemory),
     }),
   },
 }));
 
 // The barrel drags provider adapters and agent modules into the test; the
-// banner only needs the leaf presence predicate, so resolve to that module.
-jest.mock("@/modelManagement", () =>
-  jest.requireActual<typeof import("@/modelManagement/providers/providerHasApiKey")>(
+// component only needs the leaf presence predicate plus the registry bridge,
+// so resolve to the leaf and stub the context hook.
+const notifyCredentialStoreChanged = jest.fn();
+jest.mock("@/modelManagement", () => ({
+  ...jest.requireActual<typeof import("@/modelManagement/providers/providerHasApiKey")>(
     "@/modelManagement/providers/providerHasApiKey"
-  )
-);
+  ),
+  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook; name must match the export
+  useModelManagement: () => ({
+    providerRegistry: {
+      notifyCredentialStoreChanged: (): void => {
+        notifyCredentialStoreChanged();
+      },
+    },
+  }),
+}));
+
+// Auto-confirm the destructive dialog so the flow under test proceeds.
+jest.mock("@/components/modals/ConfirmModal", () => ({
+  ConfirmModal: class {
+    #onConfirm: () => void;
+    constructor(_app: unknown, onConfirm: () => void) {
+      this.#onConfirm = onConfirm;
+    }
+    open(): void {
+      this.#onConfirm();
+    }
+  },
+}));
 
 // Peripheral sections with heavy dependency chains — not under test.
 jest.mock("@/settings/v2/components/LegacyChatPromptsNotice", () => ({
   LegacyChatPromptsNotice: () => null,
 }));
-jest.mock("@/logFileManager", () => ({ logFileManager: { getLogPath: () => "" } }));
+jest.mock("@/logFileManager", () => ({
+  logFileManager: { getLogPath: () => "", append: jest.fn() },
+}));
 jest.mock("@/LLMProviders/chainRunner/utils/promptPayloadRecorder", () => ({
   flushRecordedPromptPayloadToLog: jest.fn(),
 }));
@@ -46,7 +75,8 @@ jest.mock("@/settings/copilotSaveData", () => ({ getCopilotSaveData: () => jest.
 jest.mock("@/services/settingsPersistence", () => ({
   refreshLastPersistedSettings: jest.fn(),
   releaseLegacyCredentialHold: jest.fn(),
-  runPersistenceTransaction: jest.fn(),
+  // The flow under test runs inside the transaction; execute it for real.
+  runPersistenceTransaction: (fn: () => Promise<void>) => fn(),
   suppressNextPersistOnce: jest.fn(),
 }));
 // Mobile gate keeps the lazy agentMode import (and its Node-only modules) out.
@@ -75,6 +105,8 @@ describe("AdvancedSettings", () => {
   describe("AdvancedSettings()", () => {
     beforeEach(() => {
       getSecretById.mockReset().mockReturnValue(null);
+      forgetAllSecrets.mockReset();
+      notifyCredentialStoreChanged.mockReset();
     });
 
     it("counts a BYOK provider's keychain entry so a BYOK-only setup is not reported as keyless (https://github.com/logancyang/obsidian-copilot-preview/issues/261)", () => {
@@ -92,6 +124,37 @@ describe("AdvancedSettings", () => {
       render(<AdvancedSettings />);
 
       expect(screen.getByText(/No API keys found/)).toBeTruthy();
+    });
+
+    // Subprocess agent backends bake provider keys into spawn-time config and
+    // only restart on registry emissions; "Delete All Keys" must announce the
+    // wipe through the registry or a running backend keeps using the deleted
+    // key. https://github.com/logancyang/obsidian-copilot-preview/issues/261
+    it("announces the credential wipe through the registry even when the transaction fails after the sweep ran (https://github.com/logancyang/obsidian-copilot-preview/issues/261)", async () => {
+      forgetAllSecrets.mockImplementation(async (_saveData, syncMemory) => {
+        // Partial keychain failure: memory was synced, then the error throws.
+        syncMemory({ ...DEFAULT_SETTINGS });
+        throw new Error("partial keychain failure");
+      });
+      seedSettings({ p1: byokProvider });
+      render(<AdvancedSettings />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Delete All Keys" }));
+
+      await waitFor(() => expect(notifyCredentialStoreChanged).toHaveBeenCalledTimes(1));
+    });
+
+    it("does not announce a credential wipe when the transaction returns without touching the stores (https://github.com/logancyang/obsidian-copilot-preview/issues/261)", async () => {
+      // Disk-write failure path: forgetAllSecrets swallows the error and
+      // returns without ever calling syncMemory — nothing was deleted.
+      forgetAllSecrets.mockImplementation(async () => {});
+      seedSettings({ p1: byokProvider });
+      render(<AdvancedSettings />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Delete All Keys" }));
+
+      await waitFor(() => expect(forgetAllSecrets).toHaveBeenCalledTimes(1));
+      expect(notifyCredentialStoreChanged).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/settings/v2/components/AdvancedSettings.tsx
+++ b/src/settings/v2/components/AdvancedSettings.tsx
@@ -19,7 +19,7 @@ import {
   suppressNextPersistOnce,
 } from "@/services/settingsPersistence";
 import { hasPersistedSecrets } from "@/services/settingsSecretTransforms";
-import { providerHasApiKey } from "@/modelManagement";
+import { providerHasApiKey, useModelManagement } from "@/modelManagement";
 import { logError } from "@/logger";
 import {
   type CopilotSettings,
@@ -38,6 +38,7 @@ const DESKTOP_UNAVAILABLE_FRAME_LOG_PATH = "(Agent Mode frame logs are desktop-o
 
 export const AdvancedSettings: React.FC = () => {
   const app = useApp();
+  const { providerRegistry } = useModelManagement();
   const settings = useSettingsValue();
   const [forgetting, setForgetting] = useState(false);
   const [frameLogPath, setFrameLogPath] = useState(DESKTOP_UNAVAILABLE_FRAME_LOG_PATH);
@@ -159,6 +160,15 @@ export const AdvancedSettings: React.FC = () => {
             refreshLastPersistedSettings(nextSettings as CopilotSettings);
             suppressNextPersistOnce();
             setSettings(nextSettings);
+            // The keychain sweep bypasses ProviderRegistry, but subprocess
+            // backends bake provider keys into spawn-time config and only
+            // restart on registry emissions. Notify from THIS callback, not
+            // after the await: a disk-write failure returns without reaching
+            // here (nothing was deleted — no restart), while a partial
+            // keychain failure runs this before throwing (keys DID change —
+            // restart must still fire).
+            // https://github.com/logancyang/obsidian-copilot-preview/issues/261
+            providerRegistry.notifyCredentialStoreChanged();
           }
         )
       );
@@ -168,7 +178,7 @@ export const AdvancedSettings: React.FC = () => {
     } finally {
       setForgetting(false);
     }
-  }, [app, forgetting]);
+  }, [app, forgetting, providerRegistry]);
 
   return (
     <div className="tw-space-y-4">

--- a/src/settings/v2/components/AdvancedSettings.tsx
+++ b/src/settings/v2/components/AdvancedSettings.tsx
@@ -19,6 +19,7 @@ import {
   suppressNextPersistOnce,
 } from "@/services/settingsPersistence";
 import { hasPersistedSecrets } from "@/services/settingsSecretTransforms";
+import { providerHasApiKey } from "@/modelManagement";
 import { logError } from "@/logger";
 import {
   type CopilotSettings,
@@ -57,7 +58,17 @@ export const AdvancedSettings: React.FC = () => {
   }, []);
 
   const keychainAvailable = KeychainService.getInstance().isAvailable();
-  const keychainAppearsEmpty = keychainAvailable && !hasPersistedSecrets(settings);
+  // "No API keys" must also count BYOK provider keys, which live only in the
+  // keychain behind each row's `apiKeyKeychainId` pointer — they never appear
+  // in the legacy top-level/model-level fields `hasPersistedSecrets` scans, so
+  // a BYOK-only setup would be misreported as keyless.
+  // https://github.com/logancyang/obsidian-copilot-preview/issues/261
+  const keychainAppearsEmpty =
+    keychainAvailable &&
+    !hasPersistedSecrets(settings) &&
+    !Object.values(settings.providers).some((provider) =>
+      providerHasApiKey(provider, KeychainService.getInstance())
+    );
 
   const handleReportIssue = useCallback(() => {
     // Gate before importing the agentMode barrel: on mobile the barrel pulls in


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#210
Relates to Brevilabs/obsidian-copilot-private#153

## Why

After **Settings → Advanced → Delete All Keys** empties this device's keychain, the chat model picker keeps offering the provider's models with no marker, and the first sign anything is wrong is the turn itself failing with "API key is not provided for the model". The opencode picker reports the same models' credentials as healthy. The Advanced tab tells the opposite lie: a setup whose only keys are BYOK provider keys reads "No API keys found in this device's Obsidian Keychain", because that banner never counted them.

Each of those surfaces trusted `apiKeyKeychainId` on the provider row as proof of a key. That pointer syncs with `data.json` while the entry it names is device-local, and Delete All Keys deliberately leaves it set so another device's still-valid entry is not stranded — so it cannot answer "is there a key on this device".

Verifying that fix on-device surfaced a second, older defect. Clicking Delete All Keys re-renders the chat pane while the Settings window holds focus; the pickers resolve their dropdown host at that moment from `activeDocument.body`, which follows window focus rather than the component. Once Settings closes, that body is gone and the model and mode menus open into a destroyed document: the trigger toggles, nothing appears, and Escape is inert until some unrelated re-render heals it.

## What

| Surface, immediately after "Delete All Keys" | Before | After |
| --- | --- | --- |
| Chat model picker entry | selectable, unmarked | disabled, labeled "Add API key" |
| opencode picker credential state | `ok` | `missing_key` |
| Advanced "API Key Storage" banner, BYOK-only setup | "No API keys found…" even with a key | counts BYOK keys |
| Re-entering the key | picker stuck until restart | recovers with no restart |
| First click on the model or mode picker | menu never opens | menu opens in the pane's own document |
| A running agent backend holding the deleted key | keeps using it silently | offered a reload |

Presence is now a live read of this device's keychain: the synced pointer supplies the address, the keychain supplies the fact, and a whitespace-only secret counts as missing, matching what provider verification already calls missing. Both credential writers re-issue the providers slice so those reads re-run, and the keychain sweep announces itself through the provider registry, naming each affected provider so a subprocess backend that baked the deleted key into its spawn config is offered a reload rather than restarted under the user.

The pickers ask whether the runtime must *resolve* a credential, not whether the provider *requires* one. A row that declares auth optional but still owns a keychain pointer is refused by the runtime, and the narrower question presented it as ready to use.

## Non goal

- No wrapper-level portal default for `dropdown-menu` / `popover` / `tooltip`. That needs a settings-root portal-host contract first, since the settings React root's container belongs to the main document, plus cross-document focus-scope testing. `select.tsx` and `dialog.tsx` keep Radix's main-window default for the same follow-up.
- No change to which models the pickers list, their order, or their grouping.
- No change to which model stays selected when its key is deleted. The menu row greys out, but the composer trigger keeps the model and the send still fails on the missing credential. Tracked separately as Brevilabs/obsidian-copilot-private#484.
- No change to where the picker menu opens relative to its trigger, or how tall it may grow. Tracked separately as Brevilabs/obsidian-copilot-private#483.
- Delete All Keys still leaves `apiKeyKeychainId` set on the row; clearing it would strand another device's still-valid entry.
- No cross-device syncing of key material; keys stay device-local by design.

## Screenshot

No rendered evidence: this agent session cannot upload an image to GitHub, so a local capture would only be a filesystem path. The states below were measured on-device instead, on a build of this branch in a test vault, and every one of them is reproducible through Verification in about two minutes.

| Check | Measured |
| --- | --- |
| Sweep emptied the keychain | `listSecrets()` returned `[]` |
| Picker marks a credential-less provider | `custom-gpt` disabled, labeled "Add API key" — on `master` the same row stays selectable, since it declares `requiresApiKey: false` |
| Menu opens on first click after the sweep | opened |
| Re-entering the key | row selectable again, no restart |
| Menu lands on-screen | host rect `y=37`, fully within an 865px viewport (an earlier host choice put it at `y=-225`) |

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | `providerHasApiKey.test.ts` including the whitespace-only secret, `useChatModelPicker.test.tsx` end to end through real `forgetAllSecrets` / `setApiKey` plus the optional-auth row, `opencodeModelResolve.test.ts`, `AdvancedSettings.test.tsx` for the banner and for announcing from the sweep's own snapshot, `ProviderRegistry.test.ts` for row identity and per-provider announcement, `ChatInput.send.test.tsx` for the portal host, `ModelSelector.test.tsx` for the dual-document case |
| A defect would fail CI or be obvious on first use | ✅ | Those tests run in CI, and a wrong presence state shows on the next picker render |
| A revert fully restores prior state, including persisted data | ✅ | No migration; provider rows keep identical content, only their object identity is refreshed |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Changes how key *presence* is read — boolean live keychain reads — and announces an external credential wipe through the registry. No secret value flows anywhere new |
| No public API, plugin API, message, or on-disk contract changes | ✅ | The pickers' `container` prop is optional, `opencodeEnabledModelEntries` gained a defaulted parameter, and nothing persisted changes shape |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | The sweep's announcement now reads its candidates inside the persistence transaction rather than from the render that started it, because confirmation and the write queue both await |
| No hot-path behavior lacks deterministic coverage | ✅ | Every changed branch is covered by the tests above |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | A wrong presence state or a mispositioned menu is visible on the next picker interaction |

Review: inspect `providerHasApiKey` in `src/modelManagement/providers/providerHasApiKey.ts`, `setApiKey` / `#touchProviderRow` / `notifyCredentialStoreChanged` in `src/modelManagement/providers/ProviderRegistry.ts`, the `forgetAllSecrets` callback in `handleForgetAllSecrets` in `src/settings/v2/components/AdvancedSettings.tsx`, and `setContainerEl` in `src/components/chat-components/ChatInput.tsx` line by line. Then run Verification steps 2-7, including step 5's off-screen check and step 7's restart.

## Verification

1. Configure a BYOK provider with any key, a fake one is fine, and enable one of its models for chat. Confirm the model is selectable in the chat picker and that the Advanced tab's "API Key Storage" banner does not claim the keychain is empty.
2. Settings → Advanced → Delete All Keys → Remove.
3. Without restarting, open the chat pane's model picker. The provider's entry is disabled and labeled "Add API key".
4. The Advanced banner now reads "No API keys found in this device's Obsidian Keychain".
5. Still without restarting, click the model picker and then the mode picker. Each opens on the **first** click, and the menu is fully visible and anchored to its trigger. A menu that opens off the top or bottom edge of the window, or not at all, is a failure.
6. Re-enter the key through the provider's Configure dialog. The picker entry becomes selectable again and the banner stops claiming the keychain is empty, with no restart.
7. Restart Obsidian and re-check step 6's end state; it must match.
8. With an agent session running, repeat step 2. The running backend is offered a reload rather than restarted underneath the turn.

## Note

This branch was rebased onto current `master` after the 24 Aug review, and the change is no longer the one approved then; "resolve the conflict and merge" no longer applies.

Upstream #3164 replaced the BYOK table's key badge with a verification result checked on every tab visit, which covers what this PR previously claimed for that badge, so that consumer was dropped and `ByokGlobalTable` is byte-identical to `master` again. The registry's emitter now carries a provider id and subscribers filter on it, so the sweep announces each affected provider rather than sending one anonymous signal that would be filtered out. Per upstream #3256 a backend with a live session is offered a reload instead of being restarted under the user, and this change follows that policy rather than making an exception for credential deletion.

