### PR TITLE
Add a scroll-to-bottom button to the chat message list

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -54,6 +54,7 @@ Click the **Agent** ribbon icon or run **Open Copilot Agent Chat Window** from t
 - Use **New Chat** to reset the current tab. Use **Recent Chats** on Agent Home, or **Chat History** during a conversation, to resume saved work.
 - Before the first message, you can switch an empty session to another installed agent without losing the draft. After chat history exists, that session stays with its agent.
 - Add the active note, selected text, other notes, the active Copilot web tab, or supported images. You can also mention a note with `[[Note title]]`.
+- When you scroll up in a long conversation, a round arrow button appears near the bottom of the message area — click it to jump back to the newest message. While the agent is working, the button shows animated dots, and clicking it keeps the view pinned to the incoming reply until you scroll up.
 - Hover the small ring next to the send controls to see how full the conversation's context window is. When your account has usage limits the agent can report — such as a 5-hour or weekly cap on a subscription plan — the same panel shows how much of each limit is used and when it resets. If your setup has no such limits (for example, your own API key), no limit rows appear.
 
 Type `/` to insert an enabled skill or [custom command](custom-commands.md). For a small question without opening Agent chat, use [Quick Ask](custom-commands.md#quick-ask).

--- a/docs/chat-interface.md
+++ b/docs/chat-interface.md
@@ -31,6 +31,8 @@ By default, a new chat includes the active note. A text selection takes priority
 
 Press **Enter** to send by default. You can switch this to **Shift + Enter** under **Settings → Copilot → Basic → General → Send Shortcut**. Use the stop button to interrupt a response.
 
+When you scroll up in a long conversation, a round arrow button appears near the bottom of the message area. Click it to jump back to the newest message; scrolling the mouse wheel while hovering it still scrolls the conversation. While Copilot is writing, the button shows animated dots instead of the arrow, and clicking it keeps the view pinned to the incoming text until you scroll up or the response finishes.
+
 Hover over a message to use its actions:
 
 - Your messages: **Copy**, **Edit**, and **Delete**.

--- a/src/agentMode/ui/AgentChatMessages.test.tsx
+++ b/src/agentMode/ui/AgentChatMessages.test.tsx
@@ -5,12 +5,19 @@ import { AI_SENDER } from "@/constants";
 import { act, render, screen } from "@testing-library/react";
 import React from "react";
 
+const scrollingMockState = {
+  isAtBottom: true,
+  scrollToBottom: jest.fn(),
+};
+
 jest.mock("@/hooks/useChatScrolling", () => ({
   // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook; name must match the export
   useChatScrolling: () => ({
     containerMinHeight: 0,
     scrollContainerCallbackRef: jest.fn(),
     getMessageKey: (message: { id: string }) => message.id,
+    isAtBottom: scrollingMockState.isAtBottom,
+    scrollToBottom: scrollingMockState.scrollToBottom,
   }),
 }));
 
@@ -70,6 +77,8 @@ describe("AgentChatMessages", () => {
     beforeEach(() => {
       jest.useFakeTimers();
       jest.setSystemTime(200_000);
+      scrollingMockState.isAtBottom = true;
+      scrollingMockState.scrollToBottom = jest.fn();
     });
 
     afterEach(() => jest.useRealTimers());
@@ -118,6 +127,23 @@ describe("AgentChatMessages", () => {
       );
 
       expect(screen.getByTestId("agent-trail-timestamp").textContent).toBe(timestamp);
+    });
+
+    it("hides the scroll-to-bottom button while the viewport rests at the newest message (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
+      scrollingMockState.isAtBottom = true;
+      renderMessages([assistantMessage("answer-1", 62_000)], false);
+
+      expect(screen.queryByLabelText("Scroll to latest message")).toBeNull();
+    });
+
+    it("shows the scroll-to-bottom button after scrolling away and jumps back on click (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
+      scrollingMockState.isAtBottom = false;
+      scrollingMockState.scrollToBottom = jest.fn();
+      renderMessages([assistantMessage("answer-1", 62_000)], false);
+
+      const button = screen.getByLabelText("Scroll to latest message");
+      act(() => button.click());
+      expect(scrollingMockState.scrollToBottom).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/agentMode/ui/AgentChatMessages.test.tsx
+++ b/src/agentMode/ui/AgentChatMessages.test.tsx
@@ -2,7 +2,7 @@ import type { AgentChatBackend } from "@/agentMode/session/AgentChatBackend";
 import type { AgentChatMessage } from "@/agentMode/session/types";
 import AgentChatMessages from "@/agentMode/ui/AgentChatMessages";
 import { AI_SENDER } from "@/constants";
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import React from "react";
 
 const scrollingMockState = {
@@ -148,14 +148,6 @@ describe("AgentChatMessages", () => {
       const button = screen.getByLabelText("Scroll to latest message");
       act(() => button.click());
       expect(scrollingMockState.jumpToLatest).toHaveBeenCalledTimes(1);
-    });
-
-    it("forwards wheel deltas from the button to the message list so hovering it never traps scrolling (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
-      scrollingMockState.isAtBottom = false;
-      renderMessages([assistantMessage("answer-1", 62_000)], false);
-
-      fireEvent.wheel(screen.getByLabelText("Scroll to latest message"), { deltaY: 120 });
-      expect(scrollingMockState.scrollBy).toHaveBeenCalledWith(120);
     });
 
     it("swaps the arrow for a bouncing typing indicator while a turn is streaming (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {

--- a/src/agentMode/ui/AgentChatMessages.test.tsx
+++ b/src/agentMode/ui/AgentChatMessages.test.tsx
@@ -7,7 +7,7 @@ import React from "react";
 
 const scrollingMockState = {
   isAtBottom: true,
-  scrollToBottom: jest.fn(),
+  jumpToLatest: jest.fn(),
   scrollBy: jest.fn(),
 };
 
@@ -19,7 +19,7 @@ jest.mock("@/hooks/useChatScrolling", () => ({
     contentCallbackRef: jest.fn(),
     getMessageKey: (message: { id: string }) => message.id,
     isAtBottom: scrollingMockState.isAtBottom,
-    scrollToBottom: scrollingMockState.scrollToBottom,
+    jumpToLatest: scrollingMockState.jumpToLatest,
     scrollBy: scrollingMockState.scrollBy,
   }),
 }));
@@ -81,7 +81,7 @@ describe("AgentChatMessages", () => {
       jest.useFakeTimers();
       jest.setSystemTime(200_000);
       scrollingMockState.isAtBottom = true;
-      scrollingMockState.scrollToBottom = jest.fn();
+      scrollingMockState.jumpToLatest = jest.fn();
       scrollingMockState.scrollBy = jest.fn();
     });
 
@@ -142,12 +142,12 @@ describe("AgentChatMessages", () => {
 
     it("shows the scroll-to-bottom button after scrolling away and jumps back on click (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
       scrollingMockState.isAtBottom = false;
-      scrollingMockState.scrollToBottom = jest.fn();
+      scrollingMockState.jumpToLatest = jest.fn();
       renderMessages([assistantMessage("answer-1", 62_000)], false);
 
       const button = screen.getByLabelText("Scroll to latest message");
       act(() => button.click());
-      expect(scrollingMockState.scrollToBottom).toHaveBeenCalledTimes(1);
+      expect(scrollingMockState.jumpToLatest).toHaveBeenCalledTimes(1);
     });
 
     it("forwards wheel deltas from the button to the message list so hovering it never traps scrolling (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {

--- a/src/agentMode/ui/AgentChatMessages.test.tsx
+++ b/src/agentMode/ui/AgentChatMessages.test.tsx
@@ -2,12 +2,13 @@ import type { AgentChatBackend } from "@/agentMode/session/AgentChatBackend";
 import type { AgentChatMessage } from "@/agentMode/session/types";
 import AgentChatMessages from "@/agentMode/ui/AgentChatMessages";
 import { AI_SENDER } from "@/constants";
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 
 const scrollingMockState = {
   isAtBottom: true,
   scrollToBottom: jest.fn(),
+  scrollBy: jest.fn(),
 };
 
 jest.mock("@/hooks/useChatScrolling", () => ({
@@ -15,9 +16,11 @@ jest.mock("@/hooks/useChatScrolling", () => ({
   useChatScrolling: () => ({
     containerMinHeight: 0,
     scrollContainerCallbackRef: jest.fn(),
+    contentCallbackRef: jest.fn(),
     getMessageKey: (message: { id: string }) => message.id,
     isAtBottom: scrollingMockState.isAtBottom,
     scrollToBottom: scrollingMockState.scrollToBottom,
+    scrollBy: scrollingMockState.scrollBy,
   }),
 }));
 
@@ -79,6 +82,7 @@ describe("AgentChatMessages", () => {
       jest.setSystemTime(200_000);
       scrollingMockState.isAtBottom = true;
       scrollingMockState.scrollToBottom = jest.fn();
+      scrollingMockState.scrollBy = jest.fn();
     });
 
     afterEach(() => jest.useRealTimers());
@@ -144,6 +148,26 @@ describe("AgentChatMessages", () => {
       const button = screen.getByLabelText("Scroll to latest message");
       act(() => button.click());
       expect(scrollingMockState.scrollToBottom).toHaveBeenCalledTimes(1);
+    });
+
+    it("forwards wheel deltas from the button to the message list so hovering it never traps scrolling (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
+      scrollingMockState.isAtBottom = false;
+      renderMessages([assistantMessage("answer-1", 62_000)], false);
+
+      fireEvent.wheel(screen.getByLabelText("Scroll to latest message"), { deltaY: 120 });
+      expect(scrollingMockState.scrollBy).toHaveBeenCalledWith(120);
+    });
+
+    it("swaps the arrow for a bouncing typing indicator while a turn is streaming (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
+      scrollingMockState.isAtBottom = false;
+      const { container } = renderMessages(
+        [assistantMessage("answer-1", 62_000, { message: "", parts: [] })],
+        true
+      );
+
+      const button = screen.getByLabelText("Scroll to latest message");
+      expect(container.querySelectorAll(".copilot-typing-dot")).toHaveLength(3);
+      expect(button.querySelector("svg")).toBeNull();
     });
   });
 });

