### PR TITLE
Cover the full CSI parameter-byte range when stripping agent escape sequences

### DIFF
--- a/src/agentMode/acp/AcpProcessManager.test.ts
+++ b/src/agentMode/acp/AcpProcessManager.test.ts
@@ -1,4 +1,15 @@
-import { sanitizeAcpStdout } from "@/agentMode/acp/AcpProcessManager";
+import { requireNodeModule } from "@/utils/desktopRuntime";
+import { AcpProcessManager, sanitizeAcpStdout } from "@/agentMode/acp/AcpProcessManager";
+
+jest.mock("@/logger", () => ({
+  logInfo: jest.fn(),
+  logWarn: jest.fn(),
+  logError: jest.fn(),
+}));
+
+jest.mock("@/utils/desktopRuntime", () => ({
+  requireNodeModule: jest.fn(),
+}));
 
 /** The exact prefix reported in the opencode hang (two OSC title writes). */
 const OSC_TITLES = "\x1b]0;opencode: ready\x07\x1b]0;second-brain: ready\x07";
@@ -28,8 +39,33 @@ async function readLines(stream: ReadableStream<Uint8Array>): Promise<string[]> 
 }
 
 describe("AcpProcessManager", () => {
+  describe("AcpProcessManager", () => {
+    describe("start()", () => {
+      it("returns a stdout stream with the child's terminal escape sequences already stripped (https://github.com/logancyang/obsidian-copilot/issues/2876)", async () => {
+        const identity = <T>(value: T): T => value;
+        const child = {
+          stdin: {},
+          // `toWeb` is the identity below, so the manager receives this as-is.
+          stdout: streamOf([`${OSC_TITLES}${ENVELOPE}\n`]),
+          stderr: { setEncoding: jest.fn(), on: jest.fn() },
+          on: jest.fn(),
+        };
+        (requireNodeModule as jest.Mock).mockImplementation((id: string) =>
+          id === "child_process"
+            ? { spawn: () => child }
+            : { Readable: { toWeb: identity }, Writable: { toWeb: identity } }
+        );
+        const manager = new AcpProcessManager({ command: "/bin/agent", args: ["acp"], env: {} });
+
+        const { stdout } = manager.start();
+
+        expect(await readLines(stdout)).toEqual([ENVELOPE]);
+      });
+    });
+  });
+
   describe("sanitizeAcpStdout()", () => {
-    it("makes a frame prefixed with OSC title sequences parse as JSON", async () => {
+    it("makes a frame prefixed with OSC title sequences parse as JSON (https://github.com/logancyang/obsidian-copilot/issues/2876)", async () => {
       const lines = await readLines(sanitizeAcpStdout(streamOf([`${OSC_TITLES}${ENVELOPE}\n`])));
 
       expect(lines).toHaveLength(1);
@@ -40,7 +76,16 @@ describe("AcpProcessManager", () => {
       });
     });
 
-    it("makes a frame parse as JSON when a chunk boundary splits an escape sequence", async () => {
+    it("makes a frame prefixed with CSI sequences that use the full parameter-byte range parse as JSON (https://github.com/logancyang/obsidian-copilot/issues/2876)", async () => {
+      // Truecolor uses `:` separators; `<`, `=` and `>` appear in private forms.
+      const prefix = "\x1b[38:2:255:0:0m\x1b[<0;1;2M\x1b[=5h\x1b[>4;2m";
+
+      const lines = await readLines(sanitizeAcpStdout(streamOf([`${prefix}${ENVELOPE}\n`])));
+
+      expect(lines).toEqual([ENVELOPE]);
+    });
+
+    it("makes a frame parse as JSON when a chunk boundary splits an escape sequence (https://github.com/logancyang/obsidian-copilot/issues/2876)", async () => {
       const payload = `\x1b[32m${OSC_TITLES}${ENVELOPE}\n`;
       // Cuts land inside the CSI colour code and inside the first OSC title.
       const chunks = [payload.slice(0, 3), payload.slice(3, 12), payload.slice(12)];

--- a/src/agentMode/acp/AcpProcessManager.ts
+++ b/src/agentMode/acp/AcpProcessManager.ts
@@ -158,10 +158,16 @@ export class AcpProcessManager {
  * CSI (colors, cursor moves) and OSC (window title) escape sequences. Agent
  * binaries and their plugins write these to stdout for a human terminal;
  * anything prefixed to a JSON-RPC envelope makes `JSON.parse` throw, and the
- * SDK's `ndJsonStream` drops such frames silently.
+ * SDK's `ndJsonStream` drops such frames silently — which strands Agent Mode
+ * when the decorated frame is the initialization response.
+ * See https://github.com/logancyang/obsidian-copilot/issues/2876.
+ *
+ * The CSI parameter class spans the full `0x30`-`0x3f` range ECMA-48 allows,
+ * not just digits and `;`: truecolor sequences such as `\x1b[38:2:255:0:0m`
+ * use `:`, and private forms use `<`, `=`, `>`, `?`.
  */
 // eslint-disable-next-line no-control-regex -- CSI/OSC sequences are defined by \x1b control bytes
-const TERMINAL_ESCAPE_SEQUENCE = /\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g;
+const TERMINAL_ESCAPE_SEQUENCE = /\x1b\[[0-?]*[ -/]*[@-~]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g;
 
 /**
  * Strip terminal escape sequences from an NDJSON byte stream so downstream


### PR DESCRIPTION
Fixes #2876

## Why

Agent Mode strips terminal escape sequences from a backend's stdout before the ACP SDK parses each NDJSON frame (#2909, for #2876). Its CSI matcher accepts only digits, `;` and `?` as parameter bytes.

ECMA-48 defines that parameter range as `0x30`-`0x3f`, which also covers `:`, `<`, `=` and `>`. So a backend that prefixes a frame with a truecolor sequence such as `\x1b[38:2:255:0:0m`, or with a private `<` / `=` / `>` form, is left untouched today: the escape bytes reach `JSON.parse`, it throws, and `ndJsonStream` drops the frame with nothing surfaced to the user. When the dropped frame is the initialization response, the agent never finishes connecting and the chat sits on its connecting state forever, which is the hang #2876 reported.

`AcpProcessManager.start()` also had no test of its own. The suite calls `sanitizeAcpStdout()` directly and `AcpBackendProcess.test.ts` mocks `AcpProcessManager` wholesale, so unwiring the sanitizer from what `start()` returns left every test green while production went back to hanging.

## What

> **Before:** a backend writes `\x1b[38:2:255:0:0m{"jsonrpc":"2.0",...}` on stdout. The prefix survives sanitizing, the frame is dropped, and Agent Mode hangs on connect.
>
> **After:** the prefix is stripped, the frame parses, and the session connects.

| Frame prefix | Before | After |
| --- | --- | --- |
| `\x1b[32m` (digit parameters) | stripped | stripped |
| `\x1b]0;title\x07` (OSC) | stripped | stripped |
| `\x1b[38:2:255:0:0m` (truecolor, `:` separators) | reaches `JSON.parse`, frame dropped | stripped |
| `\x1b[<0;1;2M`, `\x1b[=5h`, `\x1b[>4;2m` (private forms) | reaches `JSON.parse`, frame dropped | stripped |

No change for anyone whose backend emits only the already-covered sequences.

## Non goal

- No change to how frames are buffered, split across chunk boundaries, or logged.
- No handling of escape sequences that are neither CSI nor OSC.
- No change to stderr routing or to the debug frame log.

## Screenshot

Not applicable. The change is inside the stdout byte stream feeding the ACP parser; nothing about it renders. The behavior evidence is the table above, each row covered by a test.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | `AcpProcessManager.test.ts` covers the truecolor and private CSI forms, the OSC case, split chunks, escape-free frames, and the missing-trailing-newline flush |
| A defect would fail CI or be obvious on first use | ✅ | Those tests run in CI, and a mis-stripped frame breaks agent connect on first use |
| A revert fully restores prior state, including persisted data | ✅ | Pure in-memory stream transform, nothing persisted |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Only which escape bytes are removed before parsing |
| No public API, plugin API, message, or on-disk contract changes | ✅ | `sanitizeAcpStdout` and `start()` keep their signatures |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | The reader loop and buffering are untouched |
| No hot-path behavior lacks deterministic coverage | ✅ | Every branch of the widened character class is asserted |
| No new dependency | ✅ | Dependency manifests unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Confined to Agent Mode connect, visible immediately |

Review: read `TERMINAL_ESCAPE_SEQUENCE` in `src/agentMode/acp/AcpProcessManager.ts` and confirm the widened class only ever applies after a literal `\x1b[`, so JSON payload bytes cannot match. Then run Verification step 1.

## Verification

1. Run `npm test -- src/agentMode/acp`. The `sanitizeAcpStdout()` truecolor case fails against the previous character class and passes with this one.
2. Start Agent Mode with an opencode or codex backend and confirm the session still connects and streams a reply as before.

## Note

The `it(...)` descriptions and the matcher comment now carry the full issue URL, which AGENTS.md requires for behavioral branches added for a specific report.
