### PR TITLE
Strip terminal escape sequences from agent stdout before parsing

### DIFF
--- a/src/agentMode/acp/AcpProcessManager.test.ts
+++ b/src/agentMode/acp/AcpProcessManager.test.ts
@@ -1,0 +1,72 @@
+import { sanitizeAcpStdout } from "@/agentMode/acp/AcpProcessManager";
+
+/** The exact prefix reported in the opencode hang (two OSC title writes). */
+const OSC_TITLES = "\x1b]0;opencode: ready\x07\x1b]0;second-brain: ready\x07";
+const ENVELOPE = '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1}}';
+
+function streamOf(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+}
+
+async function readLines(stream: ReadableStream<Uint8Array>): Promise<string[]> {
+  const decoder = new TextDecoder();
+  const reader = stream.getReader();
+  let text = "";
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    if (value) text += decoder.decode(value, { stream: true });
+  }
+  text += decoder.decode();
+  return text.split("\n").filter((line) => line.length > 0);
+}
+
+describe("AcpProcessManager", () => {
+  describe("sanitizeAcpStdout()", () => {
+    it("makes a frame prefixed with OSC title sequences parse as JSON", async () => {
+      const lines = await readLines(sanitizeAcpStdout(streamOf([`${OSC_TITLES}${ENVELOPE}\n`])));
+
+      expect(lines).toHaveLength(1);
+      expect(JSON.parse(lines[0])).toEqual({
+        jsonrpc: "2.0",
+        id: 1,
+        result: { protocolVersion: 1 },
+      });
+    });
+
+    it("makes a frame parse as JSON when a chunk boundary splits an escape sequence", async () => {
+      const payload = `\x1b[32m${OSC_TITLES}${ENVELOPE}\n`;
+      // Cuts land inside the CSI colour code and inside the first OSC title.
+      const chunks = [payload.slice(0, 3), payload.slice(3, 12), payload.slice(12)];
+
+      const lines = await readLines(sanitizeAcpStdout(streamOf(chunks)));
+
+      expect(lines).toHaveLength(1);
+      expect(JSON.parse(lines[0])).toEqual({
+        jsonrpc: "2.0",
+        id: 1,
+        result: { protocolVersion: 1 },
+      });
+    });
+
+    it("preserves escape-free frames and their order", async () => {
+      const lines = await readLines(
+        sanitizeAcpStdout(streamOf(['{"a":1}\n{"b":2}\n', '{"c":3}\n']))
+      );
+
+      expect(lines).toEqual(['{"a":1}', '{"b":2}', '{"c":3}']);
+    });
+
+    it("emits a final frame that the child left without a trailing newline", async () => {
+      const lines = await readLines(sanitizeAcpStdout(streamOf([`${OSC_TITLES}${ENVELOPE}`])));
+
+      expect(lines).toEqual([ENVELOPE]);
+    });
+  });
+});

--- a/src/agentMode/acp/AcpProcessManager.ts
+++ b/src/agentMode/acp/AcpProcessManager.ts
@@ -1,5 +1,6 @@
 import { logError, logInfo, logWarn } from "@/logger";
 import { requireNodeModule } from "@/utils/desktopRuntime";
+import { NdjsonLineSplitter } from "./debugTap";
 
 type ChildProcessByStdio = import("node:child_process").ChildProcessByStdio<
   Writable,
@@ -94,7 +95,7 @@ export class AcpProcessManager {
     ).toWeb;
     return {
       stdin: writableToWeb(child.stdin),
-      stdout: readableToWeb(child.stdout),
+      stdout: sanitizeAcpStdout(readableToWeb(child.stdout)),
     };
   }
 
@@ -151,6 +152,59 @@ export class AcpProcessManager {
       await exited;
     }
   }
