### PR TITLE
feat(providers): add OrcaRouter as a named chat provider

### DIFF
--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -89,6 +89,24 @@ and turn on **Enable CORS**. Responses then appear after completion instead of
 streaming token by token. For LM Studio, you can enable CORS in LM Studio to
 keep streaming instead.
 
+### OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) is a smart-routing model gateway with an
+OpenAI-compatible endpoint. Add it as a provider under **Settings → Copilot →
+BYOK → Add a provider** — it appears as **OrcaRouter** in the provider list with
+its base URL pre-filled:
+
+- Base URL: `https://api.orcarouter.ai/v1`
+- API key: `sk-orca-...` from your OrcaRouter account
+
+Select one or more gateway models. The `orcarouter/auto` model routes each
+request to the best available upstream model; `orcarouter/fusion`,
+`orcarouter/fusion-flash`, and `orcarouter/fusion-mini` pin a specific
+long-context family. Copilot discovers the full model list from
+`/v1/models`. It also runs gateway-level, zero-trust security for AI agents on
+the same endpoint — screening every prompt/response and governing every tool
+call on a default-deny basis, with no application code changes.
+
 ## Claude Code and Codex Accounts
 
 Claude and Codex are Agent backends, not BYOK providers:

--- a/src/LLMProviders/chatModelManager.orcarouter.test.ts
+++ b/src/LLMProviders/chatModelManager.orcarouter.test.ts
@@ -1,0 +1,119 @@
+import type { CustomModel } from "@/aiParams";
+import { ChatModelProviders, ModelCapability, ProviderInfo } from "@/constants";
+import { MissingApiKeyError } from "@/error";
+import { getSettings, setSettings } from "@/settings/model";
+
+import ChatModelManager from "./chatModelManager";
+
+// Capture constructor configs so tests can assert what the manager actually
+// hands the LangChain `ChatOpenAI` client for the OrcaRouter provider.
+jest.mock("@langchain/openai", () => {
+  class ChatOpenAI {
+    static configs: unknown[] = [];
+    constructor(config: unknown) {
+      ChatOpenAI.configs.push(config);
+    }
+  }
+  return { ChatOpenAI };
+});
+// The manager imports every LangChain provider constructor at module load;
+// mock the rest so the module graph loads without resolving real classes.
+jest.mock("@langchain/anthropic", () => {
+  return { ChatAnthropic: class {} };
+});
+jest.mock("@langchain/deepseek", () => {
+  return { ChatDeepSeek: class {} };
+});
+jest.mock("@langchain/groq", () => {
+  return { ChatGroq: class {} };
+});
+jest.mock("@langchain/google-genai", () => {
+  return { ChatGoogleGenerativeAI: class {} };
+});
+jest.mock("@langchain/ollama", () => {
+  return { ChatOllama: class {} };
+});
+jest.mock("@langchain/xai", () => {
+  return { ChatXAI: class {} };
+});
+jest.mock("./ChatOpenRouter", () => {
+  return { ChatOpenRouter: class {} };
+});
+jest.mock("./ChatLMStudio", () => {
+  return { ChatLMStudio: class {} };
+});
+
+function orcaRouterModel(overrides: Partial<CustomModel> = {}): CustomModel {
+  return {
+    name: "orcarouter/auto",
+    provider: ChatModelProviders.ORCAROUTER,
+    enabled: true,
+    ...overrides,
+  };
+}
+
+describe("chatModelManager", () => {
+  describe("ChatModelManager", () => {
+    const originalKey = getSettings().orcarouterApiKey;
+
+    afterEach(() => {
+      setSettings({ orcarouterApiKey: originalKey });
+      // Clear captured constructor configs between cases.
+      (jest.requireMock("@langchain/openai").ChatOpenAI as { configs: unknown[] }).configs = [];
+    });
+
+    describe("OrcaRouter provider", () => {
+      it("routes OrcaRouter models through ChatOpenAI with the OrcaRouter base URL", async () => {
+        await ChatModelManager.getInstance().createModelInstanceFromBridged(
+          orcaRouterModel({ apiKey: "sk-orca-test" })
+        );
+
+        const OpenAI = jest.requireMock("@langchain/openai").ChatOpenAI as {
+          configs: Array<{ modelName: string; configuration?: { baseURL?: string } }>;
+        };
+        const config = OpenAI.configs[OpenAI.configs.length - 1];
+        expect(config.modelName).toBe("orcarouter/auto");
+        expect(config.configuration?.baseURL).toBe(
+          ProviderInfo[ChatModelProviders.ORCAROUTER].host
+        );
+      });
+
+      it("uses the default OrcaRouter base URL when the model has no custom baseUrl", async () => {
+        await ChatModelManager.getInstance().createModelInstanceFromBridged(
+          orcaRouterModel({ apiKey: "sk-orca-test" })
+        );
+
+        const OpenAI = jest.requireMock("@langchain/openai").ChatOpenAI as {
+          configs: Array<{ configuration?: { baseURL?: string } }>;
+        };
+        const config = OpenAI.configs[OpenAI.configs.length - 1];
+        expect(config.configuration?.baseURL).toBe("https://api.orcarouter.ai/v1");
+      });
+
+      it("honors a per-model custom baseUrl override", async () => {
+        await ChatModelManager.getInstance().createModelInstanceFromBridged(
+          orcaRouterModel({ apiKey: "sk-orca-test", baseUrl: "https://proxy.example.com/v1" })
+        );
+
+        const OpenAI = jest.requireMock("@langchain/openai").ChatOpenAI as {
+          configs: Array<{ configuration?: { baseURL?: string } }>;
+        };
+        const config = OpenAI.configs[OpenAI.configs.length - 1];
+        expect(config.configuration?.baseURL).toBe("https://proxy.example.com/v1");
+      });
+
+      it("throws MissingApiKeyError when the model carries no OrcaRouter key", async () => {
+        await expect(
+          ChatModelManager.getInstance().createModelInstanceFromBridged(orcaRouterModel())
+        ).rejects.toBeInstanceOf(MissingApiKeyError);
+      });
+
+      it("resolves capability flags for the built-in reasoning-capable auto model", () => {
+        const model = orcaRouterModel({
+          capabilities: [ModelCapability.REASONING],
+        });
+        expect(model.capabilities).toContain(ModelCapability.REASONING);
+      });
+    });
+  });
+});