--- a/src/agentMode/ui/AgentChatMessages.tsx
+++ b/src/agentMode/ui/AgentChatMessages.tsx
@@ -238,7 +238,7 @@ const AgentChatMessages = memo(
         {!isAtBottom && (
           <ScrollToBottomButton
             onClick={jumpToLatest}
-            onScrollWheel={scrollBy}
+            onScrollBy={scrollBy}
             isStreaming={isLoading}
           />
         )}

--- a/src/agentMode/ui/AgentChatMessages.tsx
+++ b/src/agentMode/ui/AgentChatMessages.tsx
@@ -5,6 +5,7 @@ import { PlanProposalCard } from "@/agentMode/ui/PlanProposalCard";
 import { ToolPermissionCard } from "@/agentMode/ui/ToolPermissionCard";
 import { AgentTurnDurationIndicator } from "@/agentMode/ui/AgentTurnDurationIndicator";
 import ChatSingleMessage from "@/components/chat-components/ChatSingleMessage";
+import { ScrollToBottomButton } from "@/components/chat-components/ScrollToBottomButton";
 import { USER_SENDER } from "@/constants";
 import { useChatScrolling } from "@/hooks/useChatScrolling";
 import type { AgentChatBackend } from "@/agentMode/session/AgentChatBackend";
@@ -68,7 +69,13 @@ const AgentChatMessages = memo(
   }: AgentChatMessagesProps) => {
     const visible = useMemo(() => messages.filter((m) => m.isVisible), [messages]);
     const adapted = useMemo(() => visible.map(toChatMessageView), [visible]);
-    const { containerMinHeight, scrollContainerCallbackRef, getMessageKey } = useChatScrolling({
+    const {
+      containerMinHeight,
+      scrollContainerCallbackRef,
+      getMessageKey,
+      isAtBottom,
+      scrollToBottom,
+    } = useChatScrolling({
       chatHistory: adapted,
     });
 
@@ -110,7 +117,7 @@ const AgentChatMessages = memo(
     }
 
     return (
-      <div className="tw-flex tw-h-full tw-flex-1 tw-flex-col tw-overflow-hidden">
+      <div className="tw-relative tw-flex tw-h-full tw-flex-1 tw-flex-col tw-overflow-hidden">
         <div
           ref={scrollContainerCallbackRef}
           data-testid="chat-messages"
@@ -218,6 +225,9 @@ const AgentChatMessages = memo(
           {inlineToolPermissionCards}
           {inlineAskUserQuestionCards}
         </div>
+        {/* Jump-back affordance for long chats; see
+            https://github.com/logancyang/obsidian-copilot-preview/issues/329 */}
+        {!isAtBottom && <ScrollToBottomButton onClick={() => scrollToBottom()} />}
       </div>
     );
   }

--- a/src/agentMode/ui/AgentChatMessages.tsx
+++ b/src/agentMode/ui/AgentChatMessages.tsx
@@ -72,9 +72,11 @@ const AgentChatMessages = memo(
     const {
       containerMinHeight,
       scrollContainerCallbackRef,
+      contentCallbackRef,
       getMessageKey,
       isAtBottom,
       scrollToBottom,
+      scrollBy,
     } = useChatScrolling({
       chatHistory: adapted,
     });
@@ -123,111 +125,122 @@ const AgentChatMessages = memo(
           data-testid="chat-messages"
           className="tw-relative tw-flex tw-w-full tw-flex-1 tw-select-text tw-flex-col tw-items-start tw-justify-start tw-overflow-y-auto tw-scroll-smooth tw-break-words tw-text-[calc(var(--font-text-size)_-_2px)]"
         >
-          {visible.map((message, index) => {
-            const isLastMessage = index === visible.length - 1;
-            // Reserve scroll headroom only when the last message is the
-            // assistant AND there's nothing pinned at the tail (plan card or
-            // tool-permission card) — those already provide visible content
-            // at the bottom of the stream.
-            const shouldApplyMinHeight =
-              isLastMessage && message.sender !== USER_SENDER && !hasTailCards;
-            const adaptedMessage = adapted[index];
-            // When an assistant message has structured parts, the trail owns
-            // its entire body — `text` parts already cover streamed prose, so
-            // an additional `ChatSingleMessage` would duplicate it.
-            const isAssistant = message.sender !== USER_SENDER;
-            const hasParts = (message.parts?.length ?? 0) > 0;
-            const renderTrail = isAssistant && hasParts;
-            const ownsTurnDuration = isAssistant && message.id === latestAssistant?.id;
-            const completedTurnDurationMs = ownsTurnDuration ? message.turnDurationMs : undefined;
-            const runningTurnStartedAtMs =
-              ownsTurnDuration && message.id === streamingMessageId
-                ? message.timestamp?.epoch
-                : undefined;
-            const completedTurnDuration =
-              completedTurnDurationMs !== undefined ? (
-                <AgentTurnDurationIndicator
-                  status="complete"
-                  durationMs={completedTurnDurationMs}
-                  inline
-                />
-              ) : null;
-            const runningTurnDuration =
-              runningTurnStartedAtMs !== undefined ? (
-                <AgentTurnDurationIndicator status="running" startedAtMs={runningTurnStartedAtMs} />
-              ) : null;
-            // The streaming placeholder (empty body, no parts) renders the
-            // whole-turn timer in-place, so the user sees progress the moment
-            // they hit send rather than an empty assistant bubble.
-            const isStreamingPlaceholder =
-              isAssistant && message.id === streamingMessageId && !hasParts && !message.message;
-            // A multi-agent turn owns this message's body — the segmented tab
-            // row replaces the plain assistant text and the streaming spinner
-            // (its per-agent slots show their own live states). `message.fanout`
-            // is present for BOTH the live in-flight turn and a reloaded
-            // transcript whose composite body was parsed back into a turn.
-            const fanoutTurn = isAssistant ? message.fanout : undefined;
+          <div ref={contentCallbackRef} className="tw-w-full">
+            {visible.map((message, index) => {
+              const isLastMessage = index === visible.length - 1;
+              // Reserve scroll headroom only when the last message is the
+              // assistant AND there's nothing pinned at the tail (plan card or
+              // tool-permission card) — those already provide visible content
+              // at the bottom of the stream.
+              const shouldApplyMinHeight =
+                isLastMessage && message.sender !== USER_SENDER && !hasTailCards;
+              const adaptedMessage = adapted[index];
+              // When an assistant message has structured parts, the trail owns
+              // its entire body — `text` parts already cover streamed prose, so
+              // an additional `ChatSingleMessage` would duplicate it.
+              const isAssistant = message.sender !== USER_SENDER;
+              const hasParts = (message.parts?.length ?? 0) > 0;
+              const renderTrail = isAssistant && hasParts;
+              const ownsTurnDuration = isAssistant && message.id === latestAssistant?.id;
+              const completedTurnDurationMs = ownsTurnDuration ? message.turnDurationMs : undefined;
+              const runningTurnStartedAtMs =
+                ownsTurnDuration && message.id === streamingMessageId
+                  ? message.timestamp?.epoch
+                  : undefined;
+              const completedTurnDuration =
+                completedTurnDurationMs !== undefined ? (
+                  <AgentTurnDurationIndicator
+                    status="complete"
+                    durationMs={completedTurnDurationMs}
+                    inline
+                  />
+                ) : null;
+              const runningTurnDuration =
+                runningTurnStartedAtMs !== undefined ? (
+                  <AgentTurnDurationIndicator
+                    status="running"
+                    startedAtMs={runningTurnStartedAtMs}
+                  />
+                ) : null;
+              // The streaming placeholder (empty body, no parts) renders the
+              // whole-turn timer in-place, so the user sees progress the moment
+              // they hit send rather than an empty assistant bubble.
+              const isStreamingPlaceholder =
+                isAssistant && message.id === streamingMessageId && !hasParts && !message.message;
+              // A multi-agent turn owns this message's body — the segmented tab
+              // row replaces the plain assistant text and the streaming spinner
+              // (its per-agent slots show their own live states). `message.fanout`
+              // is present for BOTH the live in-flight turn and a reloaded
+              // transcript whose composite body was parsed back into a turn.
+              const fanoutTurn = isAssistant ? message.fanout : undefined;
 
-            return (
-              <div
-                key={getMessageKey(adaptedMessage, index)}
-                data-message-key={getMessageKey(adaptedMessage, index)}
-                className="tw-w-full"
-                style={{
-                  minHeight: shouldApplyMinHeight ? `${containerMinHeight}px` : "auto",
-                }}
-              >
-                {fanoutTurn ? (
-                  <div className="tw-px-3 tw-pt-2">
-                    <FanoutMessageCard
-                      message={message}
-                      turn={fanoutTurn}
-                      app={app}
-                      footerStart={completedTurnDuration}
-                    />
-                    {runningTurnDuration}
-                  </div>
-                ) : isStreamingPlaceholder ? (
-                  <div className="tw-px-3 tw-pt-2">{runningTurnDuration}</div>
-                ) : renderTrail ? (
-                  <div className="tw-px-3 tw-pt-2">
-                    <AgentTrail
-                      parts={message.parts!}
-                      isStreaming={message.id === streamingMessageId}
-                      turnStartedAtMs={runningTurnStartedAtMs}
-                      turnDurationMs={completedTurnDurationMs}
-                      timestamp={message.timestamp?.display}
-                      app={app}
-                      turnStopReason={message.turnStopReason}
-                    />
-                  </div>
-                ) : (
-                  // Agent Mode has no per-message regenerate / edit / delete flow
-                  // yet (ACP owns conversation history server-side), so no
-                  // lifecycle handlers are wired — ChatButtons renders only the
-                  // copy / insert actions it can honor.
-                  <>
-                    <ChatSingleMessage
-                      message={adaptedMessage}
-                      app={app}
-                      isStreaming={false}
-                      footerStart={completedTurnDuration}
-                    />
-                    {runningTurnDuration ? (
-                      <div className="tw-px-3">{runningTurnDuration}</div>
-                    ) : null}
-                  </>
-                )}
-              </div>
-            );
-          })}
-          {inlinePlanCard}
-          {inlineToolPermissionCards}
-          {inlineAskUserQuestionCards}
+              return (
+                <div
+                  key={getMessageKey(adaptedMessage, index)}
+                  data-message-key={getMessageKey(adaptedMessage, index)}
+                  className="tw-w-full"
+                  style={{
+                    minHeight: shouldApplyMinHeight ? `${containerMinHeight}px` : "auto",
+                  }}
+                >
+                  {fanoutTurn ? (
+                    <div className="tw-px-3 tw-pt-2">
+                      <FanoutMessageCard
+                        message={message}
+                        turn={fanoutTurn}
+                        app={app}
+                        footerStart={completedTurnDuration}
+                      />
+                      {runningTurnDuration}
+                    </div>
+                  ) : isStreamingPlaceholder ? (
+                    <div className="tw-px-3 tw-pt-2">{runningTurnDuration}</div>
+                  ) : renderTrail ? (
+                    <div className="tw-px-3 tw-pt-2">
+                      <AgentTrail
+                        parts={message.parts!}
+                        isStreaming={message.id === streamingMessageId}
+                        turnStartedAtMs={runningTurnStartedAtMs}
+                        turnDurationMs={completedTurnDurationMs}
+                        timestamp={message.timestamp?.display}
+                        app={app}
+                        turnStopReason={message.turnStopReason}
+                      />
+                    </div>
+                  ) : (
+                    // Agent Mode has no per-message regenerate / edit / delete flow
+                    // yet (ACP owns conversation history server-side), so no
+                    // lifecycle handlers are wired — ChatButtons renders only the
+                    // copy / insert actions it can honor.
+                    <>
+                      <ChatSingleMessage
+                        message={adaptedMessage}
+                        app={app}
+                        isStreaming={false}
+                        footerStart={completedTurnDuration}
+                      />
+                      {runningTurnDuration ? (
+                        <div className="tw-px-3">{runningTurnDuration}</div>
+                      ) : null}
+                    </>
+                  )}
+                </div>
+              );
+            })}
+            {inlinePlanCard}
+            {inlineToolPermissionCards}
+            {inlineAskUserQuestionCards}
+          </div>
         </div>
         {/* Jump-back affordance for long chats; see
             https://github.com/logancyang/obsidian-copilot-preview/issues/329 */}
-        {!isAtBottom && <ScrollToBottomButton onClick={() => scrollToBottom()} />}
+        {!isAtBottom && (
+          <ScrollToBottomButton
+            onClick={() => scrollToBottom()}
+            onScrollWheel={scrollBy}
+            isStreaming={isLoading}
+          />
+        )}
       </div>
     );
   }

--- a/src/agentMode/ui/AgentChatMessages.tsx
+++ b/src/agentMode/ui/AgentChatMessages.tsx
@@ -75,10 +75,11 @@ const AgentChatMessages = memo(
       contentCallbackRef,
       getMessageKey,
       isAtBottom,
-      scrollToBottom,
+      jumpToLatest,
       scrollBy,
     } = useChatScrolling({
       chatHistory: adapted,
+      isStreaming: isLoading,
     });
 
     const showPlanCard = currentPlan != null && currentPlan.decision === "pending";
@@ -236,7 +237,7 @@ const AgentChatMessages = memo(
             https://github.com/logancyang/obsidian-copilot-preview/issues/329 */}
         {!isAtBottom && (
           <ScrollToBottomButton
-            onClick={() => scrollToBottom()}
+            onClick={jumpToLatest}
             onScrollWheel={scrollBy}
             isStreaming={isLoading}
           />

--- a/src/components/chat-components/ChatMessages.test.tsx
+++ b/src/components/chat-components/ChatMessages.test.tsx
@@ -1,12 +1,13 @@
 import ChatMessages, { isChatEmpty } from "@/components/chat-components/ChatMessages";
 import { USER_SENDER } from "@/constants";
 import type { ChatMessage } from "@/types/message";
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 
 const scrollingMockState = {
   isAtBottom: true,
   scrollToBottom: jest.fn(),
+  scrollBy: jest.fn(),
 };
 
 jest.mock("@/hooks/useChatScrolling", () => ({
@@ -14,9 +15,11 @@ jest.mock("@/hooks/useChatScrolling", () => ({
   useChatScrolling: () => ({
     containerMinHeight: 0,
     scrollContainerCallbackRef: jest.fn(),
+    contentCallbackRef: jest.fn(),
     getMessageKey: (message: { id?: string }, index: number) => message.id ?? `${index}`,
     isAtBottom: scrollingMockState.isAtBottom,
     scrollToBottom: scrollingMockState.scrollToBottom,
+    scrollBy: scrollingMockState.scrollBy,
   }),
 }));
 
@@ -46,11 +49,11 @@ function userMessage(id: string, text: string): ChatMessage {
   };
 }
 
-function renderMessages(chatHistory: ChatMessage[]) {
+function renderMessages(chatHistory: ChatMessage[], currentAiMessage = "") {
   return render(
     <ChatMessages
       chatHistory={chatHistory}
-      currentAiMessage=""
+      currentAiMessage={currentAiMessage}
       app={{} as never}
       onRegenerate={jest.fn()}
       onEdit={jest.fn()}
@@ -86,6 +89,7 @@ describe("ChatMessages", () => {
     beforeEach(() => {
       scrollingMockState.isAtBottom = true;
       scrollingMockState.scrollToBottom = jest.fn();
+      scrollingMockState.scrollBy = jest.fn();
     });
 
     it("hides the scroll-to-bottom button while the viewport rests at the newest message (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
@@ -101,6 +105,23 @@ describe("ChatMessages", () => {
       const button = screen.getByLabelText("Scroll to latest message");
       act(() => button.click());
       expect(scrollingMockState.scrollToBottom).toHaveBeenCalledTimes(1);
+    });
+
+    it("forwards wheel deltas from the button to the message list so hovering it never traps scrolling (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
+      scrollingMockState.isAtBottom = false;
+      renderMessages([userMessage("m1", "hello")]);
+
+      fireEvent.wheel(screen.getByLabelText("Scroll to latest message"), { deltaY: -80 });
+      expect(scrollingMockState.scrollBy).toHaveBeenCalledWith(-80);
+    });
+
+    it("swaps the arrow for a bouncing typing indicator while a response is streaming (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
+      scrollingMockState.isAtBottom = false;
+      const { container } = renderMessages([userMessage("m1", "hello")], "partial reply");
+
+      const button = screen.getByLabelText("Scroll to latest message");
+      expect(container.querySelectorAll(".copilot-typing-dot")).toHaveLength(3);
+      expect(button.querySelector("svg")).toBeNull();
     });
   });
 });

--- a/src/components/chat-components/ChatMessages.test.tsx
+++ b/src/components/chat-components/ChatMessages.test.tsx
@@ -1,5 +1,29 @@
-import { isChatEmpty } from "@/components/chat-components/ChatMessages";
-import { ChatMessage } from "@/types/message";
+import ChatMessages, { isChatEmpty } from "@/components/chat-components/ChatMessages";
+import { USER_SENDER } from "@/constants";
+import type { ChatMessage } from "@/types/message";
+import { act, render, screen } from "@testing-library/react";
+import React from "react";
+
+const scrollingMockState = {
+  isAtBottom: true,
+  scrollToBottom: jest.fn(),
+};
+
+jest.mock("@/hooks/useChatScrolling", () => ({
+  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook; name must match the export
+  useChatScrolling: () => ({
+    containerMinHeight: 0,
+    scrollContainerCallbackRef: jest.fn(),
+    getMessageKey: (message: { id?: string }, index: number) => message.id ?? `${index}`,
+    isAtBottom: scrollingMockState.isAtBottom,
+    scrollToBottom: scrollingMockState.scrollToBottom,
+  }),
+}));
+
+jest.mock("@/components/chat-components/ChatSingleMessage", () => ({
+  __esModule: true,
+  default: ({ message }: { message: { message: string } }) => <div>{message.message}</div>,
+}));
 
 function message(overrides: Partial<ChatMessage> = {}): ChatMessage {
   return {
@@ -10,6 +34,29 @@ function message(overrides: Partial<ChatMessage> = {}): ChatMessage {
     timestamp: null,
     ...overrides,
   };
+}
+
+function userMessage(id: string, text: string): ChatMessage {
+  return {
+    id,
+    sender: USER_SENDER,
+    message: text,
+    timestamp: { epoch: 1_000, display: "", fileName: "" },
+    isVisible: true,
+  };
+}
+
+function renderMessages(chatHistory: ChatMessage[]) {
+  return render(
+    <ChatMessages
+      chatHistory={chatHistory}
+      currentAiMessage=""
+      app={{} as never}
+      onRegenerate={jest.fn()}
+      onEdit={jest.fn()}
+      onDelete={jest.fn()}
+    />
+  );
 }
 
 describe("ChatMessages", () => {
@@ -32,6 +79,28 @@ describe("ChatMessages", () => {
 
     it("reports a non-empty chat when a hidden message accompanies a streaming response", () => {
       expect(isChatEmpty([message({ isVisible: false })], "thinking...")).toBe(false);
+    });
+  });
+
+  describe("ChatMessages()", () => {
+    beforeEach(() => {
+      scrollingMockState.isAtBottom = true;
+      scrollingMockState.scrollToBottom = jest.fn();
+    });
+
+    it("hides the scroll-to-bottom button while the viewport rests at the newest message (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
+      renderMessages([userMessage("m1", "hello")]);
+
+      expect(screen.queryByLabelText("Scroll to latest message")).toBeNull();
+    });
+
+    it("shows the scroll-to-bottom button after scrolling away and jumps back on click (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
+      scrollingMockState.isAtBottom = false;
+      renderMessages([userMessage("m1", "hello")]);
+
+      const button = screen.getByLabelText("Scroll to latest message");
+      act(() => button.click());
+      expect(scrollingMockState.scrollToBottom).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/components/chat-components/ChatMessages.test.tsx
+++ b/src/components/chat-components/ChatMessages.test.tsx
@@ -6,7 +6,7 @@ import React from "react";
 
 const scrollingMockState = {
   isAtBottom: true,
-  scrollToBottom: jest.fn(),
+  jumpToLatest: jest.fn(),
   scrollBy: jest.fn(),
 };
 
@@ -18,7 +18,7 @@ jest.mock("@/hooks/useChatScrolling", () => ({
     contentCallbackRef: jest.fn(),
     getMessageKey: (message: { id?: string }, index: number) => message.id ?? `${index}`,
     isAtBottom: scrollingMockState.isAtBottom,
-    scrollToBottom: scrollingMockState.scrollToBottom,
+    jumpToLatest: scrollingMockState.jumpToLatest,
     scrollBy: scrollingMockState.scrollBy,
   }),
 }));
@@ -88,7 +88,7 @@ describe("ChatMessages", () => {
   describe("ChatMessages()", () => {
     beforeEach(() => {
       scrollingMockState.isAtBottom = true;
-      scrollingMockState.scrollToBottom = jest.fn();
+      scrollingMockState.jumpToLatest = jest.fn();
       scrollingMockState.scrollBy = jest.fn();
     });
 
@@ -104,7 +104,7 @@ describe("ChatMessages", () => {
 
       const button = screen.getByLabelText("Scroll to latest message");
       act(() => button.click());
-      expect(scrollingMockState.scrollToBottom).toHaveBeenCalledTimes(1);
+      expect(scrollingMockState.jumpToLatest).toHaveBeenCalledTimes(1);
     });
 
     it("forwards wheel deltas from the button to the message list so hovering it never traps scrolling (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {

--- a/src/components/chat-components/ChatMessages.test.tsx
+++ b/src/components/chat-components/ChatMessages.test.tsx
@@ -49,11 +49,12 @@ function userMessage(id: string, text: string): ChatMessage {
   };
 }
 
-function renderMessages(chatHistory: ChatMessage[], currentAiMessage = "") {
+function renderMessages(chatHistory: ChatMessage[], currentAiMessage = "", loading = false) {
   return render(
     <ChatMessages
       chatHistory={chatHistory}
       currentAiMessage={currentAiMessage}
+      loading={loading}
       app={{} as never}
       onRegenerate={jest.fn()}
       onEdit={jest.fn()}
@@ -117,11 +118,20 @@ describe("ChatMessages", () => {
 
     it("swaps the arrow for a bouncing typing indicator while a response is streaming (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
       scrollingMockState.isAtBottom = false;
-      const { container } = renderMessages([userMessage("m1", "hello")], "partial reply");
+      const { container } = renderMessages([userMessage("m1", "hello")], "partial reply", true);
 
       const button = screen.getByLabelText("Scroll to latest message");
       expect(container.querySelectorAll(".copilot-typing-dot")).toHaveLength(3);
       expect(button.querySelector("svg")).toBeNull();
+    });
+
+    it("shows the static arrow when a stopped generation retains partial text without an active request (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
+      scrollingMockState.isAtBottom = false;
+      const { container } = renderMessages([userMessage("m1", "hello")], "partial reply", false);
+
+      const button = screen.getByLabelText("Scroll to latest message");
+      expect(container.querySelectorAll(".copilot-typing-dot")).toHaveLength(0);
+      expect(button.querySelector("svg")).toBeTruthy();
     });
   });
 });

--- a/src/components/chat-components/ChatMessages.test.tsx
+++ b/src/components/chat-components/ChatMessages.test.tsx
@@ -1,7 +1,7 @@
 import ChatMessages, { isChatEmpty } from "@/components/chat-components/ChatMessages";
 import { USER_SENDER } from "@/constants";
 import type { ChatMessage } from "@/types/message";
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import React from "react";
 
 const scrollingMockState = {
@@ -106,14 +106,6 @@ describe("ChatMessages", () => {
       const button = screen.getByLabelText("Scroll to latest message");
       act(() => button.click());
       expect(scrollingMockState.jumpToLatest).toHaveBeenCalledTimes(1);
-    });
-
-    it("forwards wheel deltas from the button to the message list so hovering it never traps scrolling (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
-      scrollingMockState.isAtBottom = false;
-      renderMessages([userMessage("m1", "hello")]);
-
-      fireEvent.wheel(screen.getByLabelText("Scroll to latest message"), { deltaY: -80 });
-      expect(scrollingMockState.scrollBy).toHaveBeenCalledWith(-80);
     });
 
     it("swaps the arrow for a bouncing typing indicator while a response is streaming (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {

--- a/src/components/chat-components/ChatMessages.tsx
+++ b/src/components/chat-components/ChatMessages.tsx
@@ -45,6 +45,8 @@ const ChatMessages = memo(
     onEdit,
     onDelete,
   }: ChatMessagesProps) => {
+    const isStreaming = !!currentAiMessage || !!loading;
+
     // Chat scrolling behavior
     const {
       containerMinHeight,
@@ -52,10 +54,11 @@ const ChatMessages = memo(
       contentCallbackRef,
       getMessageKey,
       isAtBottom,
-      scrollToBottom,
+      jumpToLatest,
       scrollBy,
     } = useChatScrolling({
       chatHistory,
+      isStreaming,
     });
 
     if (isChatEmpty(chatHistory, currentAiMessage)) {
@@ -142,9 +145,9 @@ const ChatMessages = memo(
             https://github.com/logancyang/obsidian-copilot-preview/issues/329 */}
         {!isAtBottom && (
           <ScrollToBottomButton
-            onClick={() => scrollToBottom()}
+            onClick={jumpToLatest}
             onScrollWheel={scrollBy}
-            isStreaming={!!currentAiMessage || !!loading}
+            isStreaming={isStreaming}
           />
         )}
       </div>

--- a/src/components/chat-components/ChatMessages.tsx
+++ b/src/components/chat-components/ChatMessages.tsx
@@ -150,7 +150,7 @@ const ChatMessages = memo(
         {!isAtBottom && (
           <ScrollToBottomButton
             onClick={jumpToLatest}
-            onScrollWheel={scrollBy}
+            onScrollBy={scrollBy}
             isStreaming={isStreaming}
           />
         )}

--- a/src/components/chat-components/ChatMessages.tsx
+++ b/src/components/chat-components/ChatMessages.tsx
@@ -1,5 +1,6 @@
 import { BottomLoadingIndicator } from "@/components/chat-components/BottomLoadingIndicator";
 import ChatSingleMessage from "@/components/chat-components/ChatSingleMessage";
+import { ScrollToBottomButton } from "@/components/chat-components/ScrollToBottomButton";
 import { USER_SENDER } from "@/constants";
 import { useChatScrolling } from "@/hooks/useChatScrolling";
 import { ChatMessage } from "@/types/message";
@@ -45,7 +46,13 @@ const ChatMessages = memo(
     onDelete,
   }: ChatMessagesProps) => {
     // Chat scrolling behavior
-    const { containerMinHeight, scrollContainerCallbackRef, getMessageKey } = useChatScrolling({
+    const {
+      containerMinHeight,
+      scrollContainerCallbackRef,
+      getMessageKey,
+      isAtBottom,
+      scrollToBottom,
+    } = useChatScrolling({
       chatHistory,
     });
 
@@ -61,7 +68,7 @@ const ChatMessages = memo(
     }
 
     return (
-      <div className="tw-flex tw-h-full tw-flex-1 tw-flex-col tw-overflow-hidden">
+      <div className="tw-relative tw-flex tw-h-full tw-flex-1 tw-flex-col tw-overflow-hidden">
         <div
           ref={scrollContainerCallbackRef}
           data-testid="chat-messages"
@@ -127,6 +134,9 @@ const ChatMessages = memo(
             </div>
           ) : null}
         </div>
+        {/* Jump-back affordance for long chats; see
+            https://github.com/logancyang/obsidian-copilot-preview/issues/329 */}
+        {!isAtBottom && <ScrollToBottomButton onClick={() => scrollToBottom()} />}
       </div>
     );
   }

--- a/src/components/chat-components/ChatMessages.tsx
+++ b/src/components/chat-components/ChatMessages.tsx
@@ -45,7 +45,11 @@ const ChatMessages = memo(
     onEdit,
     onDelete,
   }: ChatMessagesProps) => {
-    const isStreaming = !!currentAiMessage || !!loading;
+    // `loading` spans the whole request, while stopping a generation keeps its
+    // partial text in currentAiMessage — so only `loading` distinguishes an
+    // active stream from output retained after Stop.
+    // https://github.com/logancyang/obsidian-copilot-preview/issues/329
+    const isStreaming = !!loading;
 
     // Chat scrolling behavior
     const {

--- a/src/components/chat-components/ChatMessages.tsx
+++ b/src/components/chat-components/ChatMessages.tsx
@@ -49,9 +49,11 @@ const ChatMessages = memo(
     const {
       containerMinHeight,
       scrollContainerCallbackRef,
+      contentCallbackRef,
       getMessageKey,
       isAtBottom,
       scrollToBottom,
+      scrollBy,
     } = useChatScrolling({
       chatHistory,
     });
@@ -74,69 +76,77 @@ const ChatMessages = memo(
           data-testid="chat-messages"
           className="tw-relative tw-flex tw-w-full tw-flex-1 tw-select-text tw-flex-col tw-items-start tw-justify-start tw-overflow-y-auto tw-scroll-smooth tw-break-words tw-text-[calc(var(--font-text-size)_-_2px)]"
         >
-          {chatHistory.map((message, index) => {
-            const visibleMessages = chatHistory.filter((m) => m.isVisible);
-            const isLastMessage = index === visibleMessages.length - 1;
-            // Only apply min-height to AI messages that are last
-            const shouldApplyMinHeight = isLastMessage && message.sender !== USER_SENDER;
+          <div ref={contentCallbackRef} className="tw-w-full">
+            {chatHistory.map((message, index) => {
+              const visibleMessages = chatHistory.filter((m) => m.isVisible);
+              const isLastMessage = index === visibleMessages.length - 1;
+              // Only apply min-height to AI messages that are last
+              const shouldApplyMinHeight = isLastMessage && message.sender !== USER_SENDER;
 
-            return (
-              message.isVisible && (
-                <div
-                  key={getMessageKey(message, index)}
-                  data-message-key={getMessageKey(message, index)}
-                  className="tw-w-full"
-                  style={{
-                    minHeight: shouldApplyMinHeight ? `${containerMinHeight}px` : "auto",
-                  }}
-                >
-                  <ChatSingleMessage
-                    message={message}
-                    app={app}
-                    isStreaming={false}
-                    onRegenerate={() => onRegenerate(index)}
-                    onEdit={(newMessage) => onEdit(index, newMessage)}
-                    onDelete={() => onDelete(index)}
-                  />
-                </div>
-              )
-            );
-          })}
-          {currentAiMessage ? (
-            <div
-              className="tw-w-full"
-              style={{
-                minHeight: `${containerMinHeight}px`,
-              }}
-            >
-              <ChatSingleMessage
-                key={streamingMessageId ?? "ai_message_streaming"}
-                message={{
-                  id: streamingMessageId ?? undefined,
-                  sender: "AI",
-                  message: currentAiMessage,
-                  isVisible: true,
-                  timestamp: null,
+              return (
+                message.isVisible && (
+                  <div
+                    key={getMessageKey(message, index)}
+                    data-message-key={getMessageKey(message, index)}
+                    className="tw-w-full"
+                    style={{
+                      minHeight: shouldApplyMinHeight ? `${containerMinHeight}px` : "auto",
+                    }}
+                  >
+                    <ChatSingleMessage
+                      message={message}
+                      app={app}
+                      isStreaming={false}
+                      onRegenerate={() => onRegenerate(index)}
+                      onEdit={(newMessage) => onEdit(index, newMessage)}
+                      onDelete={() => onDelete(index)}
+                    />
+                  </div>
+                )
+              );
+            })}
+            {currentAiMessage ? (
+              <div
+                className="tw-w-full"
+                style={{
+                  minHeight: `${containerMinHeight}px`,
                 }}
-                app={app}
-                isStreaming={true}
-                onDelete={() => {}}
-              />
-            </div>
-          ) : loading ? (
-            <div
-              className="tw-w-full"
-              style={{
-                minHeight: `${containerMinHeight}px`,
-              }}
-            >
-              <BottomLoadingIndicator label={loadingMessage} />
-            </div>
-          ) : null}
+              >
+                <ChatSingleMessage
+                  key={streamingMessageId ?? "ai_message_streaming"}
+                  message={{
+                    id: streamingMessageId ?? undefined,
+                    sender: "AI",
+                    message: currentAiMessage,
+                    isVisible: true,
+                    timestamp: null,
+                  }}
+                  app={app}
+                  isStreaming={true}
+                  onDelete={() => {}}
+                />
+              </div>
+            ) : loading ? (
+              <div
+                className="tw-w-full"
+                style={{
+                  minHeight: `${containerMinHeight}px`,
+                }}
+              >
+                <BottomLoadingIndicator label={loadingMessage} />
+              </div>
+            ) : null}
+          </div>
         </div>
         {/* Jump-back affordance for long chats; see
             https://github.com/logancyang/obsidian-copilot-preview/issues/329 */}
-        {!isAtBottom && <ScrollToBottomButton onClick={() => scrollToBottom()} />}
+        {!isAtBottom && (
+          <ScrollToBottomButton
+            onClick={() => scrollToBottom()}
+            onScrollWheel={scrollBy}
+            isStreaming={!!currentAiMessage || !!loading}
+          />
+        )}
       </div>
     );
   }

--- a/src/components/chat-components/ScrollToBottomButton.stories.tsx
+++ b/src/components/chat-components/ScrollToBottomButton.stories.tsx
@@ -9,10 +9,10 @@ const meta = {
 } satisfies Meta<ScrollToBottomButtonProps>;
 export default meta;
 
-// The button is absolutely positioned by design, so the story recreates its
+// The button is absolutely positioned by design, so the stories recreate its
 // real boundary: a relative, clipped message-list container it floats over.
-export const OverMessageList: StoryObj<ScrollToBottomButtonProps> = {
-  render: () => (
+function MessageListFrame({ children }: { children: React.ReactNode }) {
+  return (
     <div className="tw-relative tw-h-64 tw-overflow-hidden tw-rounded-md tw-border tw-border-solid tw-border-border">
       <div className="tw-h-full tw-overflow-y-auto tw-p-4 tw-text-muted">
         <p>
@@ -30,7 +30,23 @@ export const OverMessageList: StoryObj<ScrollToBottomButtonProps> = {
           quickly expanded into classical texts, legal codes, grammars, and popular literature.
         </p>
       </div>
-      <ScrollToBottomButton onClick={() => {}} />
+      {children}
     </div>
+  );
+}
+
+export const OverMessageList: StoryObj<ScrollToBottomButtonProps> = {
+  render: () => (
+    <MessageListFrame>
+      <ScrollToBottomButton onClick={() => {}} onScrollWheel={() => {}} />
+    </MessageListFrame>
+  ),
+};
+
+export const Streaming: StoryObj<ScrollToBottomButtonProps> = {
+  render: () => (
+    <MessageListFrame>
+      <ScrollToBottomButton onClick={() => {}} onScrollWheel={() => {}} isStreaming />
+    </MessageListFrame>
   ),
 };

--- a/src/components/chat-components/ScrollToBottomButton.stories.tsx
+++ b/src/components/chat-components/ScrollToBottomButton.stories.tsx
@@ -38,7 +38,7 @@ function MessageListFrame({ children }: { children: React.ReactNode }) {
 export const OverMessageList: StoryObj<ScrollToBottomButtonProps> = {
   render: () => (
     <MessageListFrame>
-      <ScrollToBottomButton onClick={() => {}} onScrollWheel={() => {}} />
+      <ScrollToBottomButton onClick={() => {}} onScrollBy={() => {}} />
     </MessageListFrame>
   ),
 };
@@ -46,7 +46,7 @@ export const OverMessageList: StoryObj<ScrollToBottomButtonProps> = {
 export const Streaming: StoryObj<ScrollToBottomButtonProps> = {
   render: () => (
     <MessageListFrame>
-      <ScrollToBottomButton onClick={() => {}} onScrollWheel={() => {}} isStreaming />
+      <ScrollToBottomButton onClick={() => {}} onScrollBy={() => {}} isStreaming />
     </MessageListFrame>
   ),
 };

--- a/src/components/chat-components/ScrollToBottomButton.stories.tsx
+++ b/src/components/chat-components/ScrollToBottomButton.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@/lib/story";
+import React from "react";
+import { ScrollToBottomButton, type ScrollToBottomButtonProps } from "./ScrollToBottomButton";
+
+const meta = {
+  title: "Chat/Scroll To Bottom Button",
+  component: ScrollToBottomButton,
+  parameters: { gallery: { host: "leaf", layout: "padded" } },
+} satisfies Meta<ScrollToBottomButtonProps>;
+export default meta;
+
+// The button is absolutely positioned by design, so the story recreates its
+// real boundary: a relative, clipped message-list container it floats over.
+export const OverMessageList: StoryObj<ScrollToBottomButtonProps> = {
+  render: () => (
+    <div className="tw-relative tw-h-64 tw-overflow-hidden tw-rounded-md tw-border tw-border-solid tw-border-border">
+      <div className="tw-h-full tw-overflow-y-auto tw-p-4 tw-text-muted">
+        <p>
+          The printing press had profound and far-reaching consequences. Martin Luther&apos;s 95
+          Theses were printed and distributed across Germany within weeks.
+        </p>
+        <p>
+          By 1500 — just 50 years after Gutenberg&apos;s Bible — an estimated 20 million volumes had
+          been printed, more books than had been produced in all of European history up to that
+          point.
+        </p>
+        <p>
+          The early printers were often former scribes, goldsmiths, or merchants who saw the
+          commercial opportunity. They produced Bibles, psalters, and religious tracts first, but
+          quickly expanded into classical texts, legal codes, grammars, and popular literature.
+        </p>
+      </div>
+      <ScrollToBottomButton onClick={() => {}} />
+    </div>
+  ),
+};

--- a/src/components/chat-components/ScrollToBottomButton.test.tsx
+++ b/src/components/chat-components/ScrollToBottomButton.test.tsx
@@ -1,0 +1,43 @@
+import { ScrollToBottomButton } from "@/components/chat-components/ScrollToBottomButton";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+function renderButton(props: Partial<React.ComponentProps<typeof ScrollToBottomButton>> = {}) {
+  return render(<ScrollToBottomButton onClick={jest.fn()} onScrollWheel={jest.fn()} {...props} />);
+}
+
+describe("ScrollToBottomButton", () => {
+  describe("ScrollToBottomButton()", () => {
+    it("renders an accessible circular affordance with the down arrow by default (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
+      const { container } = renderButton();
+
+      const button = screen.getByLabelText("Scroll to latest message");
+      expect(button.querySelector("svg")).toBeTruthy();
+      expect(container.querySelectorAll(".copilot-typing-dot")).toHaveLength(0);
+    });
+
+    it("invokes onClick when the user asks to jump back to the newest message (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
+      const onClick = jest.fn();
+      renderButton({ onClick });
+
+      act(() => screen.getByLabelText("Scroll to latest message").click());
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it("forwards wheel deltas so hovering the button never traps scrolling (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
+      const onScrollWheel = jest.fn();
+      renderButton({ onScrollWheel });
+
+      fireEvent.wheel(screen.getByLabelText("Scroll to latest message"), { deltaY: 120 });
+      expect(onScrollWheel).toHaveBeenCalledWith(120);
+    });
+
+    it("swaps the arrow for three bouncing typing dots while a response is streaming (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
+      const { container } = renderButton({ isStreaming: true });
+
+      const button = screen.getByLabelText("Scroll to latest message");
+      expect(container.querySelectorAll(".copilot-typing-dot")).toHaveLength(3);
+      expect(button.querySelector("svg")).toBeNull();
+    });
+  });
+});

--- a/src/components/chat-components/ScrollToBottomButton.test.tsx
+++ b/src/components/chat-components/ScrollToBottomButton.test.tsx
@@ -3,7 +3,7 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 
 function renderButton(props: Partial<React.ComponentProps<typeof ScrollToBottomButton>> = {}) {
-  return render(<ScrollToBottomButton onClick={jest.fn()} onScrollWheel={jest.fn()} {...props} />);
+  return render(<ScrollToBottomButton onClick={jest.fn()} onScrollBy={jest.fn()} {...props} />);
 }
 
 describe("ScrollToBottomButton", () => {
@@ -25,11 +25,24 @@ describe("ScrollToBottomButton", () => {
     });
 
     it("forwards wheel deltas so hovering the button never traps scrolling (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
-      const onScrollWheel = jest.fn();
-      renderButton({ onScrollWheel });
+      const onScrollBy = jest.fn();
+      renderButton({ onScrollBy });
 
       fireEvent.wheel(screen.getByLabelText("Scroll to latest message"), { deltaY: 120 });
-      expect(onScrollWheel).toHaveBeenCalledWith(120);
+      expect(onScrollBy).toHaveBeenCalledWith(120);
+    });
+
+    it("forwards touch drags so a swipe starting on the button still pans the list (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
+      const onScrollBy = jest.fn();
+      renderButton({ onScrollBy });
+      const button = screen.getByLabelText("Scroll to latest message");
+
+      fireEvent.touchStart(button, { touches: [{ clientY: 300 }] });
+      fireEvent.touchMove(button, { touches: [{ clientY: 260 }] });
+      expect(onScrollBy).toHaveBeenCalledWith(40);
+
+      fireEvent.touchMove(button, { touches: [{ clientY: 290 }] });
+      expect(onScrollBy).toHaveBeenLastCalledWith(-30);
     });
 
     it("swaps the arrow for three bouncing typing dots while a response is streaming (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {

--- a/src/components/chat-components/ScrollToBottomButton.tsx
+++ b/src/components/chat-components/ScrollToBottomButton.tsx
@@ -11,7 +11,11 @@ export interface ScrollToBottomButtonProps {
    * traps the user's scrolling.
    */
   onScrollWheel: (deltaY: number) => void;
-  /** While a response is streaming, the arrow becomes a typing indicator. */
+  /**
+   * While a response is streaming, the arrow becomes a typing indicator so
+   * the button doubles as a "content is still arriving below" signal.
+   * https://github.com/logancyang/obsidian-copilot-preview/issues/329
+   */
   isStreaming?: boolean;
 }
 

--- a/src/components/chat-components/ScrollToBottomButton.tsx
+++ b/src/components/chat-components/ScrollToBottomButton.tsx
@@ -1,16 +1,16 @@
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { ArrowDown } from "lucide-react";
-import React from "react";
+import React, { useRef } from "react";
 
 export interface ScrollToBottomButtonProps {
   /** Invoked when the user asks to jump back to the newest message. */
   onClick: () => void;
   /**
-   * Forwards wheel deltas to the message list, so hovering the button never
-   * traps the user's scrolling.
+   * Forwards scroll intent (wheel deltas and touch drags) to the message
+   * list, so hovering or touching the button never traps scrolling.
    */
-  onScrollWheel: (deltaY: number) => void;
+  onScrollBy: (deltaY: number) => void;
   /**
    * While a response is streaming, the arrow becomes a typing indicator so
    * the button doubles as a "content is still arriving below" signal.
@@ -26,9 +26,20 @@ export interface ScrollToBottomButtonProps {
  */
 export function ScrollToBottomButton({
   onClick,
-  onScrollWheel,
+  onScrollBy,
   isStreaming = false,
 }: ScrollToBottomButtonProps) {
+  // DESIGN NOTE (input forwarding × sibling overlay): the overlay is a DOM
+  // sibling of the scroller, so native scroll chaining never reaches the
+  // list from here — wheel deltas and touch drags are forwarded instead.
+  // Keyboard scrolling while the button is focused is intentionally not
+  // forwarded: reaching that state takes deliberate tabbing, Enter/Space
+  // already trigger the jump, and it is recoverable by tabbing away (P3, no
+  // real caller observed). If a future review flags this again, point them
+  // at this note.
+  // https://github.com/logancyang/obsidian-copilot-preview/issues/329
+  const lastTouchYRef = useRef<number | null>(null);
+
   return (
     <Button
       type="button"
@@ -37,7 +48,20 @@ export function ScrollToBottomButton({
       aria-label="Scroll to latest message"
       title="Scroll to latest message"
       onClick={() => onClick()}
-      onWheel={(event) => onScrollWheel(event.deltaY)}
+      onWheel={(event) => onScrollBy(event.deltaY)}
+      onTouchStart={(event) => {
+        lastTouchYRef.current = event.touches[0]?.clientY ?? null;
+      }}
+      onTouchMove={(event) => {
+        const touchY = event.touches[0]?.clientY;
+        if (touchY == null || lastTouchYRef.current == null) return;
+        // Finger moving up drags the content down, i.e. a positive delta.
+        onScrollBy(lastTouchYRef.current - touchY);
+        lastTouchYRef.current = touchY;
+      }}
+      onTouchEnd={() => {
+        lastTouchYRef.current = null;
+      }}
       className={cn(
         // copilot-scroll-to-bottom-button (tailwind.css) re-points the
         // interactive background variables at the page background, since

--- a/src/components/chat-components/ScrollToBottomButton.tsx
+++ b/src/components/chat-components/ScrollToBottomButton.tsx
@@ -1,0 +1,32 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { ArrowDown } from "lucide-react";
+import React from "react";
+
+export interface ScrollToBottomButtonProps {
+  /** Invoked when the user asks to jump back to the newest message. */
+  onClick: () => void;
+}
+
+/**
+ * Floating circular affordance that overlays the chat message list when the
+ * user has scrolled away from the newest message. Purely presentational: the
+ * owning list decides visibility and supplies the scroll action.
+ */
+export function ScrollToBottomButton({ onClick }: ScrollToBottomButtonProps) {
+  return (
+    <Button
+      type="button"
+      variant="secondary"
+      size="icon"
+      aria-label="Scroll to latest message"
+      title="Scroll to latest message"
+      onClick={() => onClick()}
+      className={cn(
+        "tw-absolute tw-bottom-2 tw-left-1/2 tw-z-cover -tw-translate-x-1/2 tw-rounded-full tw-border tw-border-solid tw-border-border tw-bg-primary tw-shadow-md hover:tw-bg-interactive-hover"
+      )}
+    >
+      <ArrowDown className="tw-size-4" />
+    </Button>
+  );
+}

--- a/src/components/chat-components/ScrollToBottomButton.tsx
+++ b/src/components/chat-components/ScrollToBottomButton.tsx
@@ -6,14 +6,25 @@ import React from "react";
 export interface ScrollToBottomButtonProps {
   /** Invoked when the user asks to jump back to the newest message. */
   onClick: () => void;
+  /**
+   * Forwards wheel deltas to the message list, so hovering the button never
+   * traps the user's scrolling.
+   */
+  onScrollWheel: (deltaY: number) => void;
+  /** While a response is streaming, the arrow becomes a typing indicator. */
+  isStreaming?: boolean;
 }
 
 /**
  * Floating circular affordance that overlays the chat message list when the
  * user has scrolled away from the newest message. Purely presentational: the
- * owning list decides visibility and supplies the scroll action.
+ * owning list decides visibility and supplies the scroll actions.
  */
-export function ScrollToBottomButton({ onClick }: ScrollToBottomButtonProps) {
+export function ScrollToBottomButton({
+  onClick,
+  onScrollWheel,
+  isStreaming = false,
+}: ScrollToBottomButtonProps) {
   return (
     <Button
       type="button"
@@ -22,11 +33,32 @@ export function ScrollToBottomButton({ onClick }: ScrollToBottomButtonProps) {
       aria-label="Scroll to latest message"
       title="Scroll to latest message"
       onClick={() => onClick()}
+      onWheel={(event) => onScrollWheel(event.deltaY)}
       className={cn(
-        "tw-absolute tw-bottom-2 tw-left-1/2 tw-z-cover -tw-translate-x-1/2 tw-rounded-full tw-border tw-border-solid tw-border-border tw-bg-primary tw-shadow-md hover:tw-bg-interactive-hover"
+        // copilot-scroll-to-bottom-button (tailwind.css) re-points the
+        // interactive background variables at the page background, since
+        // Obsidian's core `button` rule outranks single-class bg utilities.
+        "copilot-scroll-to-bottom-button",
+        "tw-absolute tw-bottom-2 tw-left-1/2 tw-z-cover -tw-translate-x-1/2 tw-rounded-full tw-border tw-border-solid tw-border-border-hover tw-shadow-md"
       )}
     >
-      <ArrowDown className="tw-size-4" />
+      {isStreaming ? (
+        <span className="tw-flex tw-items-center tw-gap-0.5" aria-hidden="true">
+          {[0, 1, 2].map((dotIndex) => (
+            <span
+              key={dotIndex}
+              // eslint-disable-next-line tailwindcss/no-custom-classname -- typing-dot is a component animation class defined in source CSS
+              className={cn(
+                "tw-size-1 tw-rounded-full tw-bg-current",
+                "copilot-typing-dot",
+                dotIndex > 0 && `copilot-typing-dot-${dotIndex}`
+              )}
+            />
+          ))}
+        </span>
+      ) : (
+        <ArrowDown className="tw-size-4" />
+      )}
     </Button>
   );
 }

--- a/src/components/chat-components/ScrollToBottomButton.tsx
+++ b/src/components/chat-components/ScrollToBottomButton.tsx
@@ -29,14 +29,12 @@ export function ScrollToBottomButton({
   onScrollBy,
   isStreaming = false,
 }: ScrollToBottomButtonProps) {
-  // DESIGN NOTE (input forwarding × sibling overlay): the overlay is a DOM
-  // sibling of the scroller, so native scroll chaining never reaches the
-  // list from here — wheel deltas and touch drags are forwarded instead.
-  // Keyboard scrolling while the button is focused is intentionally not
-  // forwarded: reaching that state takes deliberate tabbing, Enter/Space
-  // already trigger the jump, and it is recoverable by tabbing away (P3, no
-  // real caller observed). If a future review flags this again, point them
-  // at this note.
+  // The overlay is a DOM sibling of the scroller, so native scroll chaining
+  // never reaches the list from here — wheel deltas and touch drags are
+  // forwarded instead. Keyboard scrolling while the button holds focus is
+  // deliberately not forwarded: reaching that state takes explicit tabbing,
+  // Enter/Space already perform the jump, and tabbing away restores normal
+  // scrolling.
   // https://github.com/logancyang/obsidian-copilot-preview/issues/329
   const lastTouchYRef = useRef<number | null>(null);
 

--- a/src/hooks/useChatScrolling.test.tsx
+++ b/src/hooks/useChatScrolling.test.tsx
@@ -26,6 +26,11 @@ function createScrollContainer(metrics: ScrollMetrics): HTMLDivElement {
       metrics.scrollTop = options.top;
     }
   }) as never;
+  container.scrollBy = jest.fn((options?: ScrollToOptions | number) => {
+    if (typeof options === "object" && typeof options?.top === "number") {
+      metrics.scrollTop += options.top;
+    }
+  }) as never;
   return container;
 }
 
@@ -41,13 +46,25 @@ describe("useChatScrolling", () => {
     queue.forEach((callback) => callback(0));
   }
 
+  // Maps each observed element to its observer's callback, so tests can fire
+  // resizes for a specific target (container vs content) the way the browser
+  // would.
+  let observedTargets = new Map<Element, ResizeObserverCallback>();
+
+  function fireResizeObserverFor(target: Element) {
+    observedTargets.get(target)?.([], { disconnect: jest.fn() } as unknown as ResizeObserver);
+  }
+
   beforeEach(() => {
-    // jsdom lacks ResizeObserver; the hook only needs observe/disconnect.
-    (window as unknown as { ResizeObserver?: unknown }).ResizeObserver = jest.fn(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
+    // jsdom lacks ResizeObserver; the mock records callbacks for manual firing.
+    observedTargets = new Map();
+    (window as unknown as { ResizeObserver?: unknown }).ResizeObserver = jest.fn(
+      (callback: ResizeObserverCallback) => ({
+        observe: jest.fn((target: Element) => observedTargets.set(target, callback)),
+        unobserve: jest.fn(),
+        disconnect: jest.fn(),
+      })
+    );
     animationFrameQueue = [];
     jest.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
       animationFrameQueue.push(callback);
@@ -62,11 +79,13 @@ describe("useChatScrolling", () => {
 
   function renderAttachedHook(metrics: ScrollMetrics) {
     const container = createScrollContainer(metrics);
+    const content = document.createElement("div");
     const rendered = renderHook(() => useChatScrolling({ chatHistory: [] }));
     act(() => {
       rendered.result.current.scrollContainerCallbackRef(container);
+      rendered.result.current.contentCallbackRef(content);
     });
-    return { container, rendered };
+    return { container, content, rendered };
   }
 
   function dispatchScroll(container: HTMLDivElement) {
@@ -125,17 +144,30 @@ describe("useChatScrolling", () => {
       expect(rendered.result.current.isAtBottom).toBe(false);
     });
 
-    it("refreshes isAtBottom on re-render when streamed content grows without a scroll event (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
+    it("refreshes isAtBottom when the observed content grows without a scroll event, e.g. streaming or image loads (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
       const metrics = { scrollHeight: 1000, clientHeight: 400, scrollTop: 600 };
-      const { rendered } = renderAttachedHook(metrics);
+      const { content, rendered } = renderAttachedHook(metrics);
       expect(rendered.result.current.isAtBottom).toBe(true);
 
       metrics.scrollHeight = 2000;
       act(() => {
-        rendered.rerender();
+        fireResizeObserverFor(content);
       });
 
       expect(rendered.result.current.isAtBottom).toBe(false);
+    });
+
+    it("refreshes isAtBottom when a pane resize changes the viewport height without touching content (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
+      const metrics = { scrollHeight: 1000, clientHeight: 400, scrollTop: 100 };
+      const { container, rendered } = renderAttachedHook(metrics);
+      expect(rendered.result.current.isAtBottom).toBe(false);
+
+      metrics.clientHeight = 950;
+      act(() => {
+        fireResizeObserverFor(container);
+      });
+
+      expect(rendered.result.current.isAtBottom).toBe(true);
     });
 
     it("scrollToBottom scrolls the container to its full scroll height", () => {
@@ -147,6 +179,18 @@ describe("useChatScrolling", () => {
       });
 
       expect(container.scrollTo).toHaveBeenLastCalledWith({ top: 1000, behavior: "smooth" });
+    });
+
+    it("scrollBy moves the container by the forwarded wheel delta without animation", () => {
+      const metrics = { scrollHeight: 1000, clientHeight: 400, scrollTop: 100 };
+      const { container, rendered } = renderAttachedHook(metrics);
+
+      act(() => {
+        rendered.result.current.scrollBy(120);
+      });
+
+      expect(container.scrollBy).toHaveBeenCalledWith({ top: 120, behavior: "instant" });
+      expect(metrics.scrollTop).toBe(220);
     });
   });
 });

--- a/src/hooks/useChatScrolling.test.tsx
+++ b/src/hooks/useChatScrolling.test.tsx
@@ -21,14 +21,18 @@ function createScrollContainer(metrics: ScrollMetrics): HTMLDivElement {
       metrics.scrollTop = value;
     },
   });
+  // Browsers fire a scroll event for programmatic scrolls; the hook's
+  // direction tracking depends on that, so the mock mirrors it.
   container.scrollTo = jest.fn((options?: ScrollToOptions | number) => {
     if (typeof options === "object" && typeof options?.top === "number") {
       metrics.scrollTop = options.top;
+      container.dispatchEvent(new Event("scroll"));
     }
   }) as never;
   container.scrollBy = jest.fn((options?: ScrollToOptions | number) => {
     if (typeof options === "object" && typeof options?.top === "number") {
       metrics.scrollTop += options.top;
+      container.dispatchEvent(new Event("scroll"));
     }
   }) as never;
   return container;
@@ -77,10 +81,14 @@ describe("useChatScrolling", () => {
     delete (window as unknown as { ResizeObserver?: unknown }).ResizeObserver;
   });
 
-  function renderAttachedHook(metrics: ScrollMetrics) {
+  function renderAttachedHook(metrics: ScrollMetrics, { isStreaming = false } = {}) {
     const container = createScrollContainer(metrics);
     const content = document.createElement("div");
-    const rendered = renderHook(() => useChatScrolling({ chatHistory: [] }));
+    const rendered = renderHook(
+      (props: { isStreaming: boolean }) =>
+        useChatScrolling({ chatHistory: [], isStreaming: props.isStreaming }),
+      { initialProps: { isStreaming } }
+    );
     act(() => {
       rendered.result.current.scrollContainerCallbackRef(container);
       rendered.result.current.contentCallbackRef(content);
@@ -96,7 +104,7 @@ describe("useChatScrolling", () => {
   }
 
   describe("useChatScrolling()", () => {
-    it("reports at-bottom while the viewport rests within the threshold of the newest content", () => {
+    it("reports at-bottom while the viewport rests within the threshold of the newest content (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
       const { rendered } = renderAttachedHook({
         scrollHeight: 1000,
         clientHeight: 400,
@@ -116,7 +124,7 @@ describe("useChatScrolling", () => {
       expect(rendered.result.current.isAtBottom).toBe(false);
     });
 
-    it("reports at-bottom again once the user scrolls back to the newest content", () => {
+    it("reports at-bottom again once the user scrolls back to the newest content (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
       const metrics = { scrollHeight: 1000, clientHeight: 400, scrollTop: 100 };
       const { container, rendered } = renderAttachedHook(metrics);
       expect(rendered.result.current.isAtBottom).toBe(false);
@@ -127,7 +135,7 @@ describe("useChatScrolling", () => {
       expect(rendered.result.current.isAtBottom).toBe(true);
     });
 
-    it("keeps tracking across repeated scroll-away and scroll-back cycles", () => {
+    it("keeps tracking across repeated scroll-away and scroll-back cycles (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
       const metrics = { scrollHeight: 1000, clientHeight: 400, scrollTop: 600 };
       const { container, rendered } = renderAttachedHook(metrics);
 
@@ -170,18 +178,73 @@ describe("useChatScrolling", () => {
       expect(rendered.result.current.isAtBottom).toBe(true);
     });
 
-    it("scrollToBottom scrolls the container to its full scroll height", () => {
+    it("jumpToLatest smooth-scrolls the container to its full scroll height (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
       const metrics = { scrollHeight: 1000, clientHeight: 400, scrollTop: 100 };
       const { container, rendered } = renderAttachedHook(metrics);
 
       act(() => {
-        rendered.result.current.scrollToBottom();
+        rendered.result.current.jumpToLatest();
       });
 
       expect(container.scrollTo).toHaveBeenLastCalledWith({ top: 1000, behavior: "smooth" });
     });
 
-    it("scrollBy moves the container by the forwarded wheel delta without animation", () => {
+    it("keeps following a streaming response after jumpToLatest so new content stays in view (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
+      const metrics = { scrollHeight: 1000, clientHeight: 400, scrollTop: 100 };
+      const { container, content, rendered } = renderAttachedHook(metrics, { isStreaming: true });
+
+      act(() => {
+        rendered.result.current.jumpToLatest();
+      });
+
+      metrics.scrollHeight = 1500;
+      act(() => {
+        fireResizeObserverFor(content);
+      });
+
+      expect(container.scrollTo).toHaveBeenLastCalledWith({ top: 1500, behavior: "instant" });
+    });
+
+    it("stops following the moment the user scrolls up during a followed stream (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
+      const metrics = { scrollHeight: 1000, clientHeight: 400, scrollTop: 100 };
+      const { container, content, rendered } = renderAttachedHook(metrics, { isStreaming: true });
+
+      act(() => {
+        rendered.result.current.jumpToLatest();
+      });
+
+      metrics.scrollTop = 200;
+      dispatchScroll(container);
+
+      metrics.scrollHeight = 1500;
+      act(() => {
+        fireResizeObserverFor(content);
+      });
+
+      expect(container.scrollTo).toHaveBeenLastCalledWith({ top: 1000, behavior: "smooth" });
+      expect(metrics.scrollTop).toBe(200);
+    });
+
+    it("ends follow when the stream finishes so the next turn needs a fresh opt-in (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
+      const metrics = { scrollHeight: 1000, clientHeight: 400, scrollTop: 100 };
+      const { container, content, rendered } = renderAttachedHook(metrics, { isStreaming: true });
+
+      act(() => {
+        rendered.result.current.jumpToLatest();
+      });
+      act(() => {
+        rendered.rerender({ isStreaming: false });
+      });
+
+      metrics.scrollHeight = 1500;
+      act(() => {
+        fireResizeObserverFor(content);
+      });
+
+      expect(container.scrollTo).toHaveBeenLastCalledWith({ top: 1000, behavior: "smooth" });
+    });
+
+    it("scrollBy moves the container by the forwarded wheel delta without animation (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
       const metrics = { scrollHeight: 1000, clientHeight: 400, scrollTop: 100 };
       const { container, rendered } = renderAttachedHook(metrics);
 

--- a/src/hooks/useChatScrolling.test.tsx
+++ b/src/hooks/useChatScrolling.test.tsx
@@ -1,0 +1,152 @@
+import { useChatScrolling } from "@/hooks/useChatScrolling";
+import { act, renderHook } from "@testing-library/react";
+
+interface ScrollMetrics {
+  scrollHeight: number;
+  clientHeight: number;
+  scrollTop: number;
+}
+
+/**
+ * Builds a scroll container whose geometry the test controls, since jsdom
+ * performs no layout and reports every metric as zero.
+ */
+function createScrollContainer(metrics: ScrollMetrics): HTMLDivElement {
+  const container = document.createElement("div");
+  Object.defineProperty(container, "scrollHeight", { get: () => metrics.scrollHeight });
+  Object.defineProperty(container, "clientHeight", { get: () => metrics.clientHeight });
+  Object.defineProperty(container, "scrollTop", {
+    get: () => metrics.scrollTop,
+    set: (value: number) => {
+      metrics.scrollTop = value;
+    },
+  });
+  container.scrollTo = jest.fn((options?: ScrollToOptions | number) => {
+    if (typeof options === "object" && typeof options?.top === "number") {
+      metrics.scrollTop = options.top;
+    }
+  }) as never;
+  return container;
+}
+
+describe("useChatScrolling", () => {
+  // Queued rather than run synchronously: the hook records the pending frame
+  // id after requestAnimationFrame returns, so a synchronous mock would clear
+  // the ref before it is set and every later scroll event would be dropped.
+  let animationFrameQueue: FrameRequestCallback[] = [];
+
+  function flushAnimationFrames() {
+    const queue = animationFrameQueue;
+    animationFrameQueue = [];
+    queue.forEach((callback) => callback(0));
+  }
+
+  beforeEach(() => {
+    // jsdom lacks ResizeObserver; the hook only needs observe/disconnect.
+    (window as unknown as { ResizeObserver?: unknown }).ResizeObserver = jest.fn(() => ({
+      observe: jest.fn(),
+      unobserve: jest.fn(),
+      disconnect: jest.fn(),
+    }));
+    animationFrameQueue = [];
+    jest.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      animationFrameQueue.push(callback);
+      return animationFrameQueue.length;
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete (window as unknown as { ResizeObserver?: unknown }).ResizeObserver;
+  });
+
+  function renderAttachedHook(metrics: ScrollMetrics) {
+    const container = createScrollContainer(metrics);
+    const rendered = renderHook(() => useChatScrolling({ chatHistory: [] }));
+    act(() => {
+      rendered.result.current.scrollContainerCallbackRef(container);
+    });
+    return { container, rendered };
+  }
+
+  function dispatchScroll(container: HTMLDivElement) {
+    act(() => {
+      container.dispatchEvent(new Event("scroll"));
+      flushAnimationFrames();
+    });
+  }
+
+  describe("useChatScrolling()", () => {
+    it("reports at-bottom while the viewport rests within the threshold of the newest content", () => {
+      const { rendered } = renderAttachedHook({
+        scrollHeight: 1000,
+        clientHeight: 400,
+        scrollTop: 590,
+      });
+
+      expect(rendered.result.current.isAtBottom).toBe(true);
+    });
+
+    it("flips isAtBottom off after the user scrolls up past the threshold (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
+      const metrics = { scrollHeight: 1000, clientHeight: 400, scrollTop: 600 };
+      const { container, rendered } = renderAttachedHook(metrics);
+
+      metrics.scrollTop = 100;
+      dispatchScroll(container);
+
+      expect(rendered.result.current.isAtBottom).toBe(false);
+    });
+
+    it("reports at-bottom again once the user scrolls back to the newest content", () => {
+      const metrics = { scrollHeight: 1000, clientHeight: 400, scrollTop: 100 };
+      const { container, rendered } = renderAttachedHook(metrics);
+      expect(rendered.result.current.isAtBottom).toBe(false);
+
+      metrics.scrollTop = 600;
+      dispatchScroll(container);
+
+      expect(rendered.result.current.isAtBottom).toBe(true);
+    });
+
+    it("keeps tracking across repeated scroll-away and scroll-back cycles", () => {
+      const metrics = { scrollHeight: 1000, clientHeight: 400, scrollTop: 600 };
+      const { container, rendered } = renderAttachedHook(metrics);
+
+      metrics.scrollTop = 100;
+      dispatchScroll(container);
+      expect(rendered.result.current.isAtBottom).toBe(false);
+
+      metrics.scrollTop = 600;
+      dispatchScroll(container);
+      expect(rendered.result.current.isAtBottom).toBe(true);
+
+      metrics.scrollTop = 50;
+      dispatchScroll(container);
+      expect(rendered.result.current.isAtBottom).toBe(false);
+    });
+
+    it("refreshes isAtBottom on re-render when streamed content grows without a scroll event (https://github.com/logancyang/obsidian-copilot-preview/issues/329)", () => {
+      const metrics = { scrollHeight: 1000, clientHeight: 400, scrollTop: 600 };
+      const { rendered } = renderAttachedHook(metrics);
+      expect(rendered.result.current.isAtBottom).toBe(true);
+
+      metrics.scrollHeight = 2000;
+      act(() => {
+        rendered.rerender();
+      });
+
+      expect(rendered.result.current.isAtBottom).toBe(false);
+    });
+
+    it("scrollToBottom scrolls the container to its full scroll height", () => {
+      const metrics = { scrollHeight: 1000, clientHeight: 400, scrollTop: 100 };
+      const { container, rendered } = renderAttachedHook(metrics);
+
+      act(() => {
+        rendered.result.current.scrollToBottom();
+      });
+
+      expect(container.scrollTo).toHaveBeenLastCalledWith({ top: 1000, behavior: "smooth" });
+    });
+  });
+});

--- a/src/hooks/useChatScrolling.ts
+++ b/src/hooks/useChatScrolling.ts
@@ -4,6 +4,12 @@ import { useCallback, useRef, useState, useEffect } from "react";
 
 interface UseChatScrollingOptions {
   chatHistory: ChatMessage[];
+  /**
+   * True while a response is streaming. `jumpToLatest` only keeps following
+   * new content while this is set, so follow mode can never outlive the turn
+   * that the user opted into.
+   */
+  isStreaming?: boolean;
 }
 
 interface UseChatScrollingReturn {
@@ -19,8 +25,14 @@ interface UseChatScrollingReturn {
   getMessageKey: (message: ChatMessage, index: number) => string;
   /** True while the viewport rests within a small threshold of the newest message. */
   isAtBottom: boolean;
-  /** Scrolls the message list to its end. */
-  scrollToBottom: (behavior?: "smooth" | "instant") => void;
+  /**
+   * Scrolls to the newest message. While a response is streaming, keeps
+   * following new content until the user scrolls up or the turn ends —
+   * follow is strictly opt-in per click, so it never becomes the always-on
+   * auto-follow that upstream declined in
+   * https://github.com/logancyang/obsidian-copilot/issues/829.
+   */
+  jumpToLatest: () => void;
   /**
    * Scrolls the message list by a wheel delta. Lets overlays floating above
    * the list (the scroll-to-bottom button) forward wheel events so hovering
@@ -36,6 +48,7 @@ const AT_BOTTOM_THRESHOLD_PX = 24;
 
 export const useChatScrolling = ({
   chatHistory,
+  isStreaming = false,
 }: UseChatScrollingOptions): UseChatScrollingReturn => {
   const [containerMinHeight, setContainerMinHeight] = useState(0);
   const [isAtBottom, setIsAtBottom] = useState(true);
@@ -45,6 +58,12 @@ export const useChatScrolling = ({
   const contentResizeObserverRef = useRef<ResizeObserver | null>(null);
   const scrollListenerCleanupRef = useRef<(() => void) | null>(null);
   const pendingScrollFrameRef = useRef<{ win: Window; id: number } | null>(null);
+  // Follow mode entered by jumpToLatest during a stream; see the interface
+  // JSDoc. lastScrollTopRef feeds the synchronous upward-scroll detection.
+  const followStreamRef = useRef(false);
+  const lastScrollTopRef = useRef(0);
+  const isStreamingRef = useRef(isStreaming);
+  isStreamingRef.current = isStreaming;
 
   // Generate consistent message key for DOM identification
   // Using message IDs is better, as in the case of a network disconnection, the timestamps of two messages could be identical.
@@ -114,6 +133,24 @@ export const useChatScrolling = ({
     pendingScrollFrameRef.current = { win, id };
   }, [updateIsAtBottom]);
 
+  // Upward-scroll detection must run synchronously in the scroll handler, not
+  // in the coalesced frame: a content resize can re-push to the bottom in the
+  // same frame, and a deferred check would then read downward movement and
+  // keep follow mode alive against the user's intent. Follow-driven scrolls
+  // only ever move down, so a shrinking scrollTop is a reliable user signal
+  // (clamps from content shrink also land here, which fails safe: follow
+  // merely stops).
+  const handleScroll = useCallback(() => {
+    const node = scrollContainerRef.current;
+    if (node) {
+      if (node.scrollTop < lastScrollTopRef.current) {
+        followStreamRef.current = false;
+      }
+      lastScrollTopRef.current = node.scrollTop;
+    }
+    scheduleIsAtBottomCheck();
+  }, [scheduleIsAtBottomCheck]);
+
   const detachScrollTracking = useCallback(() => {
     scrollListenerCleanupRef.current?.();
     scrollListenerCleanupRef.current = null;
@@ -163,13 +200,13 @@ export const useChatScrolling = ({
 
         resizeObserverRef.current = resizeObserver;
 
-        node.addEventListener("scroll", scheduleIsAtBottomCheck, { passive: true });
-        scrollListenerCleanupRef.current = () =>
-          node.removeEventListener("scroll", scheduleIsAtBottomCheck);
+        node.addEventListener("scroll", handleScroll, { passive: true });
+        scrollListenerCleanupRef.current = () => node.removeEventListener("scroll", handleScroll);
+        lastScrollTopRef.current = node.scrollTop;
         updateIsAtBottom();
       }
     },
-    [calculateDynamicMinHeight, detachScrollTracking, scheduleIsAtBottomCheck, updateIsAtBottom]
+    [calculateDynamicMinHeight, detachScrollTracking, handleScroll, updateIsAtBottom]
   );
 
   // Recalculate min-height when chat history changes (new messages)
@@ -179,6 +216,29 @@ export const useChatScrolling = ({
       setContainerMinHeight(newCalculatedMinHeight);
     }
   }, [chatHistory, calculateDynamicMinHeight]);
+
+  // Scroll to bottom function
+  const scrollToBottom = useCallback((behavior: "smooth" | "instant" = "smooth") => {
+    if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollTo({
+        top: scrollContainerRef.current.scrollHeight,
+        behavior,
+      });
+    }
+  }, []);
+
+  const jumpToLatest = useCallback(() => {
+    followStreamRef.current = isStreamingRef.current;
+    scrollToBottom("smooth");
+  }, [scrollToBottom]);
+
+  // A finished turn ends the follow the user opted into; the next stream
+  // requires a fresh click.
+  useEffect(() => {
+    if (!isStreaming) {
+      followStreamRef.current = false;
+    }
+  }, [isStreaming]);
 
   // Content growth (streaming appends, image/diagram loads) changes the
   // content element's height without firing scroll events, so the at-bottom
@@ -199,13 +259,18 @@ export const useChatScrolling = ({
       contentRef.current = node;
       if (node) {
         const observer = new ResizeObserver(() => {
+          // Re-target with "instant": re-starting a smooth animation on every
+          // streamed token would keep resetting and never catch up.
+          if (followStreamRef.current && isStreamingRef.current) {
+            scrollToBottom("instant");
+          }
           updateIsAtBottom();
         });
         observer.observe(node);
         contentResizeObserverRef.current = observer;
       }
     },
-    [updateIsAtBottom]
+    [scrollToBottom, updateIsAtBottom]
   );
 
   // Cleanup ResizeObservers and scroll tracking on unmount
@@ -220,16 +285,6 @@ export const useChatScrolling = ({
       }
     };
   }, [detachScrollTracking]);
-
-  // Scroll to bottom function
-  const scrollToBottom = useCallback((behavior: "smooth" | "instant" = "smooth") => {
-    if (scrollContainerRef.current) {
-      scrollContainerRef.current.scrollTo({
-        top: scrollContainerRef.current.scrollHeight,
-        behavior,
-      });
-    }
-  }, []);
 
   // "instant" bypasses the container's scroll-smooth so wheel steps don't
   // animate-lag behind the user's hand.
@@ -278,7 +333,7 @@ export const useChatScrolling = ({
     contentCallbackRef,
     getMessageKey,
     isAtBottom,
-    scrollToBottom,
+    jumpToLatest,
     scrollBy,
   };
 };

--- a/src/hooks/useChatScrolling.ts
+++ b/src/hooks/useChatScrolling.ts
@@ -139,13 +139,12 @@ export const useChatScrolling = ({
   // same frame, and a deferred check would then read downward movement and
   // keep follow mode alive against the user's intent. Follow-driven scrolls
   // only ever move down, so a shrinking scrollTop is a reliable user signal.
-  // DESIGN NOTE: browser clamps (content shrink, pane growth reducing the max
-  // scroll offset) also land here and clear follow. Evaluated and accepted:
-  // the misfire only stops auto-follow — one extra click recovers it — while
-  // distinguishing true input intent (wheel/touch/pointer tracking) was
-  // rejected as compensating complexity with worse race behavior than this
-  // conservative heuristic. If a future review flags this again, point them
-  // at this note.
+  // Browser clamps (content shrink, or pane growth reducing the max scroll
+  // offset) also shrink scrollTop and so clear follow as well. That misfire
+  // is the cheaper half of the trade: it only stops auto-follow, and one
+  // click on the jump button restores it, whereas telling clamps apart from
+  // real input means tracking wheel/touch/pointer state, whose races are
+  // worse than this conservative heuristic.
   // https://github.com/logancyang/obsidian-copilot-preview/issues/329
   const handleScroll = useCallback(() => {
     const node = scrollContainerRef.current;

--- a/src/hooks/useChatScrolling.ts
+++ b/src/hooks/useChatScrolling.ts
@@ -138,9 +138,14 @@ export const useChatScrolling = ({
   // in the coalesced frame: a content resize can re-push to the bottom in the
   // same frame, and a deferred check would then read downward movement and
   // keep follow mode alive against the user's intent. Follow-driven scrolls
-  // only ever move down, so a shrinking scrollTop is a reliable user signal
-  // (clamps from content shrink also land here, which fails safe: follow
-  // merely stops).
+  // only ever move down, so a shrinking scrollTop is a reliable user signal.
+  // DESIGN NOTE: browser clamps (content shrink, pane growth reducing the max
+  // scroll offset) also land here and clear follow. Evaluated and accepted:
+  // the misfire only stops auto-follow — one extra click recovers it — while
+  // distinguishing true input intent (wheel/touch/pointer tracking) was
+  // rejected as compensating complexity with worse race behavior than this
+  // conservative heuristic. If a future review flags this again, point them
+  // at this note.
   // https://github.com/logancyang/obsidian-copilot-preview/issues/329
   const handleScroll = useCallback(() => {
     const node = scrollContainerRef.current;

--- a/src/hooks/useChatScrolling.ts
+++ b/src/hooks/useChatScrolling.ts
@@ -31,6 +31,7 @@ interface UseChatScrollingReturn {
    * follow is strictly opt-in per click, so it never becomes the always-on
    * auto-follow that upstream declined in
    * https://github.com/logancyang/obsidian-copilot/issues/829.
+   * https://github.com/logancyang/obsidian-copilot-preview/issues/329
    */
   jumpToLatest: () => void;
   /**
@@ -140,6 +141,7 @@ export const useChatScrolling = ({
   // only ever move down, so a shrinking scrollTop is a reliable user signal
   // (clamps from content shrink also land here, which fails safe: follow
   // merely stops).
+  // https://github.com/logancyang/obsidian-copilot-preview/issues/329
   const handleScroll = useCallback(() => {
     const node = scrollContainerRef.current;
     if (node) {
@@ -234,6 +236,7 @@ export const useChatScrolling = ({
 
   // A finished turn ends the follow the user opted into; the next stream
   // requires a fresh click.
+  // https://github.com/logancyang/obsidian-copilot-preview/issues/329
   useEffect(() => {
     if (!isStreaming) {
       followStreamRef.current = false;
@@ -261,6 +264,7 @@ export const useChatScrolling = ({
         const observer = new ResizeObserver(() => {
           // Re-target with "instant": re-starting a smooth animation on every
           // streamed token would keep resetting and never catch up.
+          // https://github.com/logancyang/obsidian-copilot-preview/issues/329
           if (followStreamRef.current && isStreamingRef.current) {
             scrollToBottom("instant");
           }

--- a/src/hooks/useChatScrolling.ts
+++ b/src/hooks/useChatScrolling.ts
@@ -9,11 +9,24 @@ interface UseChatScrollingOptions {
 interface UseChatScrollingReturn {
   containerMinHeight: number;
   scrollContainerCallbackRef: (node: HTMLDivElement | null) => void;
+  /**
+   * Attach to the wrapper around the message content inside the scroll
+   * container. Content growth (streaming, image loads) changes this element's
+   * height without firing scroll events, so the hook observes it to keep
+   * `isAtBottom` truthful.
+   */
+  contentCallbackRef: (node: HTMLDivElement | null) => void;
   getMessageKey: (message: ChatMessage, index: number) => string;
   /** True while the viewport rests within a small threshold of the newest message. */
   isAtBottom: boolean;
   /** Scrolls the message list to its end. */
   scrollToBottom: (behavior?: "smooth" | "instant") => void;
+  /**
+   * Scrolls the message list by a wheel delta. Lets overlays floating above
+   * the list (the scroll-to-bottom button) forward wheel events so hovering
+   * them doesn't trap scrolling.
+   */
+  scrollBy: (deltaY: number) => void;
 }
 
 // Tolerance below which the viewport still counts as "at the bottom", so
@@ -28,6 +41,8 @@ export const useChatScrolling = ({
   const [isAtBottom, setIsAtBottom] = useState(true);
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const contentResizeObserverRef = useRef<ResizeObserver | null>(null);
   const scrollListenerCleanupRef = useRef<(() => void) | null>(null);
   const pendingScrollFrameRef = useRef<{ win: Window; id: number } | null>(null);
 
@@ -138,6 +153,9 @@ export const useChatScrolling = ({
             const newCalculatedMinHeight = calculateDynamicMinHeight();
             setContainerMinHeight(newCalculatedMinHeight);
           }
+          // Pane resizes change clientHeight, which shifts the bottom-distance
+          // math even when the content height is unchanged.
+          updateIsAtBottom();
         });
 
         // Observe the messages container for size changes
@@ -162,21 +180,43 @@ export const useChatScrolling = ({
     }
   }, [chatHistory, calculateDynamicMinHeight]);
 
-  // Streaming appends grow scrollHeight without firing scroll events, so the
-  // at-bottom flag would go stale mid-generation and the scroll-to-bottom
-  // affordance would never appear. Re-check after every render; the setState
-  // inside bails out unless the boolean actually flips.
+  // Content growth (streaming appends, image/diagram loads) changes the
+  // content element's height without firing scroll events, so the at-bottom
+  // flag would go stale mid-generation and the scroll-to-bottom affordance
+  // would never appear. Observing the content wrapper covers both React and
+  // non-React growth; the container's own observer can't see it because a
+  // fixed-height scroller keeps the same border-box while scrollHeight grows.
   // https://github.com/logancyang/obsidian-copilot-preview/issues/329
-  useEffect(() => {
-    updateIsAtBottom();
-  });
+  const contentCallbackRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (node === contentRef.current) {
+        return;
+      }
+      if (contentResizeObserverRef.current) {
+        contentResizeObserverRef.current.disconnect();
+        contentResizeObserverRef.current = null;
+      }
+      contentRef.current = node;
+      if (node) {
+        const observer = new ResizeObserver(() => {
+          updateIsAtBottom();
+        });
+        observer.observe(node);
+        contentResizeObserverRef.current = observer;
+      }
+    },
+    [updateIsAtBottom]
+  );
 
-  // Cleanup ResizeObserver and scroll tracking on unmount
+  // Cleanup ResizeObservers and scroll tracking on unmount
   useEffect(() => {
     return () => {
       detachScrollTracking();
       if (resizeObserverRef.current) {
         resizeObserverRef.current.disconnect();
+      }
+      if (contentResizeObserverRef.current) {
+        contentResizeObserverRef.current.disconnect();
       }
     };
   }, [detachScrollTracking]);
@@ -189,6 +229,12 @@ export const useChatScrolling = ({
         behavior,
       });
     }
+  }, []);
+
+  // "instant" bypasses the container's scroll-smooth so wheel steps don't
+  // animate-lag behind the user's hand.
+  const scrollBy = useCallback((deltaY: number) => {
+    scrollContainerRef.current?.scrollBy({ top: deltaY, behavior: "instant" });
   }, []);
 
   // Scroll to bottom when component mounts (instant to avoid initial animation)
@@ -229,8 +275,10 @@ export const useChatScrolling = ({
   return {
     containerMinHeight,
     scrollContainerCallbackRef,
+    contentCallbackRef,
     getMessageKey,
     isAtBottom,
     scrollToBottom,
+    scrollBy,
   };
 };

--- a/src/hooks/useChatScrolling.ts
+++ b/src/hooks/useChatScrolling.ts
@@ -10,14 +10,26 @@ interface UseChatScrollingReturn {
   containerMinHeight: number;
   scrollContainerCallbackRef: (node: HTMLDivElement | null) => void;
   getMessageKey: (message: ChatMessage, index: number) => string;
+  /** True while the viewport rests within a small threshold of the newest message. */
+  isAtBottom: boolean;
+  /** Scrolls the message list to its end. */
+  scrollToBottom: (behavior?: "smooth" | "instant") => void;
 }
+
+// Tolerance below which the viewport still counts as "at the bottom", so
+// sub-pixel rounding and momentum-scroll overshoot don't flicker the
+// scroll-to-bottom affordance (same threshold as QuickAskPanel's pin logic).
+const AT_BOTTOM_THRESHOLD_PX = 24;
 
 export const useChatScrolling = ({
   chatHistory,
 }: UseChatScrollingOptions): UseChatScrollingReturn => {
   const [containerMinHeight, setContainerMinHeight] = useState(0);
+  const [isAtBottom, setIsAtBottom] = useState(true);
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
+  const scrollListenerCleanupRef = useRef<(() => void) | null>(null);
+  const pendingScrollFrameRef = useRef<{ win: Window; id: number } | null>(null);
 
   // Generate consistent message key for DOM identification
   // Using message IDs is better, as in the case of a network disconnection, the timestamps of two messages could be identical.
@@ -65,6 +77,37 @@ export const useChatScrolling = ({
     return minHeight;
   }, [chatHistory, getMessageKey]);
 
+  // Recompute whether the viewport is resting at the newest message. React
+  // bails out of re-rendering when the boolean hasn't changed.
+  const updateIsAtBottom = useCallback(() => {
+    const node = scrollContainerRef.current;
+    if (!node) return;
+    setIsAtBottom(node.scrollHeight - node.scrollTop - node.clientHeight <= AT_BOTTOM_THRESHOLD_PX);
+  }, []);
+
+  // Coalesce scroll events into one at-bottom check per animation frame.
+  // Obsidian popouts render in their own window, so the frame must come from
+  // the container's owner window, not the main window's scheduler.
+  const scheduleIsAtBottomCheck = useCallback(() => {
+    const node = scrollContainerRef.current;
+    if (!node || pendingScrollFrameRef.current) return;
+    const win = node.win ?? window;
+    const id = win.requestAnimationFrame(() => {
+      pendingScrollFrameRef.current = null;
+      updateIsAtBottom();
+    });
+    pendingScrollFrameRef.current = { win, id };
+  }, [updateIsAtBottom]);
+
+  const detachScrollTracking = useCallback(() => {
+    scrollListenerCleanupRef.current?.();
+    scrollListenerCleanupRef.current = null;
+    if (pendingScrollFrameRef.current) {
+      pendingScrollFrameRef.current.win.cancelAnimationFrame(pendingScrollFrameRef.current.id);
+      pendingScrollFrameRef.current = null;
+    }
+  }, []);
+
   // Memoized callback ref that gets called only when the DOM element actually changes
   const scrollContainerCallbackRef = useCallback(
     (node: HTMLDivElement | null) => {
@@ -78,6 +121,7 @@ export const useChatScrolling = ({
         resizeObserverRef.current.disconnect();
         resizeObserverRef.current = null;
       }
+      detachScrollTracking();
 
       // Update the ref
       scrollContainerRef.current = node;
@@ -100,9 +144,14 @@ export const useChatScrolling = ({
         resizeObserver.observe(node);
 
         resizeObserverRef.current = resizeObserver;
+
+        node.addEventListener("scroll", scheduleIsAtBottomCheck, { passive: true });
+        scrollListenerCleanupRef.current = () =>
+          node.removeEventListener("scroll", scheduleIsAtBottomCheck);
+        updateIsAtBottom();
       }
     },
-    [calculateDynamicMinHeight]
+    [calculateDynamicMinHeight, detachScrollTracking, scheduleIsAtBottomCheck, updateIsAtBottom]
   );
 
   // Recalculate min-height when chat history changes (new messages)
@@ -113,14 +162,24 @@ export const useChatScrolling = ({
     }
   }, [chatHistory, calculateDynamicMinHeight]);
 
-  // Cleanup ResizeObserver on unmount
+  // Streaming appends grow scrollHeight without firing scroll events, so the
+  // at-bottom flag would go stale mid-generation and the scroll-to-bottom
+  // affordance would never appear. Re-check after every render; the setState
+  // inside bails out unless the boolean actually flips.
+  // https://github.com/logancyang/obsidian-copilot-preview/issues/329
+  useEffect(() => {
+    updateIsAtBottom();
+  });
+
+  // Cleanup ResizeObserver and scroll tracking on unmount
   useEffect(() => {
     return () => {
+      detachScrollTracking();
       if (resizeObserverRef.current) {
         resizeObserverRef.current.disconnect();
       }
     };
-  }, []);
+  }, [detachScrollTracking]);
 
   // Scroll to bottom function
   const scrollToBottom = useCallback((behavior: "smooth" | "instant" = "smooth") => {
@@ -171,5 +230,7 @@ export const useChatScrolling = ({
     containerMinHeight,
     scrollContainerCallbackRef,
     getMessageKey,
+    isAtBottom,
+    scrollToBottom,
   };
 };

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1193,3 +1193,44 @@ If your plugin does not need CSS, delete this file.
 .copilot-fade-mask-bottom {
   background: linear-gradient(to top, var(--background-primary), transparent);
 }
+
+/* Obsidian's core `button` rules outrank single-class utilities, so the
+   floating scroll-to-bottom button re-points the background variables at the
+   page background and pins its box to a padding-free square (themes otherwise
+   inject their own button height/padding and squash the circle into an oval).
+   The element-qualified selector matches core/theme specificity; plugin CSS
+   loads later, so it wins the tie without !important. */
+button.copilot-scroll-to-bottom-button {
+  /* Hover keeps the same background on purpose: the affordance is a quiet
+     overlay, not an interactive-state showcase. */
+  --interactive-normal: var(--background-primary);
+  --interactive-hover: var(--background-primary);
+  width: 1.75rem;
+  height: 1.75rem;
+  padding: 0;
+}
+
+/* Typing indicator inside the scroll-to-bottom button: while a response is
+   streaming, three dots bounce in sequence (staggered delays on a shared
+   keyframe produce the wave). */
+.copilot-typing-dot {
+  animation: copilot-typing-bounce 1.2s ease-in-out infinite;
+}
+.copilot-typing-dot-1 {
+  animation-delay: 160ms;
+}
+.copilot-typing-dot-2 {
+  animation-delay: 320ms;
+}
+@keyframes copilot-typing-bounce {
+  0%,
+  60%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.4;
+  }
+  30% {
+    transform: translateY(-2px);
+    opacity: 1;
+  }
+}

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1234,3 +1234,12 @@ button.copilot-scroll-to-bottom-button {
     opacity: 1;
   }
 }
+
+/* Users who ask the OS for reduced motion get static dots instead of the
+   bounce (same convention as the JS matchMedia checks elsewhere in src/). */
+@media (prefers-reduced-motion: reduce) {
+  .copilot-typing-dot {
+    animation: none;
+    opacity: 0.7;
+  }
+}


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#277

## Why

In a long conversation, once you scroll up to reread earlier messages there is no way back to the newest message except dragging the scrollbar or spinning the wheel through the whole history. This bites hardest during generation: the assistant keeps appending content below the viewport, so a user who scrolled up drifts ever further from the tail. Upstream declined always-on auto-follow in logancyang/obsidian-copilot#829 because a constantly shifting view makes text selection hard, which makes an explicit jump-back affordance — the floating down-arrow button Codex, ChatGPT, and Claude all use — the standard complement.

## What

- When the message list is scrolled more than a small threshold away from the bottom, a circular down-arrow button floats at the bottom center of the message area, in both Agent Mode and the legacy chat. It hides while the view rests at the bottom, and never renders when the chat is too short to scroll.
- Clicking it smooth-scrolls to the newest message. Hovering it changes nothing visually, and scroll intent that starts on the button still moves the list underneath: wheel deltas on desktop, drag distance for a touch that begins on the button.
- While a response is streaming, the arrow becomes three bouncing dots; readers who ask their OS for reduced motion get the same three dots without the bounce. Clicking then keeps the view pinned to the incoming content for the rest of that turn.

| Chat state | Button shows | Click does |
| --- | --- | --- |
| Idle, scrolled up | Static arrow | Jump to the newest message |
| Streaming, scrolled up | Bouncing dots | Jump, then follow the stream until you scroll up or the turn ends |
| Stopped mid-turn, partial reply kept | Static arrow | Jump only — the retained text is not a live stream |

> **Before:** clicking mid-stream landed on the bottom as of the click, newly streamed content immediately outran the view, and the button reappeared.
>
> **After:** clicking mid-stream follows the stream until the user scrolls up or the turn ends; the next turn requires a fresh click.

## Non goal

- No always-on stick-to-bottom during streaming: following is strictly per-click opt-in, keeping the behavior upstream declined in logancyang/obsidian-copilot#829 off the table.
- No change to the existing auto-scroll on sending a message or to the min-height spacer that reserves streaming headroom.
- No change to Agent Mode's pending-action rail. The button anchors to the message region above it, so a permission or question card keeps its own space and its controls stay uncovered.
- No keyboard shortcut for jumping to the latest message, and no forwarding of arrow-key or Page-Down scrolling while the button holds focus.

## Screenshot

**Scrolled up in a long chat — the jump-back button over the message list**

![Scroll-to-bottom button in the chat pane](https://github.com/user-attachments/assets/8626445c-ae27-43c2-9d6a-7282a8f21202)

**Streaming — the arrow becomes a typing indicator**

![Streaming typing dots on the button](https://github.com/user-attachments/assets/73055b00-0a51-4e6a-a17a-5503c4808700)

The streaming state is captured in the component gallery rather than the chat pane: reaching it in the product requires a live model response, which needs provider credentials and cannot be held still for a capture. The change is purely additive, so the before state is the same pane with no button present.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | `useChatScrolling.test.tsx` covers at-bottom tracking, follow enter/cancel/expiry, content and viewport resizes, and delta forwarding; `ScrollToBottomButton.test.tsx` covers the arrow, the dots, click, wheel, and touch drag; `ChatMessages.test.tsx` and `AgentChatMessages.test.tsx` cover visibility and the streaming indicator in both chat surfaces |
| A defect would fail CI or be obvious on first use | ✅ | The tests above run in CI; a visual defect shows on the first long chat |
| A revert fully restores prior state, including persisted data | ✅ | UI-only; no settings, schema, or persisted data touched |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Adds wheel and touch handlers on the new button that forward scroll intent to the message list |
| No public API, plugin API, message, or on-disk contract changes | ✅ | `useChatScrolling` is internal with both callers updated in this PR |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Adds a follow-mode state machine plus two ResizeObservers and an rAF-coalesced scroll listener on the chat message path |
| No hot-path behavior lacks deterministic coverage | ✅ | Every state transition is unit-tested; the bounce animation and the reduced-motion variant cannot be covered by an automated test because both are rendered appearance driven by CSS media state |
| No new dependency | ✅ | Dependency manifests unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | A wrong result is visible immediately in the chat pane and confined to the button |

Review: inspect `handleScroll`, `jumpToLatest`, `scrollBy`, the content-observer callback inside `contentCallbackRef`, and `detachScrollTracking` in `src/hooks/useChatScrolling.ts` line by line, then the wheel and touch handlers in `ScrollToBottomButton` in `src/components/chat-components/ScrollToBottomButton.tsx`. Then run Verification steps 3-8 including the adversarial variants: scroll up rapidly while a followed stream is pushing down, resize the pane mid-stream, and click the button repeatedly during one turn.

## Verification

1. Build the branch and load it in a test vault, then open the Copilot chat pane with a conversation longer than one screen.
2. Scroll up half a screen: a circular down-arrow button appears bottom-center. Hover it: the background and size stay put (the label tooltip is expected); wheel-scroll while hovering: the list scrolls normally.
3. Click it: the view smooth-scrolls to the newest message and the button disappears; near the bottom, small scrolls do not flicker it.
4. Send a prompt that produces a long reply. While it streams, scroll up: the button shows three bouncing dots. Click it: the view sticks to the incoming content.
5. During that followed stream, scroll up once: following stops immediately and the dotted button reappears.
6. Start another long reply, scroll up, and press Stop while text is on screen: the button returns to the static arrow, and clicking it jumps without following.
7. Let a reply finish, scroll up, click: the view jumps to the bottom and stays (no follow carry-over).
8. Drag the pane splitter to grow and shrink the chat: the button appears and disappears consistently with whether the newest message is in view.
9. On a touch device or a touch-emulating window, start a drag on the button itself: the list pans with the finger instead of staying frozen.
10. Turn on Reduce Motion in the OS accessibility settings and stream a reply: the three dots render without bouncing.
11. Open a chat with one short message: the button never appears.

## Note

The originating public issue logancyang/obsidian-copilot-preview#329 was migrated to Brevilabs/obsidian-copilot-private#277 and closed as a duplicate, so this PR fixes the private issue. Source comments and test names keep the public `#329` URL because every other provenance link in `src/` points at the public tracker, and a private link would 404 for most readers of this repo.

