### PR TITLE
Keep Claude turns alive past task-notification results

### DIFF
--- a/src/agentMode/sdk/ClaudeSdkBackendProcess.test.ts
+++ b/src/agentMode/sdk/ClaudeSdkBackendProcess.test.ts
@@ -1,4 +1,9 @@
-import type { HookCallback, ModelInfo, SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import type {
+  HookCallback,
+  ModelInfo,
+  SDKMessage,
+  SDKMessageOrigin,
+} from "@anthropic-ai/claude-agent-sdk";
 import type { BackendDescriptor, SessionEvent } from "@/agentMode/session/types";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
@@ -116,9 +121,10 @@ function streamEvent(event: object): SDKMessage {
   } as SDKMessage;
 }
 
-function resultMessage(): SDKMessage {
+function resultMessage(origin?: SDKMessageOrigin): SDKMessage {
   return {
     type: "result",
+    ...(origin ? { origin } : {}),
     subtype: "success",
     duration_ms: 1,
     duration_api_ms: 1,
@@ -422,6 +428,64 @@ describe("ClaudeSdkBackendProcess", () => {
           content: [{ type: "content", content: { type: "text", text: "late report" } }],
         },
       });
+    });
+
+    it("answers the user prompt when a stale task notification closes its own result first (https://github.com/logancyang/obsidian-copilot-preview/issues/246)", async () => {
+      queryMock.mockImplementation(() =>
+        makeQuery([
+          {
+            type: "system",
+            subtype: "task_notification",
+            task_id: "b0510bkam",
+            status: "stopped",
+            summary: "No completion record was found for this background shell command.",
+          } as unknown as SDKMessage,
+          resultMessage({ kind: "task-notification" }),
+          streamEvent({
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "text_delta", text: "the answer" },
+          }),
+          resultMessage(),
+        ])
+      );
+
+      const proc = new ClaudeSdkBackendProcess({
+        pathToClaudeCodeExecutable: "/usr/local/bin/claude",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        app: { vault: {} } as any,
+        clientVersion: "1.2.3",
+        descriptor: fakeDescriptor(),
+      });
+
+      const { sessionId } = await proc.newSession({ cwd: "/vault" });
+      const events: SessionEvent[] = [];
+      proc.registerSessionHandler(sessionId, (e) => events.push(e));
+
+      const resp = await proc.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] });
+
+      expect(resp.stopReason).toBe("end_turn");
+      const chunks = events.filter((e) => e.update.sessionUpdate === "agent_message_chunk");
+      expect(chunks).toHaveLength(1);
+    });
+
+    it("reports a cancelled turn when the only result belongs to a task notification (https://github.com/logancyang/obsidian-copilot-preview/issues/246)", async () => {
+      queryMock.mockImplementation(() => makeQuery([resultMessage({ kind: "task-notification" })]));
+
+      const proc = new ClaudeSdkBackendProcess({
+        pathToClaudeCodeExecutable: "/usr/local/bin/claude",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        app: { vault: {} } as any,
+        clientVersion: "1.2.3",
+        descriptor: fakeDescriptor(),
+      });
+
+      const { sessionId } = await proc.newSession({ cwd: "/vault" });
+      proc.registerSessionHandler(sessionId, () => {});
+
+      const resp = await proc.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] });
+
+      expect(resp.stopReason).toBe("cancelled");
     });
 
     it("forwards the composed system prompt via systemPrompt append on the claude_code preset", async () => {

--- a/src/agentMode/sdk/ClaudeSdkBackendProcess.ts
+++ b/src/agentMode/sdk/ClaudeSdkBackendProcess.ts
@@ -508,7 +508,10 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
     });
 
     const translatorState = createTranslatorState(session.claudeTaskPlan, session.backgroundTasks);
-    let stopReason: StopReason = "end_turn";
+    // Only a result that owns this turn sets the outcome. A stream that ends
+    // without one — shutdown, or nothing but background-task chatter — left the
+    // prompt unanswered, so it must not report a successful turn.
+    let stopReason: StopReason = "cancelled";
     let resultErrorMessage: string | null = null;
     try {
       let planUsageRequested = false;
@@ -528,7 +531,12 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
         }
         const events = translateSdkMessage(sdkMsg, params.sessionId, translatorState);
         for (const e of events) this.dispatchEvent(e);