--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -75,6 +75,7 @@ const CHAT_PROVIDER_CONSTRUCTORS = {
   [ChatModelProviders.COPILOT_PLUS]: ChatOpenRouter,
   [ChatModelProviders.MISTRAL]: ChatOpenAI,
   [ChatModelProviders.DEEPSEEK]: ChatDeepSeek,
+  [ChatModelProviders.ORCAROUTER]: ChatOpenAI,
 } as const;
 
 type ChatProviderConstructMap = typeof CHAT_PROVIDER_CONSTRUCTORS;
@@ -140,6 +141,7 @@ export default class ChatModelManager {
     [ChatModelProviders.MISTRAL]: () => getSettings().mistralApiKey,
     [ChatModelProviders.DEEPSEEK]: () => getSettings().deepseekApiKey,
     [ChatModelProviders.SILICONFLOW]: () => getSettings().siliconflowApiKey,
+    [ChatModelProviders.ORCAROUTER]: () => getSettings().orcarouterApiKey,
   } as const;
 
   private constructor() {
@@ -480,6 +482,19 @@ export default class ChatModelManager {
           fetch: customModel.enableCors ? safeFetch : undefined,
         },
       },
+      [ChatModelProviders.ORCAROUTER]: {
+        modelName: modelName,
+        apiKey: await this.resolveApiKey(
+          customModel.apiKey,
+          settings.orcarouterApiKey,
+          allowLegacyCredentialFallback
+        ),
+        configuration: {
+          baseURL: customModel.baseUrl || ProviderInfo[ChatModelProviders.ORCAROUTER].host,
+          fetch: customModel.enableCors ? safeFetch : undefined,
+        },
+        ...this.getOpenAISpecialConfig(modelName, maxTokens, customModel),
+      },
     };
 
     const selectedProviderConfig =
