### PR TITLE
Write the BYOK migration group-key separator as an escape sequence

### DIFF
--- a/src/settings/migrations/byokMigration.ts
+++ b/src/settings/migrations/byokMigration.ts
@@ -253,7 +253,7 @@ export function planByokMigration(settings: CopilotSettings): SetupProviderInput
       normalizeUrl(baseUrl),
       apiKey ?? "",
       enableCors ? "cors" : "stream",
-    ].join(" ");
+    ].join("\u0000");
 
     let group = groups.get(groupKey);
     if (!group) {


### PR DESCRIPTION
Fixes Brevilabs/obsidian-copilot-private#299

## Why

`planByokMigration` groups legacy models into providers using a composite key, and it joins
the parts with a character that cannot appear in any of them. That choice is right. The
separator was written as a literal NUL byte typed straight into the string literal, rather
than as an escape sequence.

A single NUL anywhere in a file is enough for `file(1)` to classify it as `data`, and every
tool with binary detection then skips it and says nothing on stdout. So on `master`, a
recursive search of `src/` for `executeByokMigration` finds the import and call site in
`src/settings/migrations/index.ts` and six references in the test file, but never the
definition in the module that exports it. Anyone reading this code sees the function used
everywhere and cannot find where it comes from.

Git never flagged it because its binary heuristic sniffs only the first 8000 bytes and this
byte sits at 10062 of 13690. Diffs and GitHub review rendered normally the whole time, which
is why it survived review in the first place.

## What

No runtime behavior changes. The escape sequence and the raw byte are the same character, so
the group key is byte for byte what it was.

> **Before:** `grep -rn "executeByokMigration" src` returns the import, the call site, and the
> test references, but not `byokMigration.ts:310` where the function is defined.
>
> **After:** the same search returns the definition too.

`file(1)` goes from reporting `data` to reporting a text type, and the module becomes
greppable by ripgrep, ugrep, and `grep -I`.

## Non goal

- Revising the group-key scheme. Provider type, catalog id, normalized URL, API key and CORS
  choice all stay exactly as they are, including the separate-provider-per-CORS-choice
  behavior.
- Preventing recurrence with tooling. A lint or CI check that rejects control characters in
  tracked source is worth having and is tracked separately.
- Auditing non-source assets. `images/*.png` and `images/ui.jpg` contain NUL bytes because
  they are genuine binaries.

## Screenshot

Not applicable. This change has no user-visible surface: it alters how one character is
spelled in source, and the migration it belongs to behaves identically. The reviewable
evidence is the `file(1)` and `grep` results in Verification.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | `\u0000` and the raw byte are the same character, so the group key is unchanged; `byokMigration.test.ts` covers the grouping, including the CORS case that depends on the separator |
| A defect would fail CI or be obvious on first use | ✅ | Those grouping tests run in CI |
| A revert fully restores prior state, including persisted data | ✅ | Nothing is migrated or written; the revert is the same single character |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | The API key flows into the key exactly as before; no handling changed |
| No public API, plugin API, message, or on-disk contract changes | ✅ | `groupKey` is only a local `Map` key at lines 258 and 276, and line 283 returns `groups.values()`, discarding the keys |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | `planByokMigration` is pure and synchronous |
| No hot-path behavior lacks deterministic coverage | ✅ | The grouping path is covered by existing tests, unmodified by this PR |
| No new dependency | ✅ | `package.json` and `package-lock.json` are untouched |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | There is no human-only behavior; nothing changes at runtime |

Review: run Verification steps 2 and 3. They show the defect and the fix directly, and CI
covers the grouping behavior.

## Verification

1. Check out this branch. No plugin build or test vault is needed.
2. Run `file src/settings/migrations/byokMigration.ts`. It reports a text type. On `master`
   the same command reports `data`.
3. Run `grep -rn "executeByokMigration" src`. The results include
   `src/settings/migrations/byokMigration.ts:310`, the definition. On `master` that line is
   missing from the results with no warning.
4. Optional, to confirm the migration is untouched: `npm test -- src/settings/migrations/byokMigration.test.ts`.
