### PR TITLE
Ignore the whole .env family, not just .env.test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,8 @@ data/
 # Exclude macOS Finder (System Explorer) View States
 .DS_Store
 
-# Test Environment
-.env.test
+# Environment files
+.env*
 
 # Claude configuration
 .claude/settings.local.json


### PR DESCRIPTION
## Why

`.gitignore` covers `.env.test` but not `.env`, and nothing under `.env*` is
tracked in this repo, so this is a gap rather than a deliberate exception.

That has two live consequences now that local machine setup writes a real `.env`
here to hold inference-provider keys for provider testing:

1. A local `.env` shows up as untracked in `git status`, one `git add -A` away
   from committing API keys to a public repo.
2. Conductor's "files to copy" only propagates files that are gitignored. An
   unignored `.env` stays in the main checkout and never reaches a workspace,
   which is where agents actually run. The keys end up present on disk and still
   unavailable to the thing that needs them.

## What

`.env`, `.env.local`, and any other `.env*` a contributor creates are now
ignored, alongside the `.env.test` that already was.

> **Before:** `git status` in a checkout with a local `.env` lists it as
> untracked, and a new workspace is created without it.
>
> **After:** it is ignored, and a workspace gets a copy.

No runtime behavior changes. The plugin reads configuration exactly as before.

## Non goal

- Adding a committed `.env.example`. Deciding which variables belong in one is
  separate from closing this gap.
- Changing how the plugin reads configuration at runtime.
- Ignoring any other untracked local file. This touches the `.env*` family only.

## Screenshot

Not applicable. This is a two-line `.gitignore` change with no rendered surface.
The observable effect is `git check-ignore`, shown under Verification.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Config-only change; its effect renders in `git status` and `git check-ignore` |
| A defect would fail CI or be obvious on first use | ✅ | A wrong pattern shows immediately in `git status` on the next checkout |
| A revert fully restores prior state, including persisted data | ✅ | `.gitignore` text only; no data written, migrated, or deleted |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | No code path changes; the change strictly reduces the chance of committing a secret |
| No public API, plugin API, message, or on-disk contract changes | ✅ | No source, manifest, or persisted format touched |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | No runtime code in the diff |
| No hot-path behavior lacks deterministic coverage | ✅ | No runtime behavior to cover |
| No new dependency | ✅ | Dependency manifests unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Confined to git ignore rules, visible on the next `git status` |

Review: read the two changed lines in `.gitignore`, then run Verification step 1
to confirm no currently tracked file is affected.

## Verification

1. Confirm nothing tracked is orphaned by the wider pattern:
   `git ls-files | grep -E '(^|/)\.env'` returns nothing.
2. On this branch, run
   `for f in .env .env.test .env.local; do git check-ignore -q $f && echo "$f ignored" || echo "$f VISIBLE"; done`.
   All three report ignored; on `master`, `.env` and `.env.local` report VISIBLE.
3. Create an empty `.env` in the checkout and confirm `git status` stays clean.

## Note

No originating issue: this was filed and fixed in the same pass at the
maintainer's request, so there is no closing reference on this PR.