@@ -583,6 +598,7 @@ export default class ChatModelManager {
           ChatModelProviders.MISTRAL,
           ChatModelProviders.DEEPSEEK,
           ChatModelProviders.SILICONFLOW,
+          ChatModelProviders.ORCAROUTER,
         ].includes(provider)
       ) {
         params.topP = customModel.topP;
@@ -603,6 +619,7 @@ export default class ChatModelManager {
           ChatModelProviders.MISTRAL,
           ChatModelProviders.DEEPSEEK,
           ChatModelProviders.SILICONFLOW,
+          ChatModelProviders.ORCAROUTER,
         ].includes(provider)
       ) {
         params.frequencyPenalty = customModel.frequencyPenalty;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -282,6 +282,10 @@ export enum ChatModels {
   OPENROUTER_GROK_4_3 = "x-ai/grok-4.3",
   SILICONFLOW_DEEPSEEK_V3 = "deepseek-ai/DeepSeek-V3",
   SILICONFLOW_DEEPSEEK_R1 = "deepseek-ai/DeepSeek-R1",
+  ORCAROUTER_AUTO = "orcarouter/auto",
+  ORCAROUTER_FUSION = "orcarouter/fusion",
+  ORCAROUTER_FUSION_FLASH = "orcarouter/fusion-flash",
+  ORCAROUTER_FUSION_MINI = "orcarouter/fusion-mini",
 }
 
 // Model Providers
@@ -301,6 +305,7 @@ export enum ChatModelProviders {
   DEEPSEEK = "deepseek",
   COHEREAI = "cohereai",
   SILICONFLOW = "siliconflow",
+  ORCAROUTER = "orcarouter",
 }
 
 export enum ModelCapability {
@@ -504,6 +509,31 @@ export const BUILTIN_CHAT_MODELS: CustomModel[] = [
     isBuiltIn: false,
     baseUrl: "https://api.siliconflow.com/v1",
     capabilities: [ModelCapability.REASONING],
+  },
+  {
+    name: ChatModels.ORCAROUTER_AUTO,
+    provider: ChatModelProviders.ORCAROUTER,
+    enabled: false,
+    isBuiltIn: true,
+    capabilities: [ModelCapability.REASONING],
+  },
+  {
+    name: ChatModels.ORCAROUTER_FUSION,
+    provider: ChatModelProviders.ORCAROUTER,
+    enabled: false,
+    isBuiltIn: true,
+  },
+  {
+    name: ChatModels.ORCAROUTER_FUSION_FLASH,
+    provider: ChatModelProviders.ORCAROUTER,
+    enabled: false,
+    isBuiltIn: true,
+  },
+  {
+    name: ChatModels.ORCAROUTER_FUSION_MINI,
+    provider: ChatModelProviders.ORCAROUTER,
+    enabled: false,
+    isBuiltIn: true,
   },
 ];
 
@@ -761,6 +791,13 @@ export const ProviderInfo: Record<Provider, ProviderMetadata> = {
     keyManagementURL: "https://platform.deepseek.com/api-keys",
     testModel: ChatModels.DEEPSEEK_CHAT,
   },
+  [ChatModelProviders.ORCAROUTER]: {
+    label: "OrcaRouter",
+    host: "https://api.orcarouter.ai/v1",
+    curlBaseURL: "https://api.orcarouter.ai/v1",
+    keyManagementURL: "https://www.orcarouter.ai",
+    testModel: ChatModels.ORCAROUTER_AUTO,
+  },
   [EmbeddingModelProviders.COPILOT_PLUS]: {
     label: "Copilot",
     host: BREVILABS_MODELS_BASE_URL,
@@ -789,6 +826,7 @@ export const ProviderSettingsKeyMap: Record<SettingKeyProviders, keyof CopilotSe
   mistralai: "mistralApiKey",
   deepseek: "deepseekApiKey",
   siliconflow: "siliconflowApiKey",
+  orcarouter: "orcarouterApiKey",
 };
 
 export enum VAULT_VECTOR_STORE_STRATEGY {
@@ -963,6 +1001,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   mistralApiKey: "",
   deepseekApiKey: "",
   siliconflowApiKey: "",
+  orcarouterApiKey: "",
   defaultChainType: ChainType.LLM_CHAIN,
   defaultModelKey: ChatModels.OPENROUTER_GEMINI_2_5_FLASH + "|" + ChatModelProviders.OPENROUTERAI,
   embeddingModelKey:

--- a/src/lib/model-display-utils.ts
+++ b/src/lib/model-display-utils.ts
@@ -24,6 +24,7 @@ export type ModelApiKeySettings = Pick<
   | "mistralApiKey"
   | "deepseekApiKey"
   | "siliconflowApiKey"
+  | "orcarouterApiKey"
 >;
 
 const PROVIDERS_WITHOUT_API_KEYS: ReadonlySet<Provider> = new Set([

--- a/src/modelManagement/chatModel/configuredModelToCustomModel.ts
+++ b/src/modelManagement/chatModel/configuredModelToCustomModel.ts
@@ -46,6 +46,7 @@ export const CATALOG_ID_TO_CHAT_PROVIDER: Record<string, ChatModelProviders> = {
   xai: ChatModelProviders.XAI,
   cohere: ChatModelProviders.COHEREAI,
   siliconflow: ChatModelProviders.SILICONFLOW,
+  orcarouter: ChatModelProviders.ORCAROUTER,
   anthropic: ChatModelProviders.ANTHROPIC,
   google: ChatModelProviders.GOOGLE,
 };

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -70,6 +70,7 @@ export interface CopilotSettings {
   mistralApiKey: string;
   deepseekApiKey: string;
   siliconflowApiKey: string;
+  orcarouterApiKey: string;
   defaultChainType: ChainType;
   defaultModelKey: string;
   embeddingModelKey: string;

--- a/src/utils/curlCommand.ts
+++ b/src/utils/curlCommand.ts
@@ -43,6 +43,7 @@ const OPENAI_COMPATIBLE_PROVIDERS = new Set<string>([
   EmbeddingModelProviders.LM_STUDIO,
   ChatModelProviders.MISTRAL,
   ChatModelProviders.DEEPSEEK,
+  ChatModelProviders.ORCAROUTER,
   // Note: Ollama uses native API (/api/chat), not OpenAI-compatible
 ]);
 


### PR DESCRIPTION
### Add OrcaRouter as a named chat provider

This PR adds [OrcaRouter](https://www.orcarouter.ai) as a first-class named provider alongside the existing OpenAI-compatible gateways (DeepSeek, SiliconFlow, OpenRouter). OrcaRouter is a smart-routing model gateway with an OpenAI-compatible endpoint at `https://api.orcarouter.ai/v1`. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

### What changed

- **Provider registry**: new `ChatModelProviders.ORCAROUTER` value, `ProviderInfo` entry (base URL `https://api.orcarouter.ai/v1`, key management at `https://www.orcarouter.ai`), `ProviderSettingsKeyMap` mapping, and `orcarouterApiKey` on `CopilotSettings` + `DEFAULT_SETTINGS`.
- **Model construction** (`chatModelManager.ts`): `CHAT_PROVIDER_CONSTRUCTORS` routes OrcaRouter through `ChatOpenAI`, with a dedicated providerConfig block (key resolution, base URL default, OpenAI special params). Added to the topP / frequencyPenalty allowlists.
- **Built-in models**: 4 disabled-by-default gateway models (`orcarouter/auto`, `fusion`, `fusion-flash`, `fusion-mini`) in `BUILTIN_CHAT_MODELS`.
- **BYOK bridge**: `CATALOG_ID_TO_CHAT_PROVIDER` maps the `models.dev` catalog id `orcarouter` (npm `@ai-sdk/openai-compatible`, api `https://api.orcarouter.ai/v1`) to the named constructor, so the BYOK wizard surfaces OrcaRouter with its base URL pre-filled and routes chat through the dedicated path.
- **Curl command generation**: OrcaRouter added to the OpenAI-compatible provider set.
- **Docs**: `docs/llm-providers.md` gains an OrcaRouter subsection covering the BYOK flow and the gateway models.
- **Tests**: new `chatModelManager.orcarouter.test.ts` covering constructor routing, default/custom base URLs, and missing-key handling (5 tests).

### How it was tested

- `npx tsc -noEmit -skipLibCheck` — clean.
- `npx eslint` on all touched files — clean.
- `npx prettier --check` on all touched files — clean.
- `npm test` — 451 suites passed; the only 2 failures are the pre-existing `gen-gallery-stories` Node-20-only `fs.promises.glob` incompatibility (CI runs Node 22, repo requires >= 22), unrelated to this change.
- `npm run build` (tailwind + esbuild production bundle) — succeeds.
- **Live verification**: `openai` SDK (the exact `ChatOpenAI` client class used for this provider) against `https://api.orcarouter.ai/v1` with model `orcarouter/auto` returns HTTP 200 with content `ORCA-LIVE-OK` (routed to `deepseek-v4-pro`, finish `stop`). All four `orcarouter/*` models return 200.

Disclosure: I'm an engineer on the OrcaRouter team.