-        if (sdkMsg.type === "result") {
+        // On a resumed session a queued background-task notification can arrive
+        // before Claude answers the new prompt, and the SDK closes it with its
+        // own `result`. Ending the turn there drops the user's prompt entirely:
+        // the answer is never consumed and the request records as interrupted.
+        // https://github.com/logancyang/obsidian-copilot-preview/issues/246
+        if (sdkMsg.type === "result" && sdkMsg.origin?.kind !== "task-notification") {
           stopReason = mapStopReason(sdkMsg);
           if (sdkMsg.subtype === "success" && sdkMsg.is_error && sdkMsg.result.trim()) {
             resultErrorMessage = sdkMsg.result;


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#246

## Why

Claude keeps background tasks (async agents, background shells) attached to a
session. When you reopen an older chat and send a new message, Claude Code can
first flush a leftover notification about one of those tasks, for example "No
completion record was found for this background shell command from the previous
session." That flush arrives as a full turn result of its own.

Copilot treated the first result it saw as the end of your turn. So the turn
ended before Claude ever answered: the chat showed "claude finished the turn
without returning any assistant text or tool activity (stop reason: end_turn).
Try again, or switch models if this repeats.", and the Claude transcript
recorded your message followed by `[Request interrupted by user]`. The message
was not slow or garbled, it was dropped, and the only recovery was to type it
again.

## What

> **Before:** Reopen a chat that has a stale background task, ask a question,
> and the answer never arrives — you get the empty-turn error while Claude's
> real reply is discarded.
>
> **After:** The notification is absorbed, the turn stays open, and Claude's
> answer streams in as normal.

A turn now completes only on a result that belongs to it. Results Claude emits
for background-task notifications no longer end the turn.

| Stream the turn receives | Before | After |
| --- | --- | --- |
| Task notification, its result, then Claude's answer and result | Empty-turn error, answer dropped | Answer shown, turn ends `end_turn` |
| Ordinary answer and result | Turn ends `end_turn` | Unchanged |
| Notification result only, nothing else | Reported as a successful turn | Reported as cancelled, no misleading error |
| Stream ends because the plugin is shutting down | Reported as a successful turn | Reported as cancelled |

## Non goal

- The persistent-streaming redesign in logancyang/obsidian-copilot-preview#226.
  This stays inside today's one-query-per-prompt model.
- Surfacing stale notifications about tasks Copilot is no longer tracking. They
  stay hidden, as before.
- Any change to how live, tracked background tasks report progress in the trail.

## Screenshot

Not applicable — this changes which SDK frame ends a turn, and the fixed state
is an ordinary Claude answer with no new or altered UI. The one visible
difference is the disappearance of the existing empty-turn error, whose exact
copy is quoted in `Why`.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Two new `prompt()` tests in `src/agentMode/sdk/ClaudeSdkBackendProcess.test.ts` cover the notification-then-answer stream and the notification-only stream; both fail on the base commit |
| A defect would fail CI or be obvious on first use | ✅ | Those tests run in CI, and a regression reproduces as the same dropped-answer error users already report |
| A revert fully restores prior state, including persisted data | ✅ | No persisted data, settings, or on-disk format is touched |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Permission handling and the `canUseTool` bridge are untouched |
| No public API, plugin API, message, or on-disk contract changes | ✅ | `prompt()` keeps its signature and `PromptOutput` shape |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | This changes when the SDK consume loop stops and which stop reason a turn reports, which is the core turn lifecycle for every Claude message |
| No hot-path behavior lacks deterministic coverage | ✅ | Both changed branches, the skipped result and the default stop reason, are asserted |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Confined to the Claude backend in Agent Mode, and a wrong outcome shows on the next message |

Review: inspect `src/agentMode/sdk/ClaudeSdkBackendProcess.ts` — the `for await`
consume loop inside `prompt()`, specifically the `stopReason` initializer and
the `sdkMsg.type === "result"` branch — line by line, and confirm a turn can
still end on every non-notification result, including error subtypes. Then run
Verification steps 2–5, including the interrupt variant in step 5.

## Verification

1. Build the branch into a test vault and open Agent Mode with the Claude
   backend.
2. Start a chat and launch a background shell command, for example ask Claude to
   run a long `sleep` in the background, then close the chat while it is still
   running and restart Obsidian.
3. Reopen that chat from history and send a new, unrelated question.
4. Confirm Claude answers the question in the chat, and that the message
   "claude finished the turn without returning any assistant text or tool
   activity" does not appear.
5. In the same chat, send another message and press stop mid-answer. Confirm the
   turn stops as a cancelled turn without the empty-turn error, and that a
   following message still gets a normal answer.