+}
+
+/**
+ * CSI (colors, cursor moves) and OSC (window title) escape sequences. Agent
+ * binaries and their plugins write these to stdout for a human terminal;
+ * anything prefixed to a JSON-RPC envelope makes `JSON.parse` throw, and the
+ * SDK's `ndJsonStream` drops such frames silently.
+ */
+// eslint-disable-next-line no-control-regex
+const TERMINAL_ESCAPE_SEQUENCE = /\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g;
+
+/**
+ * Strip terminal escape sequences from an NDJSON byte stream so downstream
+ * consumers see parseable JSON-RPC frames. Buffering to newline boundaries
+ * also keeps a sequence intact when the child splits it across two chunks.
+ *
+ * @param inner The child's raw stdout as a Web stream.
+ */
+export function sanitizeAcpStdout(inner: ReadableStream<Uint8Array>): ReadableStream<Uint8Array> {
+  // Hand-rolled instead of `pipeThrough(new TransformStream())`: `inner`
+  // comes from Node's `Readable.toWeb()` and mixing it with a global-realm
+  // stream throws `ERR_INVALID_ARG_TYPE`.
+  const reader = inner.getReader();
+  const encoder = new TextEncoder();
+  let enqueued = 0;
+  let splitter: NdjsonLineSplitter;
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      splitter = new NdjsonLineSplitter((line) => {
+        const cleaned = line.replace(TERMINAL_ESCAPE_SEQUENCE, "").trim();
+        if (!cleaned) return;
+        controller.enqueue(encoder.encode(`${cleaned}\n`));
+        enqueued += 1;
+      });
+    },
+    async pull(controller) {
+      // Keep reading until a whole frame is ready: a chunk that ends
+      // mid-frame would otherwise leave the consumer waiting forever.
+      enqueued = 0;
+      while (enqueued === 0) {
+        const { value, done } = await reader.read();
+        if (done) {
+          splitter.flush();
+          controller.close();
+          return;
+        }
+        if (value) splitter.push(value);
+      }
+    },
+    cancel(reason) {
+      return reader.cancel(reason);
+    },
+  });
 }
 
 function pipeStderrToLogger(stderr: Readable, tag: string): void {

--- a/src/agentMode/acp/AcpProcessManager.ts
+++ b/src/agentMode/acp/AcpProcessManager.ts
@@ -160,7 +160,7 @@ export class AcpProcessManager {
  * anything prefixed to a JSON-RPC envelope makes `JSON.parse` throw, and the
  * SDK's `ndJsonStream` drops such frames silently.
  */
-// eslint-disable-next-line no-control-regex
+// eslint-disable-next-line no-control-regex -- CSI/OSC sequences are defined by \x1b control bytes
 const TERMINAL_ESCAPE_SEQUENCE = /\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g;
 
 /**

--- a/src/agentMode/acp/debugTap.ts
+++ b/src/agentMode/acp/debugTap.ts
@@ -89,7 +89,11 @@ function tapReadable(
   return forConsumer;
 }
 
-class NdjsonLineSplitter {
+/**
+ * Accumulates stream bytes and hands out one complete NDJSON line at a time,
+ * so callers never see a frame that a chunk boundary cut in half.
+ */
+export class NdjsonLineSplitter {
   private buffer = "";
   private decoder = new TextDecoder();
 


### PR DESCRIPTION
Fixes #2876

## Why

Agent Mode talks to its backend binary (opencode, Claude, Codex) over JSON-RPC on the child's stdout, one JSON object per line. Plenty of those binaries — or a plugin, hook, or shell wrapper the user has installed — also write terminal decoration to stdout: an OSC window-title update such as `ESC]0;opencode: ready BEL`, or a CSI colour code. When that decoration lands immediately before a JSON-RPC envelope on the same line, the line is no longer valid JSON.

The vendored ACP SDK parses each line with a bare `JSON.parse` wrapped in a `try/catch` that only logs and moves on, so the frame is dropped with no protocol-level error. If the dropped frame is the `initialize` response, nothing ever resolves the promise the backend startup is waiting on. The user sees the Agent Mode pane sit on "Loading agent models…" forever, with `SyntaxError: Unexpected token ... "]0;openco"... is not valid JSON` in the developer console, and no way forward other than restarting Obsidian.

## What

The agent process's stdout is cleaned of terminal escape sequences before anything parses it, so a decorated line still yields its JSON-RPC frame.

> **Before:** an agent binary whose plugin writes a window title emits `ESC]0;opencode: ready BEL{"jsonrpc":"2.0","id":1,...}`. The frame is dropped, `initialize` never answers, and Agent Mode hangs on "Loading agent models…".
>
> **After:** the same line is delivered as `{"jsonrpc":"2.0","id":1,...}`. `initialize` answers, the model list loads, and the ACP debug log shows the frame by method name instead of as `(unparsed)`.

Lines carrying no escape sequences are passed through byte-for-byte and in order. A raw escape byte cannot occur inside a valid JSON string (JSON requires control characters to be `\u`-escaped), so stripping them cannot alter a real payload.

## Non goal

- No "slice from the first `{` to the last `}`" fallback. That heuristic was the issue's second suggestion; it would silently mangle a line that carries genuine non-JSON garbage or two concatenated objects, turning a loud parse failure into quiet corruption. Escape-stripping alone fully clears the reported payload.
- No change to the vendored SDK in `node_modules/@agentclientprotocol/sdk`; its `ndJsonStream` still drops any line it cannot parse.
- Stderr handling is untouched: it still goes to the logger with escapes intact.
- No user-facing surface for this: nothing new in settings, and no message when a line is cleaned.

## Screenshot

No image. The symptom is a spinner that never resolves, and reaching it needs a real vault plus an agent binary configured to write terminal titles to stdout — a state that cannot be produced from the component gallery or from a headless run. The reviewable evidence is the transformation itself, which the tests in this PR assert:

| stdout line the child writes | line the JSON-RPC parser now sees | result |
| --- | --- | --- |
| `ESC]0;opencode: ready BEL ESC]0;second-brain: ready BEL {"jsonrpc":"2.0","id":1,"result":{…}}` | `{"jsonrpc":"2.0","id":1,"result":{…}}` | parses |
| same line, split across chunks in the middle of the escape sequence | `{"jsonrpc":"2.0","id":1,"result":{…}}` | parses |
| `{"a":1}` | `{"a":1}` | unchanged |

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | `src/agentMode/acp/AcpProcessManager.test.ts` covers the reported payload, a chunk boundary splitting an escape sequence, clean frames and their order, and a final frame with no trailing newline |
| A defect would fail CI or be obvious on first use | ✅ | Every agent frame flows through this stage, so a mistake stops Agent Mode from starting at all, on the first attempt |
| A revert fully restores prior state, including persisted data | ✅ | Nothing is persisted, migrated, or written to disk |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | This is an input-handling change: bytes from an external subprocess are rewritten before the protocol parser sees them |
| No public API, plugin API, message, or on-disk contract changes | ✅ | The stdout stage stays inside `AcpProcessManager`; the wire format on the stream is unchanged NDJSON |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | A new async stream stage sits between the child process and the SDK on the Agent Mode startup path; its pull, close, and cancel behavior decides whether the backend ever starts |
| No hot-path behavior lacks deterministic coverage | ✅ | Chunking, stripping, pass-through, and end-of-stream flush each have a test |
| No new dependency | ✅ | `package.json` and the lockfile are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Confined to Agent Mode startup and streaming; a fault shows as a stalled or empty agent pane immediately |

Review: inspect `src/agentMode/acp/AcpProcessManager.ts` — `sanitizeAcpStdout` (the `pull` loop's close and cancel paths, and the `TERMINAL_ESCAPE_SEQUENCE` pattern) and the `stdout` value returned by `AcpProcessManager.start()` — line by line, then `NdjsonLineSplitter` in `src/agentMode/acp/debugTap.ts`, which is now shared with that stage. Then run Verification steps 3 to 5, which include the escape-emitting, garbage-line, and mid-stream-kill variants.

## Verification

1. Build the branch into a test vault (`npm run test:vault`) and enable Agent Mode with a CLI backend.
2. Open the Agent Mode pane with an unmodified binary and confirm the model list loads as before and a prompt streams a reply.
3. Point Agent Mode at a wrapper script that decorates stdout, for example a shell script that runs `printf '\033]0;wrapper: ready\007'` before exec'ing the real binary. On `master` the pane sticks on "Loading agent models…"; on this branch the model list loads and prompts stream normally.
4. Have the wrapper also print a line of plain non-JSON text (`echo "hello from the wrapper"`) before exec'ing. Agent Mode should still start; that one line is discarded and appears in the ACP debug log, and it must not stall the session.
5. With a session streaming, kill the agent process (`pkill -f <binary>`). The pane should surface the backend exit and let you retry, rather than hanging with no output.
6. Turn on the Agent Mode debug log with the decorating wrapper from step 3 and confirm the inbound frames are logged by method name rather than as `(unparsed)`.
