### PR TITLE
Show only the effort levels a Copilot Plus model really has

### DIFF
--- a/src/LLMProviders/brevilabsClient.ts
+++ b/src/LLMProviders/brevilabsClient.ts
@@ -195,6 +195,12 @@ export interface BrevilabsModelEntry {
   label?: string;
   /** Input context window as a display string: `1M`, `256K`. */
   context_length?: string;
+  /**
+   * Thinking-effort levels this model distinguishes, ascending. Empty means the model
+   * honors none of them. Absent from services older than the field, which is why the
+   * caller must tell absent apart from empty.
+   */
+  reasoning_efforts?: string[];
 }
 
 export interface BrevilabsModelsResponse {

--- a/src/agentMode/backends/opencode/OpencodeBackend.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.test.ts
@@ -20,6 +20,7 @@ import {
 import type { UserSystemPrompt } from "@/system-prompts/type";
 import {
   buildOpencodeConfig,
+  effortVariantsFor,
   OPENCODE_PROVIDER_MAP,
   OpencodeBackend,
   type OpencodeModelDeps,
@@ -158,6 +159,8 @@ function okEntry(provider: Provider, model: ConfiguredModel): EnabledBackendEntr
 function makeDeps(args: {
   resolved: EnabledBackendEntry[];
   keys?: Record<string, string | null>;
+  /** Published effort levels keyed by wire id; a missing key answers null. */
+  efforts?: Record<string, readonly string[] | null>;
 }): OpencodeModelDeps {
   const keys = args.keys ?? {};
   return {
@@ -171,7 +174,30 @@ function makeDeps(args: {
       url: "http://127.0.0.1:1234/search",
       token: "session-token",
     }),
+    ...(args.efforts
+      ? { getReasoningEfforts: async (id: string) => args.efforts?.[id] ?? null }
+      : {}),
   };
+}
+
+/** The Copilot Plus provider row `CopilotPlusSetupApi` seeds. */
+function makePlusProvider(): Provider {
+  return makeProvider(
+    "p-plus",
+    { kind: "copilot-plus" },
+    {
+      providerType: "openai-compatible",
+      displayName: "Copilot Plus",
+      baseUrl: "https://models.brevilabs.com/v1",
+    }
+  );
+}
+
+/** A Copilot Plus reasoning model, as `COPILOT_PLUS_MODELS` snapshots it. */
+function makePlusReasoningModel(wireId: string): ConfiguredModel {
+  const model = makeModel("p-plus", wireId);
+  model.info.reasoning = true;
+  return model;
 }
 
 const NO_MODELS_DEPS = makeDeps({ resolved: [] });
@@ -655,6 +681,89 @@ describe("buildOpencodeConfig — provider/model injection", () => {
       "X-Client-Version": "4.0.0-preview-260802",
     });
     expect(cp.models).toEqual({ "copilot-plus-flash": {} });
+  });
+
+  it("declares the effort levels Copilot Plus published, and disables the rest (https://github.com/logancyang/obsidian-copilot/issues/2917)", async () => {
+    // Left to itself opencode infers the menu from the model id — a fixed
+    // low/medium/high plus its own per-model special cases — which offers levels that
+    // are synonyms of one another and misses levels the model has. The disables are
+    // what removes an inferred level, since config variants merge over the guess.
+    const model = makePlusReasoningModel("copilot-plus-flash");
+    const deps = makeDeps({
+      resolved: [okEntry(makePlusProvider(), model)],
+      keys: { "p-plus": "plus-token-123" },
+      efforts: { "copilot-plus-flash": ["high", "max"] },
+    });
+
+    const cfg = (await buildOpencodeConfig(getSettings(), deps)) as {
+      provider: Record<string, { models?: Record<string, Record<string, unknown>> }>;
+    };
+
+    expect(cfg.provider["copilot-plus"].models?.["copilot-plus-flash"]).toEqual({
+      reasoning: true,
+      variants: {
+        high: { reasoningEffort: "high" },
+        max: { reasoningEffort: "max" },
+        none: { disabled: true },
+        minimal: { disabled: true },
+        low: { disabled: true },
+        medium: { disabled: true },
+        xhigh: { disabled: true },
+      },
+    });
+  });
+
+  it("offers no effort control for a Copilot Plus model that honors no level (https://github.com/logancyang/obsidian-copilot/issues/2917)", async () => {
+    // opencode builds the menu only for models it is told reason, so withholding the
+    // flag is what makes the control disappear. A menu whose every entry does nothing
+    // is worse than no menu.
+    const deps = makeDeps({
+      resolved: [okEntry(makePlusProvider(), makePlusReasoningModel("honors-no-level"))],
+      keys: { "p-plus": "plus-token-123" },
+      efforts: { "honors-no-level": [] },
+    });
+
+    const cfg = (await buildOpencodeConfig(getSettings(), deps)) as {
+      provider: Record<string, { models?: Record<string, Record<string, unknown>> }>;
+    };
+
+    expect(cfg.provider["copilot-plus"].models?.["honors-no-level"]).toEqual({});
+  });
+
+  it("keeps the inferred menu when the published levels cannot be read", async () => {
+    // A service too old to publish them, or one transient outage. Either way an
+    // imperfect menu beats dropping a control that works.
+    const deps = makeDeps({
+      resolved: [okEntry(makePlusProvider(), makePlusReasoningModel("copilot-plus-flash"))],
+      keys: { "p-plus": "plus-token-123" },
+      efforts: { "copilot-plus-flash": null },
+    });
+
+    const cfg = (await buildOpencodeConfig(getSettings(), deps)) as {
+      provider: Record<string, { models?: Record<string, Record<string, unknown>> }>;
+    };
+
+    expect(cfg.provider["copilot-plus"].models?.["copilot-plus-flash"]).toEqual({
+      reasoning: true,
+    });
+  });
+
+  it("never declares effort levels for a BYOK model, which has none published", async () => {
+    const provider = makeProvider("p-anthropic", { kind: "byok", catalogProviderId: "anthropic" });
+    const model = makeModel("p-anthropic", "copilot-plus-flash");
+    model.info.reasoning = true;
+    const getReasoningEfforts = jest.fn(async () => ["none", "low"]);
+    const deps = {
+      ...makeDeps({ resolved: [okEntry(provider, model)], keys: { "p-anthropic": "anth-123" } }),
+      getReasoningEfforts,
+    };
+
+    const cfg = (await buildOpencodeConfig(getSettings(), deps)) as {
+      provider: Record<string, { models?: Record<string, Record<string, unknown>> }>;
+    };
+
+    expect(cfg.provider.anthropic.models?.["copilot-plus-flash"]).toEqual({ reasoning: true });
+    expect(getReasoningEfforts).not.toHaveBeenCalled();
   });
 
   it("skips Copilot Plus when its provisioned relay token is unavailable (https://github.com/logancyang/obsidian-copilot/issues/2895)", async () => {
@@ -1225,6 +1334,41 @@ describe("OpencodeBackend.buildSpawnDescriptor", () => {
 // `COPILOT_PROMPT_BASE` and the full `buildAgentSystemPrompt` composition are
 // unit-tested in `backends/shared/agentSystemPrompt.test.ts`. The opencode tests
 // above only assert that the composed prompt reaches `cfg.agent.<id>.prompt`.
+
+describe("effortVariantsFor()", () => {
+  it("declares each published level and disables every level that was not published", () => {
+    expect(effortVariantsFor(["high", "max"])).toEqual({
+      high: { reasoningEffort: "high" },
+      max: { reasoningEffort: "max" },
+      none: { disabled: true },
+      minimal: { disabled: true },
+      low: { disabled: true },
+      medium: { disabled: true },
+      xhigh: { disabled: true },
+    });
+  });
+
+  it("disables thinking-off, which the service rejects rather than publishes", () => {
+    // An inferred menu that still offered it would invite the user to pick a level that
+    // fails the whole turn. https://github.com/logancyang/obsidian-copilot/issues/2915
+    expect(effortVariantsFor(["high", "max"]).none).toEqual({ disabled: true });
+  });
+
+  it("declares a published level the plugin does not know about", () => {
+    // The published list is the service's to extend; a client that dropped an
+    // unrecognized level would hide a level the model really has until it shipped again.
+    expect(effortVariantsFor(["ultra"])).toMatchObject({
+      ultra: { reasoningEffort: "ultra" },
+      high: { disabled: true },
+    });
+  });
+
+  it("disables every level when nothing was published", () => {
+    expect(Object.values(effortVariantsFor([]))).toEqual(
+      Array.from({ length: 7 }, () => ({ disabled: true }))
+    );
+  });
+});
 
 describe("OPENCODE_PROVIDER_MAP", () => {
   it("maps the BYOK provider ids plus Copilot Plus to opencode provider ids", () => {

--- a/src/agentMode/backends/opencode/OpencodeBackend.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.test.ts
@@ -29,6 +29,7 @@ import {
   buildAgentSystemPrompt,
   COPILOT_PROMPT_BASE,
 } from "@/agentMode/backends/shared/agentSystemPrompt";
+import { CopilotPlusUsageReader } from "@/agentMode/backends/shared/copilotPlusUsage";
 import {
   MIYO_SEARCH_FOLDER_ENV,
   MIYO_SEARCH_SCOPE_ENV,
@@ -730,7 +731,7 @@ describe("buildOpencodeConfig — provider/model injection", () => {
     expect(cfg.provider["copilot-plus"].models?.["honors-no-level"]).toEqual({});
   });
 
-  it("keeps the inferred menu when the published levels cannot be read", async () => {
+  it("keeps the inferred menu when the published levels cannot be read (https://github.com/logancyang/obsidian-copilot/issues/2917)", async () => {
     // A service too old to publish them, or one transient outage. Either way an
     // imperfect menu beats dropping a control that works.
     const deps = makeDeps({
@@ -1309,6 +1310,43 @@ describe("OpencodeBackend.buildSpawnDescriptor", () => {
     expect(cfg.agent.build.permission).toBeUndefined();
     expect(cfg.agent["copilot-build"].permission).toEqual({ bash: "ask", edit: "ask" });
     expect(logWarn).not.toHaveBeenCalled();
+  });
+
+  it("skips building the generated config when an override replaces it (https://github.com/logancyang/obsidian-copilot/issues/2917)", async () => {
+    // The override wins wholesale, so building a config would only spend a Copilot Plus
+    // catalog read on JSON that is thrown away — and an unreachable models host makes
+    // that read wait out its deadline before every spawn.
+    updateSetting("agentMode", {
+      byok: {},
+      activeBackend: "opencode",
+      debugFullFrames: false,
+      welcomeDismissed: false,
+      skills: { folder: "copilot/skills" },
+      backends: {
+        opencode: {
+          binaryPath: "/path/to/opencode",
+          envOverrides: { OPENCODE_CONFIG_CONTENT: '{"model":"custom"}' },
+        },
+      },
+    });
+    const readReasoningEfforts = jest.spyOn(
+      CopilotPlusUsageReader.prototype,
+      "readReasoningEfforts"
+    );
+    const resolveEnabled = jest.fn(() => [
+      okEntry(makePlusProvider(), makePlusReasoningModel("copilot-plus-flash")),
+    ]);
+    const backend = new OpencodeBackend({
+      ...makeDeps({ resolved: [], keys: { "p-plus": "plus-token-123" } }),
+      backendConfigRegistry: { resolveEnabled } as unknown as BackendConfigRegistry,
+    });
+
+    const desc = await backend.buildSpawnDescriptor({ vaultBasePath: "/vault/abs" });
+
+    expect(desc.env.OPENCODE_CONFIG_CONTENT).toBe('{"model":"custom"}');
+    expect(resolveEnabled).not.toHaveBeenCalled();
+    expect(readReasoningEfforts).not.toHaveBeenCalled();
+    readReasoningEfforts.mockRestore();
   });
 
   it("does not warn about the override when no cacheRoot is resolved", async () => {

--- a/src/agentMode/backends/opencode/OpencodeBackend.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.ts
@@ -74,6 +74,13 @@ export interface OpencodeModelDeps {
   getCacheRoot?: () => string | undefined;
   /** Starts or reuses the owning plugin lifecycle's provider-credential-free channel. */
   getSelfHostWebSearchChannel?: () => Promise<Readonly<SelfHostWebSearchAgentChannel>>;
+  /**
+   * Resolves the thinking-effort levels the Copilot Plus service publishes for a bare
+   * Plus model id, or null when they cannot be read. Injected so the config builder
+   * never reaches for the catalog itself. When omitted, no model gets a declared level
+   * set and opencode falls back to inferring one, which is the behavior this replaces.
+   */
+  getReasoningEfforts?: (modelId: string) => Promise<readonly string[] | null>;
 }
 
 /**
@@ -141,7 +148,14 @@ export class OpencodeBackend implements AcpBackend {
     // whitespace-only resolver result is treated as "unavailable" explicitly
     // rather than leaning on downstream truthiness.
     const cacheRoot = normalizeCacheRoot(this.#deps.getCacheRoot?.());
-    const config = await buildOpencodeConfig(settings, this.#deps, cacheRoot);
+    const config = await buildOpencodeConfig(
+      settings,
+      {
+        ...this.#deps,
+        getReasoningEfforts: (modelId) => this.#copilotPlus.readReasoningEfforts(modelId),
+      },
+      cacheRoot
+    );
     const envOverrides = sanitizeBuiltinSkillEnvOverrides(
       settings.agentMode?.backends?.opencode?.envOverrides
     );
@@ -246,6 +260,40 @@ function denyNativeWebTools(permission: unknown): Record<string, unknown> {
         ? (permission as Record<string, unknown>)
         : {};
   return { ...permissionRecord, websearch: "deny", webfetch: "deny" };
+}
+
+/**
+ * Every effort level an agent might put in a menu for one of our models. Used only to
+ * name the ones the service did not publish, so each can be switched off explicitly.
+ *
+ * `none` is in the list precisely because the service never publishes it and rejects it
+ * outright: left in an inferred menu it would be a level the user is invited to pick
+ * that fails the whole turn. https://github.com/logancyang/obsidian-copilot/issues/2915
+ */
+const ALL_EFFORT_LEVELS = ["none", "minimal", "low", "medium", "high", "xhigh", "max"];
+
+/**
+ * opencode `variants` declaring exactly the effort levels a model really has.
+ *
+ * opencode builds an effort menu for any model it is told reasons, and with no catalog
+ * entry for Copilot Plus it infers the levels from the model id — a fixed low/medium/high
+ * plus whatever its per-model special cases add. The result is wrong in both directions:
+ * it offers levels that are synonyms of each other and misses levels the model has.
+ * Config variants merge over the inferred ones and any marked `disabled` are dropped, so
+ * publishing the real set plus a disable for every other level replaces the guess
+ * outright. https://github.com/logancyang/obsidian-copilot/issues/2917
+ *
+ * @param levels - The levels the service published for this model, ascending.
+ */
+export function effortVariantsFor(
+  levels: readonly string[]
+): Record<string, Record<string, unknown>> {
+  const variants: Record<string, Record<string, unknown>> = {};
+  for (const level of levels) variants[level] = { reasoningEffort: level };
+  for (const level of ALL_EFFORT_LEVELS) {
+    if (!variants[level]) variants[level] = { disabled: true };
+  }
+  return variants;
 }
 
 /** Mutable opencode provider config entry built into `OPENCODE_CONFIG_CONTENT`. */
@@ -365,7 +413,23 @@ export async function buildOpencodeConfig(
     // for the model. opencode has no catalog entry for Copilot Plus / self-hosted
     // OpenAI-compatible providers, so without this it defaults to non-reasoning and
     // the effort picker shows "na". Mirrors the modalities injection above.
-    if (info.reasoning) modelConfig.reasoning = true;
+    if (info.reasoning) {
+      // Copilot Plus publishes the levels each of its models really has; a BYOK model
+      // has no such list and keeps opencode's own inference. Null means the catalog
+      // could not be read, which must not be mistaken for "no levels" — dropping a
+      // working control over a transient outage is worse than an imperfect menu.
+      const published =
+        origin.kind === "copilot-plus"
+          ? ((await deps.getReasoningEfforts?.(info.id)) ?? null)
+          : null;
+      // A model that honors no level gets no control at all: opencode builds the menu
+      // only for models it is told reason, so leaving `reasoning` unset is how the
+      // menu disappears rather than showing entries that do nothing.
+      if (published === null || published.length > 0) {
+        modelConfig.reasoning = true;
+        if (published) modelConfig.variants = effortVariantsFor(published);
+      }
+    }
     providerConfig.models[info.id] = modelConfig;
     injected.push(`${mapping.id}/${info.id}`);
   }

--- a/src/agentMode/backends/opencode/OpencodeBackend.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.ts
@@ -149,20 +149,27 @@ export class OpencodeBackend implements AcpBackend {
     // whitespace-only resolver result is treated as "unavailable" explicitly
     // rather than leaning on downstream truthiness.
     const cacheRoot = normalizeCacheRoot(this.#deps.getCacheRoot?.());
-    const config = await buildOpencodeConfig(
-      settings,
-      {
-        ...this.#deps,
-        getReasoningEfforts: (modelId) => this.#copilotPlus.readReasoningEfforts(modelId),
-      },
-      cacheRoot
-    );
     const envOverrides = sanitizeBuiltinSkillEnvOverrides(
       settings.agentMode?.backends?.opencode?.envOverrides
     );
     const configOverride = envOverrides.OPENCODE_CONFIG_CONTENT;
     delete envOverrides.OPENCODE_CONFIG_CONTENT;
-    let configContent = configOverride ?? JSON.stringify(config);
+    // Resolve the override before building anything: it replaces the generated config
+    // wholesale, so building one spends a Copilot Plus catalog read on JSON that is then
+    // thrown away — and an unreachable models host makes that read wait out its deadline
+    // before every spawn. https://github.com/logancyang/obsidian-copilot/issues/2917
+    let configContent =
+      configOverride ??
+      JSON.stringify(
+        await buildOpencodeConfig(
+          settings,
+          {
+            ...this.#deps,
+            getReasoningEfforts: (modelId) => this.#copilotPlus.readReasoningEfforts(modelId),
+          },
+          cacheRoot
+        )
+      );
     if (settings.enableSelfHostMode === true && configOverride !== undefined) {
       // An explicit config override must not reopen agent-native web tools while
       // Self-Host mode promises that queries stay on the configured route.
@@ -414,6 +421,7 @@ export async function buildOpencodeConfig(
       // has no such list and keeps opencode's own inference. Null means the catalog
       // could not be read, which must not be mistaken for "no levels" — dropping a
       // working control over a transient outage is worse than an imperfect menu.
+      // https://github.com/logancyang/obsidian-copilot/issues/2917
       const published =
         origin.kind === "copilot-plus"
           ? ((await deps.getReasoningEfforts?.(info.id)) ?? null)

--- a/src/agentMode/backends/opencode/OpencodeBackend.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.ts
@@ -6,6 +6,7 @@ import { providerNeedsResolvedApiKey } from "@/modelManagement";
 import { isCatalogProviderDefaultEndpoint } from "@/utils/providerBaseUrl";
 import type { BackendConfigRegistry, ProviderRegistry } from "@/modelManagement";
 import { AcpBackend, AcpSpawnDescriptor } from "@/agentMode/acp/types";
+import { EFFORT_LEVELS_ASCENDING } from "@/agentMode/session/types";
 import type { CopilotMode } from "@/agentMode/session/types";
 import { composeDenyList, getManagedSkills, SkillManager } from "@/agentMode/skills";
 import { buildAgentSystemPrompt } from "@/agentMode/backends/shared/agentSystemPrompt";
@@ -263,16 +264,6 @@ function denyNativeWebTools(permission: unknown): Record<string, unknown> {
 }
 
 /**
- * Every effort level an agent might put in a menu for one of our models. Used only to
- * name the ones the service did not publish, so each can be switched off explicitly.
- *
- * `none` is in the list precisely because the service never publishes it and rejects it
- * outright: left in an inferred menu it would be a level the user is invited to pick
- * that fails the whole turn. https://github.com/logancyang/obsidian-copilot/issues/2915
- */
-const ALL_EFFORT_LEVELS = ["none", "minimal", "low", "medium", "high", "xhigh", "max"];
-
-/**
  * opencode `variants` declaring exactly the effort levels a model really has.
  *
  * opencode builds an effort menu for any model it is told reasons, and with no catalog
@@ -290,7 +281,12 @@ export function effortVariantsFor(
 ): Record<string, Record<string, unknown>> {
   const variants: Record<string, Record<string, unknown>> = {};
   for (const level of levels) variants[level] = { reasoningEffort: level };
-  for (const level of ALL_EFFORT_LEVELS) {
+  // Completeness is the whole contract here: a level missing from the canonical
+  // vocabulary cannot be disabled, so it survives into opencode's menu for a model the
+  // service never advertised it for, and picking a level the service rejects fails the
+  // turn with a raw error payload instead of answering.
+  // https://github.com/logancyang/obsidian-copilot/issues/2915
+  for (const level of EFFORT_LEVELS_ASCENDING) {
     if (!variants[level]) variants[level] = { disabled: true };
   }
   return variants;

--- a/src/agentMode/backends/opencode/descriptor.test.ts
+++ b/src/agentMode/backends/opencode/descriptor.test.ts
@@ -10,6 +10,7 @@ import type {
   BackendState,
   EffortOption,
   EnabledModelEntry,
+  ModelEntry,
   ModelState,
 } from "@/agentMode/session/types";
 import type { CopilotSettings } from "@/settings/model";
@@ -175,6 +176,16 @@ describe("descriptor", () => {
     });
 
     describe("applySelection()", () => {
+      /** Catalog entry for the model a test activates, carrying the levels it offers. */
+      function entryOffering(baseModelId: string, efforts: string[]): ModelEntry {
+        return {
+          baseModelId,
+          name: baseModelId,
+          provider: null,
+          effortOptions: efforts.map((effort) => ({ value: effort, label: effort })),
+        };
+      }
+
       function makeSession(state: BackendState): {
         session: AgentSession;
         applyModelWireId: jest.Mock;
@@ -213,7 +224,7 @@ describe("descriptor", () => {
         const { session, applyModelWireId, setConfigOption } = makeSession({
           model: {
             current: { baseModelId: "openai/gpt-5", effort: "low" },
-            availableModels: [],
+            availableModels: [entryOffering("openai/gpt-5", ["low", "high"])],
             apply: { kind: "setConfigOption", configId: "model", effortConfigId: "effort" },
           },
           mode: null,
@@ -230,7 +241,7 @@ describe("descriptor", () => {
         const { session, applyModelWireId, setConfigOption } = makeSession({
           model: {
             current: { baseModelId: "anthropic/claude-sonnet", effort: "low" },
-            availableModels: [],
+            availableModels: [entryOffering("openai/gpt-5", ["low", "high"])],
             apply: { kind: "setConfigOption", configId: "model", effortConfigId: "effort" },
           },
           mode: null,
@@ -250,7 +261,7 @@ describe("descriptor", () => {
         const { session, applyModelWireId, setConfigOption } = makeSession({
           model: {
             current: { baseModelId: "openai/gpt-5", effort: "high" },
-            availableModels: [],
+            availableModels: [entryOffering("openai/gpt-5", ["low", "high"])],
             apply: { kind: "setConfigOption", configId: "model", effortConfigId: "effort" },
           },
           mode: null,
@@ -264,6 +275,25 @@ describe("descriptor", () => {
 
         expect(applyModelWireId).toHaveBeenCalledWith("openai/gpt-5");
         expect(setConfigOption).toHaveBeenCalledWith("effort", "high");
+      });
+
+      it("leaves the model on its native effort when the saved level is no longer offered (https://github.com/logancyang/obsidian-copilot/issues/2917)", async () => {
+        const { session, applyModelWireId, setConfigOption } = makeSession({
+          model: {
+            current: { baseModelId: "anthropic/claude-sonnet", effort: null },
+            availableModels: [entryOffering("openai/gpt-5", ["low", "high"])],
+            apply: { kind: "setConfigOption", configId: "model", effortConfigId: "effort" },
+          },
+          mode: null,
+        });
+
+        await OpencodeBackendDescriptor.applySelection(session, {
+          baseModelId: "openai/gpt-5",
+          effort: "medium",
+        });
+
+        expect(applyModelWireId).toHaveBeenCalledWith("openai/gpt-5");
+        expect(setConfigOption).not.toHaveBeenCalled();
       });
     });
 

--- a/src/agentMode/backends/opencode/descriptor.ts
+++ b/src/agentMode/backends/opencode/descriptor.ts
@@ -35,6 +35,7 @@ import type {
   SessionId,
 } from "@/agentMode/session/types";
 import type { BackendDescriptor, BackendProcess, InstallState } from "@/agentMode/session/types";
+import { EFFORT_LEVELS_ASCENDING } from "@/agentMode/session/types";
 
 /** Config option id OpenCode uses to switch the active agent at runtime. */
 const OPENCODE_MODE_CONFIG_OPTION_ID = "mode";
@@ -53,15 +54,7 @@ let managerRef: OpencodeBinaryManager | null = null;
  * the model name (e.g. `openrouter/anthropic/claude-3.5-haiku` — the
  * last segment `claude-3.5-haiku` is the model, not an effort).
  */
-const KNOWN_OPENCODE_EFFORTS = new Set([
-  "none",
-  "minimal",
-  "low",
-  "medium",
-  "high",
-  "xhigh",
-  "max",
-]);
+const KNOWN_OPENCODE_EFFORTS = new Set(EFFORT_LEVELS_ASCENDING);
 
 /**
  * Wire-format codec for Opencode. Native providers emit

--- a/src/agentMode/backends/opencode/descriptor.ts
+++ b/src/agentMode/backends/opencode/descriptor.ts
@@ -36,6 +36,7 @@ import type {
 } from "@/agentMode/session/types";
 import type { BackendDescriptor, BackendProcess, InstallState } from "@/agentMode/session/types";
 import { EFFORT_LEVELS_ASCENDING } from "@/agentMode/session/types";
+import { findModelEntry } from "@/agentMode/session/translateBackendState";
 
 /** Config option id OpenCode uses to switch the active agent at runtime. */
 const OPENCODE_MODE_CONFIG_OPTION_ID = "mode";
@@ -196,10 +197,17 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
         );
       }
       if (selection.effort !== null) {
-        const refreshedApply = session.getState()?.model?.apply;
+        const refreshed = session.getState()?.model;
+        const refreshedApply = refreshed?.apply;
         const effortConfigId =
           refreshedApply?.kind === "setConfigOption" ? refreshedApply.effortConfigId : undefined;
-        if (effortConfigId) {
+        // Only write a level the now-active model actually offers. A saved default can
+        // name a level the model has since stopped publishing, and the failed write
+        // takes the whole seeded selection down with it — the session reverts to the
+        // model it had before, not just to the default effort.
+        // https://github.com/logancyang/obsidian-copilot/issues/2917
+        const offered = findModelEntry(refreshed, selection.baseModelId)?.effortOptions;
+        if (effortConfigId && offered?.some((option) => option.value === selection.effort)) {
           await session.setConfigOption(effortConfigId, selection.effort);
         }
       }

--- a/src/agentMode/backends/shared/copilotPlusUsage.test.ts
+++ b/src/agentMode/backends/shared/copilotPlusUsage.test.ts
@@ -212,9 +212,9 @@ describe("copilotPlusUsage", () => {
       // the caller cannot act on has to read the same as the field being absent.
       mockGetModels.mockResolvedValue({
         data: [
-          { id: "garbage-levels", reasoning_efforts: [7, "", null] },
+          { id: "garbage-levels", reasoning_efforts: [7, "", null, "  "] },
           { id: "wrong-type", reasoning_efforts: "high" },
-          { id: "partly-usable", reasoning_efforts: ["high", 7] },
+          { id: "partly-usable", reasoning_efforts: [" high ", 7] },
         ],
       });
       const reader = new CopilotPlusUsageReader();
@@ -247,6 +247,28 @@ describe("copilotPlusUsage", () => {
         jest.advanceTimersByTime(3_000);
 
         await expect(pending).resolves.toBeNull();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it("retries the catalog after a read times out instead of reusing the dead request (https://github.com/logancyang/obsidian-copilot/issues/2917)", async () => {
+      // Keeping the timed-out request as the shared one would make every later read wait
+      // out the same dead connection, so the menu would stay guessed even once the host
+      // came back.
+      jest.useFakeTimers();
+      try {
+        mockGetModels
+          .mockReturnValueOnce(new Promise(() => {}))
+          .mockResolvedValue({ data: [{ id: "gpt-5", reasoning_efforts: ["low", "high"] }] });
+        const reader = new CopilotPlusUsageReader();
+
+        const timedOut = reader.readReasoningEfforts("gpt-5");
+        jest.advanceTimersByTime(3_000);
+        await expect(timedOut).resolves.toBeNull();
+
+        await expect(reader.readReasoningEfforts("gpt-5")).resolves.toEqual(["low", "high"]);
+        expect(mockGetModels).toHaveBeenCalledTimes(2);
       } finally {
         jest.useRealTimers();
       }

--- a/src/agentMode/backends/shared/copilotPlusUsage.test.ts
+++ b/src/agentMode/backends/shared/copilotPlusUsage.test.ts
@@ -166,6 +166,92 @@ describe("copilotPlusUsage", () => {
       expect(mockGetModels).toHaveBeenCalledTimes(1);
     });
 
+    it("answers the effort levels a model publishes, from the same catalog fetch", async () => {
+      mockGetModels.mockResolvedValue({
+        data: [
+          {
+            id: "reasons-three-ways",
+            context_length: "1M",
+            reasoning_efforts: ["none", "low", "max"],
+          },
+          { id: "honors-no-level", context_length: "1M", reasoning_efforts: [] },
+        ],
+      });
+      const reader = new CopilotPlusUsageReader();
+
+      await expect(reader.readReasoningEfforts("reasons-three-ways")).resolves.toEqual([
+        "none",
+        "low",
+        "max",
+      ]);
+      await expect(reader.readContextWindow("reasons-three-ways")).resolves.toBe(1_048_576);
+      expect(mockGetModels).toHaveBeenCalledTimes(1);
+    });
+
+    it("tells a model that honors no level apart from one that published none", async () => {
+      // An empty list means the model has no effort to vary and its caller should offer
+      // no control; an absent field means an older service that cannot say, where the
+      // caller must keep whatever menu it already had.
+      // https://github.com/logancyang/obsidian-copilot/issues/2917
+      mockGetModels.mockResolvedValue({
+        data: [
+          { id: "honors-no-level", reasoning_efforts: [] },
+          { id: "service-too-old", context_length: "1M" },
+        ],
+      });
+      const reader = new CopilotPlusUsageReader();
+
+      await expect(reader.readReasoningEfforts("honors-no-level")).resolves.toEqual([]);
+      await expect(reader.readReasoningEfforts("service-too-old")).resolves.toBeNull();
+      await expect(reader.readReasoningEfforts("not-in-catalog")).resolves.toBeNull();
+    });
+
+    it("treats an unusable effort list as unknown rather than as no levels", async () => {
+      // "No levels" removes the effort control. Doing that because the field arrived
+      // malformed would delete a working menu on the strength of garbage, so anything
+      // the caller cannot act on has to read the same as the field being absent.
+      mockGetModels.mockResolvedValue({
+        data: [
+          { id: "garbage-levels", reasoning_efforts: [7, "", null] },
+          { id: "wrong-type", reasoning_efforts: "high" },
+          { id: "partly-usable", reasoning_efforts: ["high", 7] },
+        ],
+      });
+      const reader = new CopilotPlusUsageReader();
+
+      await expect(reader.readReasoningEfforts("garbage-levels")).resolves.toBeNull();
+      await expect(reader.readReasoningEfforts("wrong-type")).resolves.toBeNull();
+      await expect(reader.readReasoningEfforts("partly-usable")).resolves.toEqual(["high"]);
+    });
+
+    it("answers null for effort levels when the catalog cannot be read", async () => {
+      // Not "no levels": dropping a working effort control over one transient outage is
+      // worse than leaving the menu as it was.
+      mockGetModels.mockResolvedValue(null);
+
+      await expect(
+        new CopilotPlusUsageReader().readReasoningEfforts("any-model")
+      ).resolves.toBeNull();
+    });
+
+    it("gives up on a catalog read that never answers, so the agent still starts", async () => {
+      // The opencode spawn path waits on this read and the HTTP layer enforces no
+      // timeout, so an unreachable host would otherwise hold up starting the agent.
+      // https://github.com/logancyang/obsidian-copilot/issues/2917
+      jest.useFakeTimers();
+      try {
+        mockGetModels.mockReturnValue(new Promise(() => {}));
+        const reader = new CopilotPlusUsageReader();
+
+        const pending = reader.readReasoningEfforts("never-answers");
+        jest.advanceTimersByTime(3_000);
+
+        await expect(pending).resolves.toBeNull();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
     it("retries after a failed catalog fetch instead of caching the failure (https://github.com/logancyang/obsidian-copilot-preview/issues/193)", async () => {
       // One transient outage at the wrong moment must not strand the context ring on a
       // bare token count for the rest of the session.

--- a/src/agentMode/backends/shared/copilotPlusUsage.ts
+++ b/src/agentMode/backends/shared/copilotPlusUsage.ts
@@ -125,9 +125,10 @@ function withDeadline<T>(promise: Promise<T | null>, ms: number): Promise<T | nu
 function parseReasoningEfforts(raw: unknown): readonly string[] | null {
   if (!Array.isArray(raw)) return null;
   if (raw.length === 0) return NO_REASONING_EFFORTS;
-  const levels = raw.filter(
-    (level): level is string => typeof level === "string" && level.length > 0
-  );
+  const levels = raw
+    .filter((level): level is string => typeof level === "string")
+    .map((level) => level.trim())
+    .filter((level) => level.length > 0);
   // A list that arrived with entries but none usable is a malformed answer, not a model
   // that honors no level. Reading it as the latter would delete a working effort menu on
   // the strength of garbage.
@@ -185,10 +186,17 @@ export class CopilotPlusUsageReader {
   private async loadCatalog(): Promise<Map<string, CatalogEntry> | null> {
     if (this.catalog) return this.catalog;
     // Share one request between concurrent callers, but do not remember a failed one.
-    this.inFlight ??= this.fetchCatalog().finally(() => {
-      this.inFlight = null;
-    });
-    const catalog = await withDeadline(this.inFlight, CATALOG_TIMEOUT_MS);
+    // The deadline belongs to the shared promise rather than to each await: a request
+    // that never settles would otherwise stay the shared one forever, so every later
+    // read would wait out the same dead connection and never retry once the host came
+    // back. The identity check keeps a timed-out request from clearing its successor.
+    const pending: Promise<Map<string, CatalogEntry> | null> = (this.inFlight ??= withDeadline(
+      this.fetchCatalog(),
+      CATALOG_TIMEOUT_MS
+    ).finally(() => {
+      if (this.inFlight === pending) this.inFlight = null;
+    }));
+    const catalog = await pending;
     if (catalog) this.catalog = catalog;
     return catalog;
   }

--- a/src/agentMode/backends/shared/copilotPlusUsage.ts
+++ b/src/agentMode/backends/shared/copilotPlusUsage.ts
@@ -78,8 +78,64 @@ export function parseContextLength(display: unknown): number | null {
   return Math.round(value * multiplier);
 }
 
+/** What the published catalog says about one Copilot Plus model. */
+interface CatalogEntry {
+  /** Input context window in tokens, or null when the endpoint published none. */
+  contextWindow: number | null;
+  /**
+   * Thinking-effort levels this model distinguishes, or null when the endpoint did
+   * not publish any — an older service the caller must not read a menu into.
+   */
+  reasoningEfforts: readonly string[] | null;
+}
+
+/** A model that honors no effort level at all, shared so "empty" stays one value. */
+const NO_REASONING_EFFORTS: readonly string[] = Object.freeze([]);
+
 /**
- * Reads Copilot Plus caps and model context windows on behalf of whichever backend is
+ * Upper bound on one catalog read.
+ *
+ * The opencode spawn path waits on this to learn a model's effort levels, and
+ * `requestUrl` enforces no timeout of its own, so an unreachable host would otherwise
+ * hold up starting the agent for as long as the OS takes to give up on the connection.
+ * Giving up early costs an accurate effort menu for that session; not giving up costs
+ * the agent.
+ */
+const CATALOG_TIMEOUT_MS = 3_000;
+
+/** Resolve with null if `promise` has not settled within `ms`. */
+function withDeadline<T>(promise: Promise<T | null>, ms: number): Promise<T | null> {
+  return new Promise((resolve) => {
+    const timer = window.setTimeout(() => resolve(null), ms);
+    const settle = (value: T | null) => {
+      window.clearTimeout(timer);
+      resolve(value);
+    };
+    promise.then(settle, () => settle(null));
+  });
+}
+
+/**
+ * Levels a published list may contain, or null when the field is missing or unusable.
+ *
+ * An empty list is a real answer — the model honors no level and its caller should
+ * offer no control — so it is kept distinct from the absent case. Anything the caller
+ * cannot act on collapses into the absent case rather than into the empty one.
+ */
+function parseReasoningEfforts(raw: unknown): readonly string[] | null {
+  if (!Array.isArray(raw)) return null;
+  if (raw.length === 0) return NO_REASONING_EFFORTS;
+  const levels = raw.filter(
+    (level): level is string => typeof level === "string" && level.length > 0
+  );
+  // A list that arrived with entries but none usable is a malformed answer, not a model
+  // that honors no level. Reading it as the latter would delete a working effort menu on
+  // the strength of garbage.
+  return levels.length > 0 ? Object.freeze(levels) : null;
+}
+
+/**
+ * Reads Copilot Plus caps and per-model capabilities on behalf of whichever backend is
  * serving those models, caching the published catalog for that backend's lifetime.
  *
  * The catalog changes when we publish a new model list, not while a vault is open, so it
@@ -88,8 +144,8 @@ export function parseContextLength(display: unknown): number | null {
  * (https://github.com/logancyang/obsidian-copilot-preview/issues/193).
  */
 export class CopilotPlusUsageReader {
-  private contextWindows: Map<string, number> | null = null;
-  private inFlight: Promise<Map<string, number> | null> | null = null;
+  private catalog: Map<string, CatalogEntry> | null = null;
+  private inFlight: Promise<Map<string, CatalogEntry> | null> | null = null;
 
   /** The account's cap utilization as the models host currently reports it. */
   async readPlanUsage(): Promise<PlanUsageReading> {
@@ -106,31 +162,51 @@ export class CopilotPlusUsageReader {
   async readContextWindow(modelId: string | null): Promise<number | null> {
     if (!modelId) return null;
     const catalog = await this.loadCatalog();
-    return catalog?.get(modelId) ?? null;
+    return catalog?.get(modelId)?.contextWindow ?? null;
   }
 
-  private async loadCatalog(): Promise<Map<string, number> | null> {
-    if (this.contextWindows) return this.contextWindows;
+  /**
+   * Thinking-effort levels a Copilot Plus model distinguishes, as the service publishes
+   * them, or null when they cannot be read.
+   *
+   * The caller must not treat null as "no levels": an agent harness left without a
+   * published list falls back to guessing the menu from the model id, and dropping the
+   * control instead would remove a working one over a transient outage.
+   *
+   * @param modelId - Bare Copilot Plus model id, with any backend-specific wire prefix
+   *   already stripped by the caller. Null for a model this account does not serve.
+   */
+  async readReasoningEfforts(modelId: string | null): Promise<readonly string[] | null> {
+    if (!modelId) return null;
+    const catalog = await this.loadCatalog();
+    return catalog?.get(modelId)?.reasoningEfforts ?? null;
+  }
+
+  private async loadCatalog(): Promise<Map<string, CatalogEntry> | null> {
+    if (this.catalog) return this.catalog;
     // Share one request between concurrent callers, but do not remember a failed one.
     this.inFlight ??= this.fetchCatalog().finally(() => {
       this.inFlight = null;
     });
-    const catalog = await this.inFlight;
-    if (catalog) this.contextWindows = catalog;
+    const catalog = await withDeadline(this.inFlight, CATALOG_TIMEOUT_MS);
+    if (catalog) this.catalog = catalog;
     return catalog;
   }
 
-  private async fetchCatalog(): Promise<Map<string, number> | null> {
+  private async fetchCatalog(): Promise<Map<string, CatalogEntry> | null> {
     const response = await BrevilabsClient.getInstance().getModels();
     if (!response?.data) {
       logInfo("[AgentMode] Copilot Plus catalog unavailable; context ring will retry");
       return null;
     }
-    const windows = new Map<string, number>();
+    const catalog = new Map<string, CatalogEntry>();
     for (const entry of response.data) {
-      const tokens = parseContextLength(entry?.context_length);
-      if (entry?.id && tokens !== null) windows.set(entry.id, tokens);
+      if (!entry?.id) continue;
+      catalog.set(entry.id, {
+        contextWindow: parseContextLength(entry.context_length),
+        reasoningEfforts: parseReasoningEfforts(entry.reasoning_efforts),
+      });
     }
-    return windows;
+    return catalog;
   }
 }

--- a/src/agentMode/session/translateBackendState.test.ts
+++ b/src/agentMode/session/translateBackendState.test.ts
@@ -204,6 +204,102 @@ describe("translateBackendState — model catalog from config option (opencode �
   });
 });
 
+describe("translateBackendState — effort option ordering", () => {
+  it("reorders a config-option menu the agent reported high-before-none into ascending order (https://github.com/logancyang/obsidian-copilot/issues/2917)", () => {
+    const modelOpt = selectOption(
+      "model",
+      [{ value: "copilot-plus/deepseek-v4-pro" }],
+      undefined,
+      "model"
+    );
+    const effortOpt = selectOption(
+      "effort",
+      [{ value: "high" }, { value: "none" }],
+      "high",
+      "thought_level"
+    );
+    const state = translateBackendState(
+      { models: null, modes: null, configOptions: [modelOpt, effortOpt] },
+      suffixDescriptor()
+    );
+    expect(state.model?.availableModels[0]?.effortOptions).toEqual([
+      { value: "none", label: "none" },
+      { value: "high", label: "high" },
+    ]);
+  });
+
+  it("orders a full menu by thinking level rather than by the agent's reported order", () => {
+    const modelOpt = selectOption("model", [{ value: "p/m" }], undefined, "model");
+    const effortOpt = selectOption(
+      "effort",
+      [
+        { value: "max" },
+        { value: "low" },
+        { value: "xhigh" },
+        { value: "none" },
+        { value: "high" },
+        { value: "minimal" },
+        { value: "medium" },
+      ],
+      "low",
+      "thought_level"
+    );
+    const state = translateBackendState(
+      { models: null, modes: null, configOptions: [modelOpt, effortOpt] },
+      suffixDescriptor()
+    );
+    expect(state.model?.availableModels[0]?.effortOptions.map((o) => o.value)).toEqual([
+      "none",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+    ]);
+  });
+
+  it("orders suffix-style variants ascending and keeps the bare default first", () => {
+    const models: RawModelState = {
+      currentModelId: "p/m",
+      availableModels: [
+        { modelId: "p/m/high", name: "p/m/high" },
+        { modelId: "p/m", name: "p/m" },
+        { modelId: "p/m/none", name: "p/m/none" },
+      ],
+    };
+    const state = translateBackendState(
+      { models, modes: null, configOptions: null },
+      suffixDescriptor()
+    );
+    expect(findModelEntry(state.model, "p/m")?.effortOptions).toEqual([
+      { value: null, label: "default" },
+      { value: "none", label: "none" },
+      { value: "high", label: "high" },
+    ]);
+  });
+
+  it("keeps levels outside the canonical vocabulary in the agent's order, after the ranked ones", () => {
+    const modelOpt = selectOption("model", [{ value: "p/m" }], undefined, "model");
+    const effortOpt = selectOption(
+      "effort",
+      [{ value: "turbo" }, { value: "high" }, { value: "ludicrous" }, { value: "none" }],
+      "high",
+      "thought_level"
+    );
+    const state = translateBackendState(
+      { models: null, modes: null, configOptions: [modelOpt, effortOpt] },
+      suffixDescriptor()
+    );
+    expect(state.model?.availableModels[0]?.effortOptions.map((o) => o.value)).toEqual([
+      "none",
+      "high",
+      "turbo",
+      "ludicrous",
+    ]);
+  });
+});
+
 describe("translateBackendState — name normalization + description", () => {
   it("passes the backend-reported description through when the backend opts in", () => {
     const models: RawModelState = {

--- a/src/agentMode/session/translateBackendState.ts
+++ b/src/agentMode/session/translateBackendState.ts
@@ -16,6 +16,7 @@ import type {
   ModelSelection,
   ModelState,
 } from "@/agentMode/session/types";
+import { EFFORT_LEVELS_ASCENDING } from "@/agentMode/session/types";
 
 const CANONICAL_ORDER: CopilotMode[] = ["default", "plan", "auto"];
 const CANONICAL_LABELS: Record<CopilotMode, string> = {
@@ -237,7 +238,7 @@ function deriveEffortOptions(
       if (v.effort === null) continue;
       options.push({ value: v.effort, label: v.effort.toLowerCase() });
     }
-    return options;
+    return sortEffortOptions(options);
   }
   // Descriptor-style: ask the codec for a per-model effort option.
   if (descriptor.wire.effortConfigFor) {
@@ -257,7 +258,35 @@ function optionsFromConfigOption(opt: BackendConfigOption | null): EffortOption[
       flat.push({ value: entry.value, name: entry.name });
     }
   }
-  return flat.map((o) => ({ value: o.value, label: (o.name || o.value).toLowerCase() }));
+  return sortEffortOptions(
+    flat.map((o) => ({ value: o.value, label: (o.name || o.value).toLowerCase() }))
+  );
+}
+
+/**
+ * Rank of one effort level, least thinking first. The bare/"default" variant leads, and a
+ * level outside the canonical vocabulary trails every ranked one.
+ */
+function effortRank(value: string | null): number {
+  if (value === null) return -1;
+  const rank = EFFORT_LEVELS_ASCENDING.indexOf(value);
+  return rank === -1 ? Number.MAX_SAFE_INTEGER : rank;
+}
+
+/**
+ * Order a reported effort menu least-thinking-first.
+ *
+ * The order an agent reports is its own business, and at least one ranks a declared
+ * variant set by rules of its own — opencode hands back `high` before `none` for a
+ * Copilot Plus model, which would draw a slider that turns thinking *off* as the user
+ * drags it up, and only for the models that publish an off switch.
+ * https://github.com/logancyang/obsidian-copilot/issues/2917
+ *
+ * Levels we cannot rank keep the agent's relative order at the end, since its ordering is
+ * the only signal left for them; the sort is stable, so that fallback holds.
+ */
+function sortEffortOptions(options: EffortOption[]): EffortOption[] {
+  return [...options].sort((a, b) => effortRank(a.value) - effortRank(b.value));
 }
 
 /**

--- a/src/agentMode/session/types.ts
+++ b/src/agentMode/session/types.ts
@@ -98,6 +98,26 @@ export interface EffortOption {
 }
 
 /**
+ * Every thinking-effort level our backends speak, ascending — least thinking first.
+ *
+ * Canonical in two directions. It ranks a reported menu so the picker's slider always
+ * runs the same way, and it is the vocabulary a backend checks a level against, so an
+ * agent-reported string that is not in here is one we cannot place. Agents report their
+ * levels in whatever order they please, and one that ranks them by its own rules will
+ * hand back a menu that runs backwards.
+ * https://github.com/logancyang/obsidian-copilot/issues/2917
+ */
+export const EFFORT_LEVELS_ASCENDING: readonly string[] = [
+  "none",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+];
+
+/**
  * One entry in the picker's deduped catalog. One entry per base model id;
  * suffix-style variants (codex/opencode) collapse into one entry whose
  * `effortOptions` enumerates the variants.


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot#2917

## Why

In v4 agent chat with the opencode agent, picking how hard a Copilot Plus model
should think gives you a menu that was never built from what that model can do.
Copilot tells the agent only that a model supports reasoning. It never says which
levels that model has, so the agent falls back to inferring them from the model's
name: a fixed `Low / Medium / High` for every model, plus an extra entry when the
name happens to match a pattern it recognises.

Names are not capabilities, so the menu is wrong in both directions, and which
way it is wrong depends on what a model is called rather than on what it does. On
some models two of the entries do the same thing, so the user picks between
`Medium` and `High` and gets an identical reply either way. On others the hardest
setting the model has is simply absent, so the top of the menu is not the top of
the model. And some models grade nothing at all, yet still show three entries,
none of which change the reply.

## What

Copilot now declares each model's real level set to the agent, so the menu lists
exactly those levels. The levels come from the Copilot Plus service, which
publishes them per model, rather than from anything hardcoded here, so a model
whose levels change later needs no plugin release.

| What the service publishes | Effort menu before | Effort menu after |
| --- | --- | --- |
| A list of levels | Low / Medium / High, plus a name-matched extra | Exactly the published levels, in order |
| An empty list | Low / Medium / High, none of which do anything | No effort control at all |
| Nothing (older service, or the read fails) | Low / Medium / High, plus a name-matched extra | Unchanged from before |

An empty list is a real answer and is kept distinct from no answer. A model that
honors no level should offer no control, whereas a model whose levels we could
not read should keep the menu it already had, because dropping a working control
after one failed network read is worse than an imperfect menu. A list that arrives
malformed is treated as no answer for the same reason.

This also puts one network read on the path that starts the agent, so that read
is now bounded. The HTTP layer enforces no timeout of its own, and an unreachable
host would otherwise hold up starting the agent for as long as the operating
system takes to give up on the connection.

## Non goal

- Not changing the effort levels offered for models on a user's own API key, or
  for the Claude and Codex agents. Those keep the agent's own inference.
- Not adding a thinking-off option. The service neither publishes nor accepts
  one, and this PR disables it wherever the agent's own inference offers it.
- Not forking or patching the agent. Declaring per-model variants is its
  supported configuration surface.
- Not changing legacy (non-agent) chat's effort selector.
- Not hardcoding any model's levels in the plugin.

## Screenshot

The changed menu cannot be rendered from this branch yet, and the blocker is
specific and checkable: the levels come from a `reasoning_efforts` field the
Copilot Plus service does not publish yet. Every entry `GET
https://models.brevilabs.com/v1/models` returns still lacks that field, so on
this branch against production the read finds nothing and the menu is identical
to `master` by design. That is the third row of the table above, and it is the
only row reachable today. Rendering the first two rows needs a build pointed at a
service that publishes the field, which is a different branch than this one.

The reviewable evidence that does exist is the exact config handed to the agent
for each case, asserted in
`src/agentMode/backends/opencode/OpencodeBackend.test.ts`:

| Published | Declared to the agent |
| --- | --- |
| `["high", "max"]` | those two as effort variants, with `none`, `minimal`, `low`, `medium` and `xhigh` explicitly disabled |
| `[]` | the model is not declared as reasoning, so the agent builds no effort menu |
| nothing | `reasoning: true` alone, exactly as before this PR |

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | `OpencodeBackend.test.ts` covers all three published cases and the BYOK path; `copilotPlusUsage.test.ts` covers empty, absent, malformed, unreadable and timed-out reads |
| A defect would fail CI or be obvious on first use | ✅ | Both suites run in CI, and a wrong menu is visible the moment the effort picker is opened |
| A revert fully restores prior state, including persisted data | ✅ | Nothing is persisted: the agent config is regenerated on every spawn |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Parses a new field off the models-catalog response, including its malformed forms |
| No public API, plugin API, message, or on-disk contract changes | ✅ | `variants` is the agent's own documented per-model config key; no Copilot API, settings schema, or persisted format changes |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Agent spawn now awaits a network read before building the config. It is cached after the first call and bounded at 3s, falling back to today's behavior |
| No hot-path behavior lacks deterministic coverage | ✅ | The timeout, the failed read and each published shape are all covered by tests |
| No new dependency | ✅ | `package.json` is unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Confined to the opencode effort picker |

Review: inspect `effortVariantsFor` and the `if (info.reasoning)` block inside
`buildOpencodeConfig` in
`src/agentMode/backends/opencode/OpencodeBackend.ts`, then `withDeadline`,
`parseReasoningEfforts` and `loadCatalog` in
`src/agentMode/backends/shared/copilotPlusUsage.ts`. The load-bearing questions
are whether a failed or slow catalog read can block or degrade agent startup, and
whether any input shape can be mistaken for "this model honors no level" and
silently delete a working menu. Verification steps 3 to 5 are the adversarial
variants for both.

## Verification

1. With Copilot Plus signed in, open v4 agent chat on the opencode backend and
   open the thinking-effort picker for a Copilot Plus model. The menu is
   unchanged from `master`, because the service field is not deployed yet. Send a
   turn and confirm the agent starts and replies normally.
2. Switch to a model on your own API key and open its effort picker. It is
   unchanged, since only Copilot Plus models take declared levels.
3. Go offline, or block `models.brevilabs.com` in your hosts file, then start a
   new agent session. The agent still starts, within a couple of seconds rather
   than hanging, and the effort picker still shows its usual entries.
4. Come back online and start another session. The picker still works, so one
   failed read is not remembered for the rest of the session.
5. Sign out of Copilot Plus and start a session with a BYOK model only. The agent
   starts and no effort lookup happens.

