### PR TITLE
Authenticate keyless openai-format embedding endpoints

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -127,3 +127,16 @@ if (typeof window.activeDocument === "undefined") {
 if (typeof window.activeWindow === "undefined") {
   window.activeWindow = window;
 }
+
+// Polyfill Obsidian's `Array.prototype.contains` augmentation (an alias of
+// `includes`). It is defined non-enumerably so `for...in` over arrays is
+// unaffected, matching how the runtime installs it.
+if (typeof Array.prototype.contains !== "function") {
+  Object.defineProperty(Array.prototype, "contains", {
+    value: function (target) {
+      return this.includes(target);
+    },
+    writable: true,
+    configurable: true,
+  });
+}

--- a/src/LLMProviders/embeddingManager.test.ts
+++ b/src/LLMProviders/embeddingManager.test.ts
@@ -1,0 +1,62 @@
+import type { CustomModel } from "@/aiParams";
+import { EmbeddingModelProviders } from "@/constants";
+import { getModelKeyFromModel, setSettings } from "@/settings/model";
+import { OllamaEmbeddings } from "@langchain/ollama";
+import { OpenAIEmbeddings } from "@langchain/openai";
+import { CustomOpenAIEmbeddings } from "./CustomOpenAIEmbeddings";
+import EmbeddingManager from "./embeddingManager";
+
+jest.mock("@langchain/openai", () => ({
+  ...jest.requireActual<typeof import("@langchain/openai")>("@langchain/openai"),
+  OpenAIEmbeddings: jest.fn(),
+}));
+jest.mock("@langchain/ollama", () => ({
+  ...jest.requireActual<typeof import("@langchain/ollama")>("@langchain/ollama"),
+  OllamaEmbeddings: jest.fn(),
+}));
+jest.mock("./CustomOpenAIEmbeddings", () => ({
+  CustomOpenAIEmbeddings: jest.fn(),
+}));
+
+describe("embeddingManager", () => {
+  describe("EmbeddingManager", () => {
+    describe("getEmbeddingsAPI()", () => {
+      beforeEach(() => {
+        jest.clearAllMocks();
+      });
+
+      it.each([
+        [EmbeddingModelProviders.OPENAI_FORMAT, OpenAIEmbeddings, { openAIApiKey: "default-key" }],
+        [
+          EmbeddingModelProviders.LM_STUDIO,
+          CustomOpenAIEmbeddings,
+          { openAIApiKey: "default-key" },
+        ],
+        [
+          EmbeddingModelProviders.OLLAMA,
+          OllamaEmbeddings,
+          { headers: { Authorization: "Bearer default-key" } },
+        ],
+      ])(
+        "credentials a keyless %s model with the keyless sentinel instead of an empty key",
+        async (provider, EmbeddingConstructor, expectedCredential) => {
+          const model: CustomModel = {
+            name: "local-embedding-model",
+            provider,
+            enabled: true,
+          };
+          setSettings({
+            activeEmbeddingModels: [model],
+            embeddingModelKey: getModelKeyFromModel(model),
+          });
+
+          await EmbeddingManager.getInstance().getEmbeddingsAPI();
+
+          expect(EmbeddingConstructor).toHaveBeenCalledWith(
+            expect.objectContaining(expectedCredential)
+          );
+        }
+      );
+    });
+  });
+});

--- a/src/LLMProviders/embeddingManager.ts
+++ b/src/LLMProviders/embeddingManager.ts
@@ -283,7 +283,7 @@ export default class EmbeddingManager {
       },
       [EmbeddingModelProviders.OPENAI_FORMAT]: {
         modelName,
-        openAIApiKey: customModel.apiKey || "",
+        openAIApiKey: customModel.apiKey || "default-key",
         batchSize: getSettings().embeddingBatchSize,
         configuration: {
           baseURL: customModel.baseUrl,


### PR DESCRIPTION
Fixes #2837

## Why

A vault upgrading from 3.x can carry a saved embedding model whose provider is
`3rd party (openai-format)` and whose API key field is empty, because the
endpoint behind it — Ollama or LM Studio behind a proxy, LiteLLM, vLLM — needs
no key. Copilot lists that model as usable, then fails the moment it tries to
embed anything. The user sees only `Failed to initialize Copilot database. Some
features may be limited`; the real cause, `Missing credentials. Please pass an
apiKey ...` from the OpenAI SDK, is logged behind the debug flag and is
invisible by default.

The two halves of the code disagreed about what a keyless endpoint looks like.
The usability check treats a missing key for this provider as the placeholder
`default-key`, so the model passes the gate. The config that actually builds the
embedding client handed it an empty string instead, and the OpenAI SDK refuses
to construct a client without a credential.

## What

> **Before:** a saved `3rd party (openai-format)` embedding model with an empty
> API key is offered as usable, and every embedding attempt against it fails
> with a generic database-initialization notice.
>
> **After:** the same model reaches its endpoint. The request carries the same
> non-secret `default-key` placeholder that keyless LM Studio and Ollama
> embedding models already send, so a keyless endpoint answers normally and an
> endpoint that really does want a key answers with its own auth error instead
> of a silent local failure.

Nothing changes for a model that has an API key set: that key is still used.

## Non goal

- Does not generalize the fallback across the other provider blocks in the same
  config. Each block names its credential field differently — `apiKey`,
  `openAIApiKey`, `azureOpenAIApiKey`, an `Authorization` header — so deriving
  every one of the eleven from the shared provider-key map costs roughly ten
  lines and eleven touch points in a file that is scheduled for deletion.
- Does not add embedding-model UI. v4 has none, so this only helps vaults whose
  saved settings already contain such a model.
- Does not change how the underlying failure is surfaced or logged.

## Screenshot

Not applicable — this changes the credential handed to an embedding client
constructor. It has no rendered surface, and v4 ships no embedding-model UI to
photograph.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | `src/LLMProviders/embeddingManager.test.ts` asserts the credential handed to the embedding client for keyless openai-format, LM Studio, and Ollama models |
| A defect would fail CI or be obvious on first use | ✅ | Those tests run in CI and fail against the previous empty-string fallback |
| A revert fully restores prior state, including persisted data | ✅ | Nothing is written or migrated; the change is one literal in a config built per call |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | The credential sent to an openai-format embedding endpoint changes from an empty string to the `default-key` placeholder when the user set no key |
| No public API, plugin API, message, or on-disk contract changes | ✅ | No exported signature, settings schema, or serialized format changes |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | A synchronous value in a config object |
| No hot-path behavior lacks deterministic coverage | ✅ | The one changed branch is covered by the new tests |
| No new dependency | ✅ | `package.json` and `package-lock.json` are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | A wrong value fails on the first embedding call against the configured endpoint |

Review: inspect the `EmbeddingModelProviders.OPENAI_FORMAT` entry of
`getEmbeddingConfig` in `src/LLMProviders/embeddingManager.ts` and confirm its
`openAIApiKey` fallback matches the `OPENAI_FORMAT` entry of
`providerApiKeyMap` in the same file. Then run Verification steps 2 and 3,
including the step-4 variant where the endpoint requires a key.

## Verification

1. In a vault whose settings already list an embedding model with provider
   `3rd party (openai-format)`, an empty API key, and a base URL pointing at a
   keyless OpenAI-compatible server (for example `llama-server`, vLLM, or
   LiteLLM with auth disabled), select that model as the embedding model.
2. Reload the plugin and trigger indexing. On `master`, `Failed to initialize
   Copilot database. Some features may be limited` appears and, with debug
   logging on, the console shows `Missing credentials`.
3. On this branch, repeat step 2. Indexing proceeds and the notice does not
   appear.
4. Point the same model at an endpoint that does require a key and leave the key
   blank. Confirm the failure now comes back from the server as an
   authentication error rather than as the generic database notice.

## Note

`src/LLMProviders/embeddingManager.ts` is scheduled for deletion by
`logancyang/obsidian-copilot-preview#333` under epic
`logancyang/obsidian-copilot-preview#336`, which retires the in-plugin Orama
indexing path. With no embedding-model UI in v4
(`logancyang/obsidian-copilot#2836`), this fix reaches only vaults upgrading
from 3.x that carry a persisted `activeEmbeddingModels` row. The reviewer may
want to judge whether the one-line fix is worth carrying until `#333` lands.
