### PR TITLE
Move Relevant Notes semantic scoring to Miyo

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -191,6 +191,12 @@ Miyo supplies Copilot's current semantic search and selected chat-history search
 
 If Miyo is reachable but the vault is not registered, the connection dialog offers **Register & connect** for a local Miyo. With a remote server or mobile setup, select **Open Miyo**, add the vault there, then **Retry**. Register only folders you intend Miyo and any enabled Relay clients to access.
 
+### Index scope
+
+Use **Exclusions** to skip folders, tags, individual notes, or file extensions. Use **Inclusions** to search only selected folders, tags, or notes. Exclusions take precedence, and Copilot's own working folder always stays excluded.
+
+Copilot applies every pattern to its own search results and Relevant Notes. Folder and file-extension changes also update the registered Miyo folder automatically, even when this settings tab is closed. Copilot preserves filters configured directly in Miyo and does not widen a stricter Miyo inclusion whitelist. Miyo's folder API cannot represent tags or individual notes, so those patterns remain Copilot-side filters. If Miyo is unavailable when a representable pattern changes, Copilot keeps the setting and shows that Miyo was not updated.
+
 ### Powered by Miyo
 
 | Control                          | Default                                    | Dependency and effect                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |

--- a/docs/vault-search-and-indexing.md
+++ b/docs/vault-search-and-indexing.md
@@ -39,6 +39,12 @@ Use **Search scope** in the Miyo settings tab:
 
 The scope is a retrieval preference, not a security boundary. Keep Miyo's registered folders intentional, especially when you use an unrestricted scope or connect to a shared remote server.
 
+### Relevant Notes
+
+Relevant Notes always includes direct links and backlinks that pass Copilot's search scope. Miyo is the only source of semantic matches and similarity percentages in this pane; Copilot's legacy local embedding index no longer scores Relevant Notes.
+
+If Miyo is not connected, link and backlink rows stay visible without percentages and the pane offers Miyo download and setup actions. If Miyo is enabled but returns no semantic matches, the same rows remain visible and the pane asks you to check the connection and confirm that this vault is registered and indexed. Use **Open Miyo settings** to return directly to the existing connection flow under **Settings → Copilot → Miyo**, including when you use a remote endpoint or mobile device.
+
 ## Search conversations and process documents
 
 Miyo can also index supported ChatGPT and Claude chat histories. Configure those sources in Miyo, then use the **Search chat** row in Copilot to see their status and open Miyo's management screen. Chat-history search is separate from vault search.

--- a/docs/vault-search-and-indexing.md
+++ b/docs/vault-search-and-indexing.md
@@ -39,6 +39,8 @@ Use **Search scope** in the Miyo settings tab:
 
 The scope is a retrieval preference, not a security boundary. Keep Miyo's registered folders intentional, especially when you use an unrestricted scope or connect to a shared remote server.
 
+Under **Index scope**, Copilot's inclusions and exclusions control which notes its searches and Relevant Notes can return. Folder and file-extension changes also update this vault's registered Miyo folder automatically. Filters configured directly in Miyo remain in place, and Copilot does not widen a stricter Miyo inclusion whitelist. Tags and individual-note patterns still filter Copilot results, but Miyo continues indexing them because its folder API cannot represent those pattern types. If Miyo cannot be reached during an update, Copilot keeps the local setting and tells you that Miyo was not updated.
+
 ### Relevant Notes
 
 Relevant Notes always includes direct links and backlinks that pass Copilot's search scope. Miyo is the only source of semantic matches and similarity percentages in this pane; Copilot's legacy local embedding index no longer scores Relevant Notes.
@@ -74,7 +76,7 @@ Connector access is separate from Agent Chat search. Review the folders, remote 
 - **Relevant Notes has no semantic results:** **No semantic matches yet** means Miyo answered successfully but found no related notes. **This note isn't indexed in Miyo** means the note may still be indexing or may be excluded from Miyo. Links and backlinks remain visible in either state.
 - **Agent Chat Miyo document processing fails:** install Miyo on this computer so its local CLI is available, or switch **Document Processor** to **Plus**. A remote Miyo search connection does not provide the local CLI Agent Chat needs.
 - **Quick Chat Miyo document processing fails:** confirm that the connected Miyo service can access the registered vault and document. When a remote server is configured, troubleshoot the document on that server.
-- **Copilot asks for a resync:** use **Resync Miyo** so Miyo excludes Copilot's own working folder and conversation files.
+- **Copilot asks for a resync:** use **Resync Miyo** so Miyo excludes Copilot's own working folder and conversation files. Ordinary folder and file-extension edits under **Index scope** update Miyo automatically and do not require this rebuild.
 - **Mobile:** a remote Miyo server can be configured on mobile, but Agent Chat and its Skills are desktop features. Use Quick Chat on mobile.
 
 ## Related

--- a/docs/vault-search-and-indexing.md
+++ b/docs/vault-search-and-indexing.md
@@ -43,7 +43,9 @@ The scope is a retrieval preference, not a security boundary. Keep Miyo's regist
 
 Relevant Notes always includes direct links and backlinks that pass Copilot's search scope. Miyo is the only source of semantic matches and similarity percentages in this pane; Copilot's legacy local embedding index no longer scores Relevant Notes.
 
-If Miyo is not connected, link and backlink rows stay visible without percentages and the pane offers Miyo download and setup actions. If Miyo is enabled but returns no semantic matches, the same rows remain visible and the pane asks you to check the connection and confirm that this vault is registered and indexed. Use **Open Miyo settings** to return directly to the existing connection flow under **Settings → Copilot → Miyo**, including when you use a remote endpoint or mobile device.
+If Miyo is disabled, link and backlink rows stay visible without percentages and the pane offers Miyo download and setup actions. If Miyo is unavailable or the vault registration cannot be confirmed, the same rows remain visible and **Open Miyo settings** returns directly to the existing connection flow under **Settings → Copilot → Miyo**, including when you use a remote endpoint or mobile device.
+
+A successful search with zero results shows **No semantic matches yet** without treating the empty result as a setup failure. When Miyo reports that the active path has no indexed chunks but the vault is registered, the pane instead shows **This note isn't indexed in Miyo**. Miyo uses that response for both a note that is still indexing and a path excluded from Miyo, so Copilot does not claim to know which one applies. On a local desktop connection, **Open Miyo** opens the Miyo app so you can review the folder's indexing and exclusion settings. Mobile and remote connections instead offer **Review Miyo connection**, which opens Copilot's Miyo tab to review the configured server without implying that Copilot can change Miyo's exclusions. Copilot's own inclusion and exclusion rules remain separate: a locally excluded active note still shows **This note is excluded**.
 
 ## Search conversations and process documents
 
@@ -69,6 +71,7 @@ Connector access is separate from Agent Chat search. Review the folders, remote 
 - **Register this vault:** register the folder in Miyo, then connect again.
 - **Semantic search is missing:** confirm the connection is healthy and turn on **Semantic search**. Copilot installs the shared Miyo skill for opencode, Claude, and Codex.
 - **New notes are missing:** ask Miyo to refresh the registered folder. Indexing progress is shown in Miyo.
+- **Relevant Notes has no semantic results:** **No semantic matches yet** means Miyo answered successfully but found no related notes. **This note isn't indexed in Miyo** means the note may still be indexing or may be excluded from Miyo. Links and backlinks remain visible in either state.
 - **Agent Chat Miyo document processing fails:** install Miyo on this computer so its local CLI is available, or switch **Document Processor** to **Plus**. A remote Miyo search connection does not provide the local CLI Agent Chat needs.
 - **Quick Chat Miyo document processing fails:** confirm that the connected Miyo service can access the registered vault and document. When a remote server is configured, troubleshoot the document on that server.
 - **Copilot asks for a resync:** use **Resync Miyo** so Miyo excludes Copilot's own working folder and conversation files.

--- a/src/components/chat-components/RelevantNotes.test.tsx
+++ b/src/components/chat-components/RelevantNotes.test.tsx
@@ -2,7 +2,8 @@
 import { RelevantNotes } from "@/components/chat-components/RelevantNotes";
 import { useActiveFile } from "@/hooks/useActiveFile";
 import { findRelevantNotes } from "@/search/findRelevantNotes";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { openMiyoSettings } from "@/settings/openSettings";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { TFile } from "obsidian";
 import React from "react";
 
@@ -17,14 +18,12 @@ const mockApp = {
     getLeaf: mockGetLeaf,
   },
 };
-
-jest.mock("@/aiParams", () => ({
-  useIndexingProgress: () => [{ isActive: false, indexedCount: 0, totalFiles: 0 }],
-}));
-
-jest.mock("@/components/modals/SemanticSearchToggleModal", () => ({
-  SemanticSearchToggleModal: jest.fn(),
-}));
+let mockSettings = {
+  enableMiyo: false,
+  miyoServerUrl: "",
+  qaInclusions: "",
+  qaExclusions: "",
+};
 
 jest.mock("@/context", () => ({
   useApp: () => mockApp,
@@ -36,11 +35,6 @@ jest.mock("@/hooks/useActiveFile", () => ({
 
 jest.mock("@/hooks/useNoteDrag", () => ({
   useNoteDrag: () => jest.fn(),
-}));
-
-jest.mock("@/miyo/miyoUtils", () => ({
-  getSearchBackend: () => "keyword",
-  shouldUseMiyo: () => false,
 }));
 
 jest.mock("@/search/findRelevantNotes", () => ({
@@ -56,21 +50,11 @@ jest.mock("@/search/searchUtils", () => ({
   shouldIndexFile: () => true,
 }));
 
-jest.mock("@/search/vectorStoreManager", () => ({
-  __esModule: true,
-  default: {
-    getInstance: () => ({
-      hasIndex: jest.fn().mockResolvedValue(true),
-      indexVaultToVectorStore: jest.fn().mockResolvedValue(undefined),
-    }),
-  },
+jest.mock("@/settings/model", () => ({
+  useSettingsValue: () => mockSettings,
 }));
 
-jest.mock("@/settings/model", () => ({
-  getSettings: () => ({ enableSemanticSearchV3: true }),
-  updateSetting: jest.fn(),
-  useSettingsValue: () => ({ qaInclusions: "", qaExclusions: "" }),
-}));
+jest.mock("@/settings/openSettings", () => ({ openMiyoSettings: jest.fn() }));
 
 const mockUseActiveFile = useActiveFile as jest.MockedFunction<typeof useActiveFile>;
 const mockFindRelevantNotes = findRelevantNotes as jest.MockedFunction<typeof findRelevantNotes>;
@@ -83,6 +67,12 @@ function makeMarkdownFile(path: string): TFile {
 describe("RelevantNotes", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSettings = {
+      enableMiyo: false,
+      miyoServerUrl: "",
+      qaInclusions: "",
+      qaExclusions: "",
+    };
     const sourceFile = makeMarkdownFile("Source.md");
     const targetFile = makeMarkdownFile("Target.md");
     mockUseActiveFile.mockReturnValue(sourceFile);
@@ -110,6 +100,135 @@ describe("RelevantNotes", () => {
 
       expect(mockGetLeaf).toHaveBeenCalledWith(true);
       expect(mockOpenFile).toHaveBeenCalledWith(expect.objectContaining({ path: "Target.md" }));
+    });
+
+    it("keeps links-only rows visible without a meter and shows Miyo download guidance (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      mockFindRelevantNotes.mockResolvedValue([
+        {
+          note: { path: "Target.md", title: "Target" },
+          metadata: {
+            score: 0,
+            similarityScore: undefined,
+            hasOutgoingLinks: false,
+            hasBacklinks: true,
+          },
+        },
+      ]);
+
+      render(<RelevantNotes onAddToChat={jest.fn()} />);
+
+      expect(await screen.findByText("Target")).toBeTruthy();
+      expect(screen.getByText("Add semantic matches with Miyo")).toBeTruthy();
+      expect(screen.queryByText(/%/)).toBeNull();
+    });
+
+    it("shows setup guidance for links-only rows when Miyo is enabled and opens the Miyo settings tab (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      mockSettings = { ...mockSettings, enableMiyo: true };
+      mockFindRelevantNotes.mockResolvedValue([
+        {
+          note: { path: "Target.md", title: "Target" },
+          metadata: {
+            score: 0,
+            similarityScore: undefined,
+            hasOutgoingLinks: true,
+            hasBacklinks: false,
+          },
+        },
+      ]);
+
+      render(<RelevantNotes onAddToChat={jest.fn()} />);
+
+      fireEvent.click(await screen.findByRole("button", { name: "Open Miyo settings" }));
+      expect(openMiyoSettings).toHaveBeenCalledWith(mockApp, window);
+    });
+
+    it("refetches Relevant Notes when Miyo settings change (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      const { rerender } = render(<RelevantNotes onAddToChat={jest.fn()} />);
+      await waitFor(() => expect(mockFindRelevantNotes).toHaveBeenCalledTimes(1));
+
+      mockSettings = { ...mockSettings, enableMiyo: true };
+      rerender(<RelevantNotes onAddToChat={jest.fn()} />);
+
+      await waitFor(() => expect(mockFindRelevantNotes).toHaveBeenCalledTimes(2));
+    });
+
+    it("keeps a superseded Miyo request from overwriting newer results (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      let resolveFirst:
+        | ((notes: Awaited<ReturnType<typeof findRelevantNotes>>) => void)
+        | undefined;
+      const firstResult = new Promise<Awaited<ReturnType<typeof findRelevantNotes>>>((resolve) => {
+        resolveFirst = resolve;
+      });
+      mockFindRelevantNotes.mockReturnValueOnce(firstResult).mockResolvedValueOnce([
+        {
+          note: { path: "Current.md", title: "Current" },
+          metadata: {
+            score: 0.9,
+            similarityScore: 0.9,
+            hasOutgoingLinks: false,
+            hasBacklinks: false,
+          },
+        },
+      ]);
+
+      const { rerender } = render(<RelevantNotes onAddToChat={jest.fn()} />);
+      await waitFor(() => expect(mockFindRelevantNotes).toHaveBeenCalledTimes(1));
+
+      mockSettings = { ...mockSettings, enableMiyo: true, miyoServerUrl: "https://new-miyo" };
+      rerender(<RelevantNotes onAddToChat={jest.fn()} />);
+      expect(await screen.findByText("Current")).toBeTruthy();
+
+      await act(async () => {
+        resolveFirst?.([
+          {
+            note: { path: "Stale.md", title: "Stale" },
+            metadata: {
+              score: 0.7,
+              similarityScore: 0.7,
+              hasOutgoingLinks: false,
+              hasBacklinks: false,
+            },
+          },
+        ]);
+        await firstResult;
+      });
+
+      expect(screen.queryByText("Stale")).toBeNull();
+      expect(screen.getByText("Current")).toBeTruthy();
+    });
+
+    it("keeps a superseded Miyo failure from clearing newer results (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      let rejectFirst: ((reason: Error) => void) | undefined;
+      const firstResult = new Promise<Awaited<ReturnType<typeof findRelevantNotes>>>(
+        (_, reject) => {
+          rejectFirst = reject;
+        }
+      );
+      mockFindRelevantNotes.mockReturnValueOnce(firstResult).mockResolvedValueOnce([
+        {
+          note: { path: "Current.md", title: "Current" },
+          metadata: {
+            score: 0.9,
+            similarityScore: 0.9,
+            hasOutgoingLinks: false,
+            hasBacklinks: false,
+          },
+        },
+      ]);
+
+      const { rerender } = render(<RelevantNotes onAddToChat={jest.fn()} />);
+      await waitFor(() => expect(mockFindRelevantNotes).toHaveBeenCalledTimes(1));
+
+      mockSettings = { ...mockSettings, enableMiyo: true, miyoServerUrl: "https://new-miyo" };
+      rerender(<RelevantNotes onAddToChat={jest.fn()} />);
+      expect(await screen.findByText("Current")).toBeTruthy();
+
+      await act(async () => {
+        rejectFirst?.(new Error("Old endpoint failed"));
+        await expect(firstResult).rejects.toThrow("Old endpoint failed");
+      });
+
+      expect(screen.getByText("Current")).toBeTruthy();
     });
   });
 });

--- a/src/components/chat-components/RelevantNotes.test.tsx
+++ b/src/components/chat-components/RelevantNotes.test.tsx
@@ -246,6 +246,17 @@ describe("RelevantNotes", () => {
       expect(screen.queryByText("No relevant notes found")).toBeNull();
     });
 
+    it("shows the neutral empty state when no Markdown note is active instead of loading forever (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      mockSettings = { ...mockSettings, enableMiyo: true };
+      mockUseActiveFile.mockReturnValue(null);
+
+      render(<RelevantNotes onAddToChat={jest.fn()} />);
+
+      expect(await screen.findByText("No relevant notes found")).toBeTruthy();
+      expect(mockFindRelevantNotes).not.toHaveBeenCalled();
+      expect(screen.queryByText("No semantic matches yet")).toBeNull();
+    });
+
     it("keeps the excluded-note card and suppresses semantic guidance (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
       mockSettings = { ...mockSettings, enableMiyo: true };
       mockShouldIndexFile.mockReturnValue(false);

--- a/src/components/chat-components/RelevantNotes.test.tsx
+++ b/src/components/chat-components/RelevantNotes.test.tsx
@@ -4,11 +4,12 @@ import { useActiveFile } from "@/hooks/useActiveFile";
 import { findRelevantNotes } from "@/search/findRelevantNotes";
 import { openMiyoSettings } from "@/settings/openSettings";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { TFile } from "obsidian";
+import { Platform, TFile } from "obsidian";
 import React from "react";
 
 const mockOpenFile = jest.fn().mockResolvedValue(undefined);
 const mockGetLeaf = jest.fn(() => ({ openFile: mockOpenFile }));
+const mockShouldIndexFile = jest.fn(() => true);
 const mockApp = {
   vault: {
     getAbstractFileByPath: jest.fn(),
@@ -47,7 +48,7 @@ jest.mock("@/search/indexSignal", () => ({
 
 jest.mock("@/search/searchUtils", () => ({
   getMatchingPatterns: () => ({ inclusions: [], exclusions: [] }),
-  shouldIndexFile: () => true,
+  shouldIndexFile: () => mockShouldIndexFile(),
 }));
 
 jest.mock("@/settings/model", () => ({
@@ -67,6 +68,8 @@ function makeMarkdownFile(path: string): TFile {
 describe("RelevantNotes", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (Platform as { isMobile: boolean }).isMobile = false;
+    mockShouldIndexFile.mockReturnValue(true);
     mockSettings = {
       enableMiyo: false,
       miyoServerUrl: "",
@@ -79,17 +82,25 @@ describe("RelevantNotes", () => {
     mockApp.vault.getAbstractFileByPath.mockImplementation((path: string) =>
       path === targetFile.path ? targetFile : sourceFile
     );
-    mockFindRelevantNotes.mockResolvedValue([
-      {
-        note: { path: targetFile.path, title: targetFile.basename },
-        metadata: {
-          score: 0.8,
-          similarityScore: 0.8,
-          hasOutgoingLinks: false,
-          hasBacklinks: false,
+    mockFindRelevantNotes.mockResolvedValue({
+      notes: [
+        {
+          note: { path: targetFile.path, title: targetFile.basename },
+          metadata: {
+            score: 0.8,
+            similarityScore: 0.8,
+            hasOutgoingLinks: false,
+            hasBacklinks: false,
+          },
         },
-      },
-    ]);
+      ],
+      semanticState: "ready",
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    (Platform as { isMobile: boolean }).isMobile = false;
   });
 
   describe("RelevantNotes()", () => {
@@ -103,17 +114,20 @@ describe("RelevantNotes", () => {
     });
 
     it("keeps links-only rows visible without a meter and shows Miyo download guidance (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
-      mockFindRelevantNotes.mockResolvedValue([
-        {
-          note: { path: "Target.md", title: "Target" },
-          metadata: {
-            score: 0,
-            similarityScore: undefined,
-            hasOutgoingLinks: false,
-            hasBacklinks: true,
+      mockFindRelevantNotes.mockResolvedValue({
+        notes: [
+          {
+            note: { path: "Target.md", title: "Target" },
+            metadata: {
+              score: 0,
+              similarityScore: undefined,
+              hasOutgoingLinks: false,
+              hasBacklinks: true,
+            },
           },
-        },
-      ]);
+        ],
+        semanticState: "disabled",
+      });
 
       render(<RelevantNotes onAddToChat={jest.fn()} />);
 
@@ -122,24 +136,125 @@ describe("RelevantNotes", () => {
       expect(screen.queryByText(/%/)).toBeNull();
     });
 
-    it("shows setup guidance for links-only rows when Miyo is enabled and opens the Miyo settings tab (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+    it("shows setup guidance for links-only rows only when Miyo is unavailable and opens the Miyo settings tab (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
       mockSettings = { ...mockSettings, enableMiyo: true };
-      mockFindRelevantNotes.mockResolvedValue([
-        {
-          note: { path: "Target.md", title: "Target" },
-          metadata: {
-            score: 0,
-            similarityScore: undefined,
-            hasOutgoingLinks: true,
-            hasBacklinks: false,
+      mockFindRelevantNotes.mockResolvedValue({
+        notes: [
+          {
+            note: { path: "Target.md", title: "Target" },
+            metadata: {
+              score: 0,
+              similarityScore: undefined,
+              hasOutgoingLinks: true,
+              hasBacklinks: false,
+            },
           },
-        },
-      ]);
+        ],
+        semanticState: "unavailable",
+      });
 
       render(<RelevantNotes onAddToChat={jest.fn()} />);
 
       fireEvent.click(await screen.findByRole("button", { name: "Open Miyo settings" }));
       expect(openMiyoSettings).toHaveBeenCalledWith(mockApp, window);
+    });
+
+    it("shows an informational no-matches state without setup actions when registered Miyo is ready (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      mockSettings = { ...mockSettings, enableMiyo: true };
+      mockFindRelevantNotes.mockResolvedValue({
+        notes: [
+          {
+            note: { path: "Target.md", title: "Target" },
+            metadata: {
+              score: 0,
+              similarityScore: undefined,
+              hasOutgoingLinks: false,
+              hasBacklinks: true,
+            },
+          },
+        ],
+        semanticState: "ready",
+      });
+
+      render(<RelevantNotes onAddToChat={jest.fn()} />);
+
+      expect(await screen.findByText("No semantic matches yet")).toBeTruthy();
+      expect(screen.getByText("Target")).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Open Miyo settings" })).toBeNull();
+    });
+
+    it("shows an informational not-indexed state beside links without claiming a setup problem (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      mockSettings = { ...mockSettings, enableMiyo: true };
+      mockFindRelevantNotes.mockResolvedValue({
+        notes: [
+          {
+            note: { path: "Target.md", title: "Target" },
+            metadata: {
+              score: 0,
+              similarityScore: undefined,
+              hasOutgoingLinks: true,
+              hasBacklinks: false,
+            },
+          },
+        ],
+        semanticState: "not-indexed",
+      });
+
+      const openSpy = jest.spyOn(window, "open").mockImplementation(() => null);
+      render(<RelevantNotes onAddToChat={jest.fn()} />);
+
+      expect(await screen.findByText("This note isn't indexed in Miyo")).toBeTruthy();
+      expect(
+        screen.getByText(
+          "It may still be indexing or be excluded from Miyo. Open Miyo to review this folder's indexing and exclusion settings."
+        )
+      ).toBeTruthy();
+      expect(screen.getByText("Target")).toBeTruthy();
+      fireEvent.click(screen.getByRole("button", { name: "Open Miyo" }));
+      expect(openSpy).toHaveBeenCalledWith("miyo://", "_blank");
+      openSpy.mockRestore();
+    });
+
+    it.each([
+      { runtime: "mobile", isMobile: true, miyoServerUrl: "http://127.0.0.1:8742" },
+      { runtime: "remote", isMobile: false, miyoServerUrl: "https://remote-miyo.example" },
+    ])(
+      "routes the $runtime not-indexed action to Copilot settings instead of a local deeplink (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)",
+      async ({ isMobile, miyoServerUrl }) => {
+        (Platform as { isMobile: boolean }).isMobile = isMobile;
+        mockSettings = { ...mockSettings, enableMiyo: true, miyoServerUrl };
+        mockFindRelevantNotes.mockResolvedValue({ notes: [], semanticState: "not-indexed" });
+        const openSpy = jest.spyOn(window, "open").mockImplementation(() => null);
+
+        render(<RelevantNotes onAddToChat={jest.fn()} />);
+
+        fireEvent.click(await screen.findByRole("button", { name: "Review Miyo connection" }));
+        expect(openMiyoSettings).toHaveBeenCalledWith(mockApp, window);
+        expect(openSpy).not.toHaveBeenCalled();
+        openSpy.mockRestore();
+      }
+    );
+
+    it("shows no readiness or setup guidance while the current Miyo request is loading (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      mockSettings = { ...mockSettings, enableMiyo: true };
+      mockFindRelevantNotes.mockReturnValue(new Promise(() => undefined));
+
+      const { container } = render(<RelevantNotes onAddToChat={jest.fn()} />);
+      await waitFor(() => expect(mockFindRelevantNotes).toHaveBeenCalledTimes(1));
+
+      expect(container.querySelector("[data-miyo-guidance]")).toBeNull();
+      expect(screen.queryByText("No relevant notes found")).toBeNull();
+    });
+
+    it("keeps the excluded-note card and suppresses semantic guidance (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      mockSettings = { ...mockSettings, enableMiyo: true };
+      mockShouldIndexFile.mockReturnValue(false);
+      mockFindRelevantNotes.mockResolvedValue({ notes: [], semanticState: "unavailable" });
+
+      const { container } = render(<RelevantNotes onAddToChat={jest.fn()} />);
+
+      expect(await screen.findByText("This note is excluded")).toBeTruthy();
+      expect(container.querySelector("[data-miyo-guidance]")).toBeNull();
     });
 
     it("refetches Relevant Notes when Miyo settings change (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
@@ -159,17 +274,20 @@ describe("RelevantNotes", () => {
       const firstResult = new Promise<Awaited<ReturnType<typeof findRelevantNotes>>>((resolve) => {
         resolveFirst = resolve;
       });
-      mockFindRelevantNotes.mockReturnValueOnce(firstResult).mockResolvedValueOnce([
-        {
-          note: { path: "Current.md", title: "Current" },
-          metadata: {
-            score: 0.9,
-            similarityScore: 0.9,
-            hasOutgoingLinks: false,
-            hasBacklinks: false,
+      mockFindRelevantNotes.mockReturnValueOnce(firstResult).mockResolvedValueOnce({
+        notes: [
+          {
+            note: { path: "Current.md", title: "Current" },
+            metadata: {
+              score: 0.9,
+              similarityScore: 0.9,
+              hasOutgoingLinks: false,
+              hasBacklinks: false,
+            },
           },
-        },
-      ]);
+        ],
+        semanticState: "ready",
+      });
 
       const { rerender } = render(<RelevantNotes onAddToChat={jest.fn()} />);
       await waitFor(() => expect(mockFindRelevantNotes).toHaveBeenCalledTimes(1));
@@ -179,17 +297,20 @@ describe("RelevantNotes", () => {
       expect(await screen.findByText("Current")).toBeTruthy();
 
       await act(async () => {
-        resolveFirst?.([
-          {
-            note: { path: "Stale.md", title: "Stale" },
-            metadata: {
-              score: 0.7,
-              similarityScore: 0.7,
-              hasOutgoingLinks: false,
-              hasBacklinks: false,
+        resolveFirst?.({
+          notes: [
+            {
+              note: { path: "Stale.md", title: "Stale" },
+              metadata: {
+                score: 0.7,
+                similarityScore: 0.7,
+                hasOutgoingLinks: false,
+                hasBacklinks: false,
+              },
             },
-          },
-        ]);
+          ],
+          semanticState: "ready",
+        });
         await firstResult;
       });
 
@@ -204,17 +325,20 @@ describe("RelevantNotes", () => {
           rejectFirst = reject;
         }
       );
-      mockFindRelevantNotes.mockReturnValueOnce(firstResult).mockResolvedValueOnce([
-        {
-          note: { path: "Current.md", title: "Current" },
-          metadata: {
-            score: 0.9,
-            similarityScore: 0.9,
-            hasOutgoingLinks: false,
-            hasBacklinks: false,
+      mockFindRelevantNotes.mockReturnValueOnce(firstResult).mockResolvedValueOnce({
+        notes: [
+          {
+            note: { path: "Current.md", title: "Current" },
+            metadata: {
+              score: 0.9,
+              similarityScore: 0.9,
+              hasOutgoingLinks: false,
+              hasBacklinks: false,
+            },
           },
-        },
-      ]);
+        ],
+        semanticState: "ready",
+      });
 
       const { rerender } = render(<RelevantNotes onAddToChat={jest.fn()} />);
       await waitFor(() => expect(mockFindRelevantNotes).toHaveBeenCalledTimes(1));

--- a/src/components/chat-components/RelevantNotes.tsx
+++ b/src/components/chat-components/RelevantNotes.tsx
@@ -1,33 +1,25 @@
-import { useIndexingProgress } from "@/aiParams";
-import { SemanticSearchToggleModal } from "@/components/modals/SemanticSearchToggleModal";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
-import { Progress } from "@/components/ui/progress";
+import {
+  RelevantNotesPane,
+  type RelevantNotesGuidance,
+} from "@/components/chat-components/ui/RelevantNotesPane";
+import { MIYO_HOMEPAGE_URL } from "@/constants";
 import { useApp } from "@/context";
 import { useActiveFile } from "@/hooks/useActiveFile";
 import { useNoteDrag } from "@/hooks/useNoteDrag";
 import { cn } from "@/lib/utils";
 import { logError, logWarn } from "@/logger";
-import { getSearchBackend } from "@/miyo/miyoUtils";
 import { findRelevantNotes, RelevantNoteEntry } from "@/search/findRelevantNotes";
 import { onIndexChanged } from "@/search/indexSignal";
 import { getMatchingPatterns, shouldIndexFile } from "@/search/searchUtils";
+import { openMiyoSettings } from "@/settings/openSettings";
 import { useSettingsValue } from "@/settings/model";
-import {
-  ArrowRight,
-  EyeOff,
-  FileInput,
-  FileOutput,
-  FileText,
-  GitFork,
-  Loader2,
-  PlusCircle,
-  RefreshCw,
-} from "lucide-react";
+import { ArrowRight, EyeOff, FileInput, FileOutput, FileText, PlusCircle } from "lucide-react";
 import { TFile } from "obsidian";
 import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
 
-function useRelevantNotes(refresher: number) {
+function useRelevantNotes(enableMiyo: boolean, miyoServerUrl: string) {
   const app = useApp();
   const [relevantNotes, setRelevantNotes] = useState<RelevantNoteEntry[]>([]);
   const [signalTick, setSignalTick] = useState(0);
@@ -36,55 +28,31 @@ function useRelevantNotes(refresher: number) {
   useEffect(() => onIndexChanged(() => setSignalTick((t) => t + 1)), []);
 
   useEffect(() => {
+    let cancelled = false;
+
     async function fetchNotes() {
       if (!activeFile?.path) return;
       try {
         const notes = await findRelevantNotes({ app, filePath: activeFile.path });
-        setRelevantNotes(notes);
+        // A settings or active-note change can supersede an in-flight Miyo
+        // request. Its older result must not replace the newer pane state.
+        // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+        if (!cancelled) setRelevantNotes(notes);
       } catch (error) {
-        logWarn("Failed to fetch relevant notes", error);
-        setRelevantNotes([]);
+        if (!cancelled) {
+          logWarn("Failed to fetch relevant notes", error);
+          setRelevantNotes([]);
+        }
       }
     }
 
     void fetchNotes();
-  }, [app, activeFile?.path, refresher, signalTick]);
+    return () => {
+      cancelled = true;
+    };
+  }, [app, activeFile?.path, enableMiyo, miyoServerUrl, signalTick]);
 
   return relevantNotes;
-}
-
-function useHasIndex(notePath: string, refresher: number) {
-  const [hasIndex, setHasIndex] = useState(true);
-  const [signalTick, setSignalTick] = useState(0);
-
-  useEffect(() => onIndexChanged(() => setSignalTick((t) => t + 1)), []);
-
-  useEffect(() => {
-    if (!notePath) return;
-
-    async function fetchHasIndex() {
-      try {
-        const VectorStoreManager = (await import("@/search/vectorStoreManager")).default;
-        const { getSettings } = await import("@/settings/model");
-        const settings = getSettings();
-        const useMiyo = getSearchBackend(settings) === "miyo";
-
-        if (useMiyo) {
-          const isEmpty = await VectorStoreManager.getInstance().isIndexEmpty();
-          setHasIndex(!isEmpty);
-          return;
-        }
-
-        const has = await VectorStoreManager.getInstance().hasIndex(notePath);
-        setHasIndex(has);
-      } catch {
-        setHasIndex(false);
-      }
-    }
-
-    void fetchHasIndex();
-  }, [notePath, refresher, signalTick]);
-  return hasIndex;
 }
 
 /** Map a 0–1 similarity score directly to the meter fill width (70% → 70%). */
@@ -346,15 +314,7 @@ function RelevantNoteRow({
   );
 }
 
-function RelevantNotesToolbar({
-  activeFileName,
-  isBuilding,
-  onBuild,
-}: {
-  activeFileName: string | undefined;
-  isBuilding: boolean;
-  onBuild: () => void;
-}) {
+function RelevantNotesToolbar({ activeFileName }: { activeFileName: string | undefined }) {
   return (
     <div className="tw-flex tw-flex-none tw-items-center tw-gap-2 tw-border-[0px] tw-border-b tw-border-solid tw-border-border tw-px-3 tw-py-2">
       <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-1.5 tw-text-xs tw-text-faint">
@@ -368,32 +328,6 @@ function RelevantNotesToolbar({
           <span className="tw-text-muted">—</span>
         )}
       </div>
-      <Button
-        variant="secondary"
-        size="sm"
-        disabled={isBuilding}
-        onClick={onBuild}
-        className="tw-ml-auto tw-shrink-0 tw-gap-1.5"
-      >
-        <RefreshCw className={cn("tw-size-3.5", isBuilding && "tw-animate-spin")} />
-        {isBuilding ? "Building…" : "Build index"}
-      </Button>
-    </div>
-  );
-}
-
-function BuildOverlay({ indexedCount, totalFiles }: { indexedCount: number; totalFiles: number }) {
-  const progress = totalFiles > 0 ? Math.round((indexedCount / totalFiles) * 100) : 0;
-  return (
-    <div className="tw-absolute tw-inset-0 tw-flex tw-flex-col tw-items-center tw-justify-center tw-gap-4 tw-px-10 tw-text-center tw-backdrop-blur-sm tw-bg-primary/90">
-      <Loader2 className="tw-size-6 tw-animate-spin tw-text-accent" />
-      <span className="tw-text-sm tw-font-semibold tw-text-normal">Indexing your vault</span>
-      <Progress value={progress} className="tw-h-1 tw-w-48" />
-      {totalFiles > 0 && (
-        <span className="tw-text-xs tw-tabular-nums tw-text-faint">
-          {indexedCount} / {totalFiles} notes embedded
-        </span>
-      )}
     </div>
   );
 }
@@ -407,12 +341,9 @@ interface RelevantNotesProps {
 export const RelevantNotes = memo(
   ({ className, onAddToChat }: RelevantNotesProps): React.ReactElement => {
     const app = useApp();
-    const [refresher, setRefresher] = useState(0);
-    const relevantNotes = useRelevantNotes(refresher);
     const activeFile = useActiveFile();
-    const hasIndex = useHasIndex(activeFile?.path ?? "", refresher);
-    const [indexingState] = useIndexingProgress();
     const settings = useSettingsValue();
+    const relevantNotes = useRelevantNotes(settings.enableMiyo, settings.miyoServerUrl);
 
     // The active note itself is excluded from the index (by the QA
     // inclusion/exclusion settings or an internal exclusion), so no relevant
@@ -437,37 +368,19 @@ export const RelevantNotes = memo(
       onAddToChat(`[[${prompt}]]`);
     };
 
-    const handleBuildIndex = async () => {
-      const { getSettings, updateSetting } = await import("@/settings/model");
-      const settings = getSettings();
-
-      if (!settings.enableSemanticSearchV3) {
-        // Semantic search is off — show confirmation modal (same as settings page)
-        new SemanticSearchToggleModal(
-          app,
-          async () => {
-            updateSetting("enableSemanticSearchV3", true);
-            const VectorStoreManager = (await import("@/search/vectorStoreManager")).default;
-            await VectorStoreManager.getInstance().indexVaultToVectorStore(false, {
-              userInitiated: true,
-            });
-            setRefresher(refresher + 1);
-          },
-          true // enabling
-        ).open();
-      } else {
-        // Semantic search is on but index missing — build it
-        const VectorStoreManager = (await import("@/search/vectorStoreManager")).default;
-        await VectorStoreManager.getInstance().indexVaultToVectorStore(false, {
-          userInitiated: true,
-        });
-        setRefresher(refresher + 1);
-      }
-    };
+    // A links-only result set signals the absence of Miyo scores directly. It
+    // must keep its rows visible while still showing download or setup help.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+    const hasSemanticMatches = relevantNotes.some((note) => note.metadata.similarityScore != null);
+    const guidance: RelevantNotesGuidance = hasSemanticMatches
+      ? null
+      : settings.enableMiyo
+        ? "setup"
+        : "download";
 
     return (
       <div className={cn("tw-flex tw-min-h-full tw-w-full tw-flex-1 tw-flex-col", className)}>
-        {isActiveFileExcluded && (
+        {isActiveFileExcluded ? (
           <div
             data-relevant-notes-empty-state
             className="tw-flex tw-flex-1 tw-flex-col tw-items-center tw-justify-center tw-px-6"
@@ -487,71 +400,26 @@ export const RelevantNotes = memo(
               </div>
             </div>
           </div>
-        )}
-
-        {!isActiveFileExcluded && !hasIndex && (
-          <div
-            data-relevant-notes-empty-state
-            className="tw-flex tw-flex-1 tw-flex-col tw-items-center tw-justify-center tw-px-6"
-          >
-            <div className="tw-flex tw-w-full tw-max-w-xs tw-flex-col tw-items-center tw-gap-6 tw-text-center">
-              <div className="tw-flex tw-size-16 tw-items-center tw-justify-center tw-rounded-xl tw-border tw-border-solid tw-border-border tw-bg-secondary">
-                <GitFork className="tw-size-7 tw-text-accent" />
-              </div>
-              <div className="tw-flex tw-flex-col tw-gap-1.5">
-                <span className="tw-text-lg tw-font-semibold tw-text-normal">
-                  No semantic index yet
-                </span>
-                <span className="tw-text-sm tw-text-muted">
-                  {"Build it once to surface notes related to whatever you're writing."}
-                </span>
-              </div>
-              <div className="tw-flex tw-w-full tw-flex-col tw-items-center tw-gap-3">
-                <Button
-                  variant="default"
-                  onClick={() => void handleBuildIndex()}
-                  className="tw-h-11 tw-w-full tw-gap-2 tw-rounded-lg"
-                >
-                  <GitFork className="tw-size-4" />
-                  Build index
-                </Button>
-              </div>
-            </div>
-          </div>
-        )}
-
-        {!isActiveFileExcluded && hasIndex && (
+        ) : (
           <>
-            <RelevantNotesToolbar
-              activeFileName={activeFile?.basename}
-              isBuilding={indexingState.isActive}
-              onBuild={() => void handleBuildIndex()}
-            />
+            <RelevantNotesToolbar activeFileName={activeFile?.basename} />
             <div className="tw-relative tw-min-h-0 tw-flex-1">
               <div className="tw-absolute tw-inset-0 tw-overflow-y-auto tw-p-2">
-                {relevantNotes.length === 0 ? (
-                  <div className="tw-flex tw-h-full tw-items-center tw-justify-center tw-px-4 tw-text-center">
-                    <span className="tw-text-sm tw-text-muted">No relevant notes found</span>
-                  </div>
-                ) : (
-                  <div className="tw-flex tw-flex-col tw-gap-0.5">
-                    {relevantNotes.map((note) => (
-                      <RelevantNoteRow
-                        key={note.note.path}
-                        note={note}
-                        onAddToChat={() => addToChat(note.note.title)}
-                        onNavigateToNote={() => navigateToNote(note.note.path)}
-                      />
-                    ))}
-                  </div>
-                )}
-              </div>
-              {indexingState.isActive && (
-                <BuildOverlay
-                  indexedCount={indexingState.indexedCount}
-                  totalFiles={indexingState.totalFiles}
+                <RelevantNotesPane
+                  guidance={guidance}
+                  noteCount={relevantNotes.length}
+                  noteRows={relevantNotes.map((note) => (
+                    <RelevantNoteRow
+                      key={note.note.path}
+                      note={note}
+                      onAddToChat={() => addToChat(note.note.title)}
+                      onNavigateToNote={() => navigateToNote(note.note.path)}
+                    />
+                  ))}
+                  miyoDownloadUrl={MIYO_HOMEPAGE_URL}
+                  onOpenMiyoSettings={(event) => openMiyoSettings(app, event.currentTarget.win)}
                 />
-              )}
+              </div>
             </div>
           </>
         )}

--- a/src/components/chat-components/RelevantNotes.tsx
+++ b/src/components/chat-components/RelevantNotes.tsx
@@ -25,6 +25,10 @@ import { Platform, TFile } from "obsidian";
 import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
 
 const EMPTY_RELEVANT_NOTES = Object.freeze([]) as unknown as RelevantNoteEntry[];
+const IDLE_RELEVANT_NOTES_RESULT = Object.freeze({
+  notes: EMPTY_RELEVANT_NOTES,
+  semanticState: "idle" as const,
+});
 const DISABLED_RELEVANT_NOTES_RESULT = Object.freeze({
   notes: EMPTY_RELEVANT_NOTES,
   semanticState: "disabled" as const,
@@ -52,11 +56,17 @@ function useRelevantNotes(enableMiyo: boolean, miyoServerUrl: string) {
     let cancelled = false;
 
     async function fetchNotes() {
+      // With no active Markdown note there is no source to query. Keep the
+      // neutral empty state instead of entering loading forever.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+      if (!activeFile?.path) {
+        setResult(IDLE_RELEVANT_NOTES_RESULT);
+        return;
+      }
       // Do not claim that Miyo is ready or unavailable while the request that
       // establishes its current state is still pending.
       // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
       setResult(enableMiyo ? LOADING_RELEVANT_NOTES_RESULT : DISABLED_RELEVANT_NOTES_RESULT);
-      if (!activeFile?.path) return;
       try {
         const notes = await findRelevantNotes({ app, filePath: activeFile.path });
         // A settings or active-note change can supersede an in-flight Miyo
@@ -407,7 +417,7 @@ export const RelevantNotes = memo(
           ? "unavailable"
           : result.semanticState === "not-indexed"
             ? "not-indexed"
-            : result.semanticState === "loading"
+            : result.semanticState === "loading" || result.semanticState === "idle"
               ? null
               : hasSemanticMatches
                 ? null

--- a/src/components/chat-components/RelevantNotes.tsx
+++ b/src/components/chat-components/RelevantNotes.tsx
@@ -10,18 +10,39 @@ import { useActiveFile } from "@/hooks/useActiveFile";
 import { useNoteDrag } from "@/hooks/useNoteDrag";
 import { cn } from "@/lib/utils";
 import { logError, logWarn } from "@/logger";
-import { findRelevantNotes, RelevantNoteEntry } from "@/search/findRelevantNotes";
+import { isLocalMiyoUrl, MIYO_DEEPLINK_URL } from "@/miyo/miyoUtils";
+import {
+  findRelevantNotes,
+  type RelevantNoteEntry,
+  type RelevantNotesResult,
+} from "@/search/findRelevantNotes";
 import { onIndexChanged } from "@/search/indexSignal";
 import { getMatchingPatterns, shouldIndexFile } from "@/search/searchUtils";
 import { openMiyoSettings } from "@/settings/openSettings";
 import { useSettingsValue } from "@/settings/model";
 import { ArrowRight, EyeOff, FileInput, FileOutput, FileText, PlusCircle } from "lucide-react";
-import { TFile } from "obsidian";
+import { Platform, TFile } from "obsidian";
 import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
+
+const EMPTY_RELEVANT_NOTES = Object.freeze([]) as unknown as RelevantNoteEntry[];
+const DISABLED_RELEVANT_NOTES_RESULT = Object.freeze({
+  notes: EMPTY_RELEVANT_NOTES,
+  semanticState: "disabled" as const,
+});
+const LOADING_RELEVANT_NOTES_RESULT = Object.freeze({
+  notes: EMPTY_RELEVANT_NOTES,
+  semanticState: "loading" as const,
+});
+const UNAVAILABLE_RELEVANT_NOTES_RESULT = Object.freeze({
+  notes: EMPTY_RELEVANT_NOTES,
+  semanticState: "unavailable" as const,
+});
 
 function useRelevantNotes(enableMiyo: boolean, miyoServerUrl: string) {
   const app = useApp();
-  const [relevantNotes, setRelevantNotes] = useState<RelevantNoteEntry[]>([]);
+  const [result, setResult] = useState<RelevantNotesResult>(
+    enableMiyo ? LOADING_RELEVANT_NOTES_RESULT : DISABLED_RELEVANT_NOTES_RESULT
+  );
   const [signalTick, setSignalTick] = useState(0);
   const activeFile = useActiveFile();
 
@@ -31,17 +52,23 @@ function useRelevantNotes(enableMiyo: boolean, miyoServerUrl: string) {
     let cancelled = false;
 
     async function fetchNotes() {
+      // Do not claim that Miyo is ready or unavailable while the request that
+      // establishes its current state is still pending.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+      setResult(enableMiyo ? LOADING_RELEVANT_NOTES_RESULT : DISABLED_RELEVANT_NOTES_RESULT);
       if (!activeFile?.path) return;
       try {
         const notes = await findRelevantNotes({ app, filePath: activeFile.path });
         // A settings or active-note change can supersede an in-flight Miyo
         // request. Its older result must not replace the newer pane state.
         // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
-        if (!cancelled) setRelevantNotes(notes);
+        if (!cancelled) setResult(notes);
       } catch (error) {
         if (!cancelled) {
           logWarn("Failed to fetch relevant notes", error);
-          setRelevantNotes([]);
+          setResult(
+            enableMiyo ? UNAVAILABLE_RELEVANT_NOTES_RESULT : DISABLED_RELEVANT_NOTES_RESULT
+          );
         }
       }
     }
@@ -52,7 +79,7 @@ function useRelevantNotes(enableMiyo: boolean, miyoServerUrl: string) {
     };
   }, [app, activeFile?.path, enableMiyo, miyoServerUrl, signalTick]);
 
-  return relevantNotes;
+  return result;
 }
 
 /** Map a 0–1 similarity score directly to the meter fill width (70% → 70%). */
@@ -343,7 +370,8 @@ export const RelevantNotes = memo(
     const app = useApp();
     const activeFile = useActiveFile();
     const settings = useSettingsValue();
-    const relevantNotes = useRelevantNotes(settings.enableMiyo, settings.miyoServerUrl);
+    const result = useRelevantNotes(settings.enableMiyo, settings.miyoServerUrl);
+    const relevantNotes = result.notes;
 
     // The active note itself is excluded from the index (by the QA
     // inclusion/exclusion settings or an internal exclusion), so no relevant
@@ -368,15 +396,26 @@ export const RelevantNotes = memo(
       onAddToChat(`[[${prompt}]]`);
     };
 
-    // A links-only result set signals the absence of Miyo scores directly. It
-    // must keep its rows visible while still showing download or setup help.
+    // Backend health distinguishes a healthy zero-match note from a broken
+    // setup. Link-only rows remain visible beneath whichever message applies.
     // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
     const hasSemanticMatches = relevantNotes.some((note) => note.metadata.similarityScore != null);
-    const guidance: RelevantNotesGuidance = hasSemanticMatches
-      ? null
-      : settings.enableMiyo
-        ? "setup"
-        : "download";
+    const guidance: RelevantNotesGuidance =
+      result.semanticState === "disabled"
+        ? "download"
+        : result.semanticState === "unavailable"
+          ? "unavailable"
+          : result.semanticState === "not-indexed"
+            ? "not-indexed"
+            : result.semanticState === "loading"
+              ? null
+              : hasSemanticMatches
+                ? null
+                : "no-matches";
+    // A local-app deeplink cannot configure the remote server used on mobile
+    // or by an explicit remote endpoint, so those runtimes stay in Copilot.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+    const canOpenMiyoApp = !Platform.isMobile && isLocalMiyoUrl(settings.miyoServerUrl);
 
     return (
       <div className={cn("tw-flex tw-min-h-full tw-w-full tw-flex-1 tw-flex-col", className)}>
@@ -405,20 +444,29 @@ export const RelevantNotes = memo(
             <RelevantNotesToolbar activeFileName={activeFile?.basename} />
             <div className="tw-relative tw-min-h-0 tw-flex-1">
               <div className="tw-absolute tw-inset-0 tw-overflow-y-auto tw-p-2">
-                <RelevantNotesPane
-                  guidance={guidance}
-                  noteCount={relevantNotes.length}
-                  noteRows={relevantNotes.map((note) => (
-                    <RelevantNoteRow
-                      key={note.note.path}
-                      note={note}
-                      onAddToChat={() => addToChat(note.note.title)}
-                      onNavigateToNote={() => navigateToNote(note.note.path)}
-                    />
-                  ))}
-                  miyoDownloadUrl={MIYO_HOMEPAGE_URL}
-                  onOpenMiyoSettings={(event) => openMiyoSettings(app, event.currentTarget.win)}
-                />
+                {/* A pending request has not established a semantic result or
+                    setup failure, so keep the pane neutral until it settles.
+                    https://github.com/Brevilabs/obsidian-copilot-private/issues/280 */}
+                {result.semanticState !== "loading" && (
+                  <RelevantNotesPane
+                    guidance={guidance}
+                    noteCount={relevantNotes.length}
+                    noteRows={relevantNotes.map((note) => (
+                      <RelevantNoteRow
+                        key={note.note.path}
+                        note={note}
+                        onAddToChat={() => addToChat(note.note.title)}
+                        onNavigateToNote={() => navigateToNote(note.note.path)}
+                      />
+                    ))}
+                    miyoDownloadUrl={MIYO_HOMEPAGE_URL}
+                    canOpenMiyoApp={canOpenMiyoApp}
+                    onOpenMiyoApp={(event) =>
+                      event.currentTarget.win.open(MIYO_DEEPLINK_URL, "_blank")
+                    }
+                    onOpenMiyoSettings={(event) => openMiyoSettings(app, event.currentTarget.win)}
+                  />
+                )}
               </div>
             </div>
           </>

--- a/src/components/chat-components/RelevantNotes.tsx
+++ b/src/components/chat-components/RelevantNotes.tsx
@@ -444,7 +444,7 @@ export const RelevantNotes = memo(
                 </span>
                 <span className="tw-text-sm tw-text-muted">
                   It falls outside your semantic index settings, so related notes can&apos;t be
-                  shown here. Adjust inclusions or exclusions in Copilot settings to include it.
+                  shown here. Adjust Index scope in the Miyo tab of Copilot settings to include it.
                 </span>
               </div>
             </div>

--- a/src/components/chat-components/ui/RelevantNotesPane.stories.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.stories.tsx
@@ -38,6 +38,8 @@ const baseArgs: RelevantNotesPaneProps = {
   noteCount: 2,
   noteRows: <NoteRows scored />,
   miyoDownloadUrl: "https://www.miyo.md/",
+  canOpenMiyoApp: true,
+  onOpenMiyoApp: () => undefined,
   onOpenMiyoSettings: () => undefined,
 };
 
@@ -61,5 +63,21 @@ export const LinksOnlyDownloadGuidance: StoryObj<RelevantNotesPaneProps> = {
 };
 
 export const LinksOnlySetupGuidance: StoryObj<RelevantNotesPaneProps> = {
-  args: { guidance: "setup", noteRows: <NoteRows scored={false} /> },
+  args: { guidance: "unavailable", noteRows: <NoteRows scored={false} /> },
+};
+
+export const EmptyNoSemanticMatches: StoryObj<RelevantNotesPaneProps> = {
+  args: { guidance: "no-matches", noteCount: 0, noteRows: null },
+};
+
+export const LinksOnlyNotIndexedGuidance: StoryObj<RelevantNotesPaneProps> = {
+  args: { guidance: "not-indexed", noteRows: <NoteRows scored={false} /> },
+};
+
+export const LinksOnlyNotIndexedRemoteGuidance: StoryObj<RelevantNotesPaneProps> = {
+  args: {
+    guidance: "not-indexed",
+    noteRows: <NoteRows scored={false} />,
+    canOpenMiyoApp: false,
+  },
 };

--- a/src/components/chat-components/ui/RelevantNotesPane.stories.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.stories.tsx
@@ -1,0 +1,65 @@
+import {
+  RelevantNotesPane,
+  type RelevantNotesPaneProps,
+} from "@/components/chat-components/ui/RelevantNotesPane";
+import type { Meta, StoryObj } from "@/lib/story";
+import { FileInput, FileOutput } from "lucide-react";
+import React from "react";
+
+function NoteRows({ scored }: { scored: boolean }) {
+  return (
+    <>
+      {[
+        { title: "Design principles", score: 0.86, outgoing: true, backlink: false },
+        { title: "Product research", score: 0.72, outgoing: false, backlink: true },
+      ].map((note) => (
+        <div
+          key={note.title}
+          className="tw-flex tw-min-h-8 tw-items-center tw-gap-2 tw-rounded-md tw-px-2.5 tw-py-1.5"
+        >
+          <span className="tw-min-w-0 tw-flex-1 tw-truncate tw-text-sm tw-font-medium tw-text-normal">
+            {note.title}
+          </span>
+          {note.outgoing && <FileOutput className="tw-size-3 tw-text-faint" />}
+          {note.backlink && <FileInput className="tw-size-3 tw-text-faint" />}
+          {scored && (
+            <span className="tw-text-xs tw-font-medium tw-tabular-nums tw-text-muted">
+              {Math.round(note.score * 100)}%
+            </span>
+          )}
+        </div>
+      ))}
+    </>
+  );
+}
+
+const baseArgs: RelevantNotesPaneProps = {
+  guidance: null,
+  noteCount: 2,
+  noteRows: <NoteRows scored />,
+  miyoDownloadUrl: "https://www.miyo.md/",
+  onOpenMiyoSettings: () => undefined,
+};
+
+const meta = {
+  title: "Chat/Relevant Notes Pane",
+  component: RelevantNotesPane,
+  args: baseArgs,
+  parameters: { gallery: { host: "leaf", layout: "fullscreen" } },
+} satisfies Meta<RelevantNotesPaneProps>;
+
+export default meta;
+
+export const ConnectedScoredResults: StoryObj<RelevantNotesPaneProps> = {};
+
+export const NoMiyoEmptyGuidance: StoryObj<RelevantNotesPaneProps> = {
+  args: { guidance: "download", noteCount: 0, noteRows: null },
+};
+
+export const LinksOnlyDownloadGuidance: StoryObj<RelevantNotesPaneProps> = {
+  args: { guidance: "download", noteRows: <NoteRows scored={false} /> },
+};
+
+export const LinksOnlySetupGuidance: StoryObj<RelevantNotesPaneProps> = {
+  args: { guidance: "setup", noteRows: <NoteRows scored={false} /> },
+};

--- a/src/components/chat-components/ui/RelevantNotesPane.test.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.test.tsx
@@ -1,0 +1,58 @@
+import { RelevantNotesPane, type RelevantNotesPaneProps } from "./RelevantNotesPane";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+const BASE_PROPS: RelevantNotesPaneProps = {
+  guidance: null,
+  noteCount: 1,
+  noteRows: <div>Related note</div>,
+  miyoDownloadUrl: "https://www.miyo.md/",
+  onOpenMiyoSettings: jest.fn(),
+};
+
+describe("RelevantNotesPane", () => {
+  describe("RelevantNotesPane()", () => {
+    it("renders scored results without setup guidance", () => {
+      render(<RelevantNotesPane {...BASE_PROPS} />);
+
+      expect(screen.getByText("Related note")).toBeTruthy();
+      expect(screen.queryByText(/Miyo/)).toBeNull();
+    });
+
+    it("shows honest download guidance when no Miyo scores exist, including beside link rows (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
+      render(<RelevantNotesPane {...BASE_PROPS} guidance="download" />);
+
+      expect(screen.getByText("Related note")).toBeTruthy();
+      expect(screen.getByText("Add semantic matches with Miyo")).toBeTruthy();
+      expect(screen.getByRole("link", { name: "Download Miyo" }).getAttribute("href")).toBe(
+        "https://www.miyo.md/"
+      );
+    });
+
+    it("shows setup guidance beside link rows and opens Copilot's Miyo tab (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
+      const onOpenMiyoSettings = jest.fn();
+      render(
+        <RelevantNotesPane
+          {...BASE_PROPS}
+          guidance="setup"
+          onOpenMiyoSettings={onOpenMiyoSettings}
+        />
+      );
+
+      expect(screen.getByText("Related note")).toBeTruthy();
+      expect(screen.getByText("Check your Miyo setup")).toBeTruthy();
+      expect(screen.queryByRole("link", { name: "Open Miyo" })).toBeNull();
+      fireEvent.click(screen.getByRole("button", { name: "Open Miyo settings" }));
+      expect(onOpenMiyoSettings).toHaveBeenCalledTimes(1);
+    });
+
+    it("centers download guidance when there are no notes or Miyo scores (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
+      render(
+        <RelevantNotesPane {...BASE_PROPS} guidance="download" noteCount={0} noteRows={null} />
+      );
+
+      expect(screen.getByText("Add semantic matches with Miyo")).toBeTruthy();
+      expect(screen.queryByText("No relevant notes found")).toBeNull();
+    });
+  });
+});

--- a/src/components/chat-components/ui/RelevantNotesPane.test.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.test.tsx
@@ -7,6 +7,8 @@ const BASE_PROPS: RelevantNotesPaneProps = {
   noteCount: 1,
   noteRows: <div>Related note</div>,
   miyoDownloadUrl: "https://www.miyo.md/",
+  canOpenMiyoApp: true,
+  onOpenMiyoApp: jest.fn(),
   onOpenMiyoSettings: jest.fn(),
 };
 
@@ -20,21 +22,22 @@ describe("RelevantNotesPane", () => {
     });
 
     it("shows honest download guidance when no Miyo scores exist, including beside link rows (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
-      render(<RelevantNotesPane {...BASE_PROPS} guidance="download" />);
+      const { container } = render(<RelevantNotesPane {...BASE_PROPS} guidance="download" />);
 
       expect(screen.getByText("Related note")).toBeTruthy();
       expect(screen.getByText("Add semantic matches with Miyo")).toBeTruthy();
       expect(screen.getByRole("link", { name: "Download Miyo" }).getAttribute("href")).toBe(
         "https://www.miyo.md/"
       );
+      expect(container.querySelector("[data-miyo-guidance]")?.className).toContain("tw-max-w-xs");
     });
 
     it("shows setup guidance beside link rows and opens Copilot's Miyo tab (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
       const onOpenMiyoSettings = jest.fn();
-      render(
+      const { container } = render(
         <RelevantNotesPane
           {...BASE_PROPS}
-          guidance="setup"
+          guidance="unavailable"
           onOpenMiyoSettings={onOpenMiyoSettings}
         />
       );
@@ -43,6 +46,55 @@ describe("RelevantNotesPane", () => {
       expect(screen.getByText("Check your Miyo setup")).toBeTruthy();
       expect(screen.queryByRole("link", { name: "Open Miyo" })).toBeNull();
       fireEvent.click(screen.getByRole("button", { name: "Open Miyo settings" }));
+      expect(onOpenMiyoSettings).toHaveBeenCalledTimes(1);
+      expect(container.querySelector("[data-miyo-guidance]")?.className).toContain("tw-max-w-xs");
+    });
+
+    it("shows a centered no-matches card without setup actions beside link rows (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
+      const { container } = render(<RelevantNotesPane {...BASE_PROPS} guidance="no-matches" />);
+
+      expect(screen.getByText("No semantic matches yet")).toBeTruthy();
+      expect(screen.getByText("Related note")).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Open Miyo settings" })).toBeNull();
+      expect(container.querySelector("[data-miyo-guidance]")?.className).toContain("tw-max-w-xs");
+    });
+
+    it("shows a centered not-indexed card without setup actions beside link rows (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
+      const onOpenMiyoApp = jest.fn();
+      const { container } = render(
+        <RelevantNotesPane {...BASE_PROPS} guidance="not-indexed" onOpenMiyoApp={onOpenMiyoApp} />
+      );
+
+      expect(screen.getByText("This note isn't indexed in Miyo")).toBeTruthy();
+      expect(
+        screen.getByText(
+          "It may still be indexing or be excluded from Miyo. Open Miyo to review this folder's indexing and exclusion settings."
+        )
+      ).toBeTruthy();
+      expect(screen.getByText("Related note")).toBeTruthy();
+      fireEvent.click(screen.getByRole("button", { name: "Open Miyo" }));
+      expect(onOpenMiyoApp).toHaveBeenCalledTimes(1);
+      expect(container.querySelector("[data-miyo-guidance]")?.className).toContain("tw-max-w-xs");
+    });
+
+    it("routes the not-indexed action to Copilot settings when a local Miyo app cannot be opened (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
+      const onOpenMiyoSettings = jest.fn();
+      render(
+        <RelevantNotesPane
+          {...BASE_PROPS}
+          guidance="not-indexed"
+          canOpenMiyoApp={false}
+          onOpenMiyoSettings={onOpenMiyoSettings}
+        />
+      );
+
+      expect(screen.queryByRole("button", { name: "Open Miyo" })).toBeNull();
+      expect(
+        screen.getByText(
+          "It may still be indexing or be excluded from Miyo. Review the configured Miyo connection or server in Copilot."
+        )
+      ).toBeTruthy();
+      fireEvent.click(screen.getByRole("button", { name: "Review Miyo connection" }));
       expect(onOpenMiyoSettings).toHaveBeenCalledTimes(1);
     });
 

--- a/src/components/chat-components/ui/RelevantNotesPane.test.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.test.tsx
@@ -29,7 +29,7 @@ describe("RelevantNotesPane", () => {
       expect(screen.getByRole("link", { name: "Download Miyo" }).getAttribute("href")).toBe(
         "https://www.miyo.md/"
       );
-      expect(container.querySelector("[data-miyo-guidance]")?.className).toContain("tw-max-w-xs");
+      expect(container.querySelector("[data-miyo-guidance]")?.className).toContain("tw-w-full");
     });
 
     it("shows setup guidance beside link rows and opens Copilot's Miyo tab (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
@@ -47,19 +47,19 @@ describe("RelevantNotesPane", () => {
       expect(screen.queryByRole("link", { name: "Open Miyo" })).toBeNull();
       fireEvent.click(screen.getByRole("button", { name: "Open Miyo settings" }));
       expect(onOpenMiyoSettings).toHaveBeenCalledTimes(1);
-      expect(container.querySelector("[data-miyo-guidance]")?.className).toContain("tw-max-w-xs");
+      expect(container.querySelector("[data-miyo-guidance]")?.className).toContain("tw-w-full");
     });
 
-    it("shows a centered no-matches card without setup actions beside link rows (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
+    it("shows a full-width no-matches card without setup actions beside link rows (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
       const { container } = render(<RelevantNotesPane {...BASE_PROPS} guidance="no-matches" />);
 
       expect(screen.getByText("No semantic matches yet")).toBeTruthy();
       expect(screen.getByText("Related note")).toBeTruthy();
       expect(screen.queryByRole("button", { name: "Open Miyo settings" })).toBeNull();
-      expect(container.querySelector("[data-miyo-guidance]")?.className).toContain("tw-max-w-xs");
+      expect(container.querySelector("[data-miyo-guidance]")?.className).toContain("tw-w-full");
     });
 
-    it("shows a centered not-indexed card without setup actions beside link rows (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
+    it("shows a full-width not-indexed card without setup actions beside link rows (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
       const onOpenMiyoApp = jest.fn();
       const { container } = render(
         <RelevantNotesPane {...BASE_PROPS} guidance="not-indexed" onOpenMiyoApp={onOpenMiyoApp} />
@@ -74,7 +74,7 @@ describe("RelevantNotesPane", () => {
       expect(screen.getByText("Related note")).toBeTruthy();
       fireEvent.click(screen.getByRole("button", { name: "Open Miyo" }));
       expect(onOpenMiyoApp).toHaveBeenCalledTimes(1);
-      expect(container.querySelector("[data-miyo-guidance]")?.className).toContain("tw-max-w-xs");
+      expect(container.querySelector("[data-miyo-guidance]")?.className).toContain("tw-w-full");
     });
 
     it("routes the not-indexed action to Copilot settings when a local Miyo app cannot be opened (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
@@ -98,7 +98,7 @@ describe("RelevantNotesPane", () => {
       expect(onOpenMiyoSettings).toHaveBeenCalledTimes(1);
     });
 
-    it("centers download guidance when there are no notes or Miyo scores (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
+    it("shows download guidance when there are no notes or Miyo scores (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
       render(
         <RelevantNotesPane {...BASE_PROPS} guidance="download" noteCount={0} noteRows={null} />
       );

--- a/src/components/chat-components/ui/RelevantNotesPane.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.tsx
@@ -1,0 +1,79 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { Download } from "lucide-react";
+import React from "react";
+
+export type RelevantNotesGuidance = "download" | "setup" | null;
+
+export interface RelevantNotesPaneProps {
+  guidance: RelevantNotesGuidance;
+  noteCount: number;
+  noteRows: React.ReactNode;
+  miyoDownloadUrl: string;
+  onOpenMiyoSettings: (event: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+/** Render the result, empty, and Miyo-help states without plugin or Obsidian runtime access. */
+export function RelevantNotesPane({
+  guidance,
+  noteCount,
+  noteRows,
+  miyoDownloadUrl,
+  onOpenMiyoSettings,
+}: RelevantNotesPaneProps): React.ReactElement {
+  const isDownload = guidance === "download";
+  // A links-only result set must keep its rows and show the same actionable
+  // guidance as an empty semantic result. Otherwise backlinks hide Miyo setup.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+  const guidancePanel = guidance ? (
+    <div
+      data-miyo-guidance={guidance}
+      className={cn(
+        "tw-flex tw-w-full tw-flex-col tw-gap-3 tw-rounded-lg tw-border tw-border-solid tw-border-border tw-bg-secondary tw-p-3",
+        noteCount === 0 && "tw-max-w-xs tw-items-center tw-p-5 tw-text-center"
+      )}
+    >
+      <div className="tw-flex tw-flex-col tw-gap-1">
+        <span className="tw-text-sm tw-font-semibold tw-text-normal">
+          {isDownload ? "Add semantic matches with Miyo" : "Check your Miyo setup"}
+        </span>
+        <span className="tw-text-xs tw-leading-normal tw-text-muted">
+          {isDownload
+            ? "Download Miyo, then connect it in Copilot settings. Links and backlinks still work without it."
+            : "Check your connection and make sure this vault is registered and indexed."}
+        </span>
+      </div>
+      <div className="tw-flex tw-flex-wrap tw-justify-center tw-gap-2">
+        {isDownload && (
+          <Button asChild variant="secondary" size="sm">
+            <a href={miyoDownloadUrl} target="_blank" rel="noopener noreferrer">
+              <Download className="tw-size-3.5" />
+              Download Miyo
+            </a>
+          </Button>
+        )}
+        <Button variant="default" size="sm" onClick={onOpenMiyoSettings}>
+          {isDownload ? "Set up in Copilot" : "Open Miyo settings"}
+        </Button>
+      </div>
+    </div>
+  ) : null;
+
+  if (noteCount === 0) {
+    return (
+      <div
+        data-relevant-notes-empty-state
+        className="tw-flex tw-h-full tw-items-center tw-justify-center tw-px-4"
+      >
+        {guidancePanel ?? <span className="tw-text-sm tw-text-muted">No relevant notes found</span>}
+      </div>
+    );
+  }
+
+  return (
+    <div className="tw-flex tw-flex-col tw-gap-2">
+      {guidancePanel}
+      <div className="tw-flex tw-flex-col tw-gap-0.5">{noteRows}</div>
+    </div>
+  );
+}

--- a/src/components/chat-components/ui/RelevantNotesPane.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.tsx
@@ -33,65 +33,63 @@ export function RelevantNotesPane({
   const isNoMatches = guidance === "no-matches";
   const isNotIndexed = guidance === "not-indexed";
   const isInformational = isNoMatches || isNotIndexed;
-  // A links-only result set must keep its rows beneath the same centered state
-  // card as an empty semantic result. Otherwise backlinks hide Miyo's status.
+  // A links-only result set must keep its rows beneath the same state card as
+  // an empty semantic result. Otherwise backlinks hide Miyo's status.
   // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
   const guidancePanel = guidance ? (
-    <div className="tw-flex tw-w-full tw-justify-center">
-      <div
-        data-miyo-guidance={guidance}
-        className="tw-flex tw-w-full tw-max-w-xs tw-flex-col tw-items-center tw-gap-3 tw-rounded-lg tw-border tw-border-solid tw-border-border tw-bg-secondary tw-p-5 tw-text-center"
-      >
-        <div className="tw-flex tw-flex-col tw-gap-1">
-          <span className="tw-text-sm tw-font-semibold tw-text-normal">
-            {isDownload
-              ? "Add semantic matches with Miyo"
-              : isNoMatches
-                ? "No semantic matches yet"
-                : isNotIndexed
-                  ? "This note isn't indexed in Miyo"
-                  : "Check your Miyo setup"}
-          </span>
-          <span className="tw-text-xs tw-leading-normal tw-text-muted">
-            {isDownload
-              ? "Download Miyo, then connect it in Copilot settings. Links and backlinks still work without it."
-              : isNoMatches
-                ? "Miyo is connected, but no related notes were found."
-                : isNotIndexed
-                  ? canOpenMiyoApp
-                    ? "It may still be indexing or be excluded from Miyo. Open Miyo to review this folder's indexing and exclusion settings."
-                    : "It may still be indexing or be excluded from Miyo. Review the configured Miyo connection or server in Copilot."
-                  : "Check your connection and make sure this vault is registered and indexed."}
-          </span>
-        </div>
-        {!isInformational && (
-          <div className="tw-flex tw-flex-wrap tw-justify-center tw-gap-2">
-            {isDownload && (
-              <Button asChild variant="secondary" size="sm">
-                <a href={miyoDownloadUrl} target="_blank" rel="noopener noreferrer">
-                  <Download className="tw-size-3.5" />
-                  Download Miyo
-                </a>
-              </Button>
-            )}
-            <Button variant="default" size="sm" onClick={onOpenMiyoSettings}>
-              {isDownload ? "Set up in Copilot" : "Open Miyo settings"}
-            </Button>
-          </div>
-        )}
-        {/* An unindexed source needs a configuration handoff, not install or
-            setup language. The container selects the runtime-safe destination.
-            https://github.com/Brevilabs/obsidian-copilot-private/issues/280 */}
-        {isNotIndexed && (
-          <Button
-            variant="default"
-            size="sm"
-            onClick={canOpenMiyoApp ? onOpenMiyoApp : onOpenMiyoSettings}
-          >
-            {canOpenMiyoApp ? "Open Miyo" : "Review Miyo connection"}
-          </Button>
-        )}
+    <div
+      data-miyo-guidance={guidance}
+      className="tw-flex tw-w-full tw-flex-col tw-items-start tw-gap-3 tw-rounded-lg tw-border tw-border-solid tw-border-border tw-bg-secondary tw-p-4"
+    >
+      <div className="tw-flex tw-flex-col tw-gap-1">
+        <span className="tw-text-sm tw-font-semibold tw-text-normal">
+          {isDownload
+            ? "Add semantic matches with Miyo"
+            : isNoMatches
+              ? "No semantic matches yet"
+              : isNotIndexed
+                ? "This note isn't indexed in Miyo"
+                : "Check your Miyo setup"}
+        </span>
+        <span className="tw-text-xs tw-leading-normal tw-text-muted">
+          {isDownload
+            ? "Download Miyo, then connect it in Copilot settings. Links and backlinks still work without it."
+            : isNoMatches
+              ? "Miyo is connected, but no related notes were found."
+              : isNotIndexed
+                ? canOpenMiyoApp
+                  ? "It may still be indexing or be excluded from Miyo. Open Miyo to review this folder's indexing and exclusion settings."
+                  : "It may still be indexing or be excluded from Miyo. Review the configured Miyo connection or server in Copilot."
+                : "Check your connection and make sure this vault is registered and indexed."}
+        </span>
       </div>
+      {!isInformational && (
+        <div className="tw-flex tw-flex-wrap tw-gap-2">
+          {isDownload && (
+            <Button asChild variant="secondary" size="sm">
+              <a href={miyoDownloadUrl} target="_blank" rel="noopener noreferrer">
+                <Download className="tw-size-3.5" />
+                Download Miyo
+              </a>
+            </Button>
+          )}
+          <Button variant="default" size="sm" onClick={onOpenMiyoSettings}>
+            {isDownload ? "Set up in Copilot" : "Open Miyo settings"}
+          </Button>
+        </div>
+      )}
+      {/* An unindexed source needs a configuration handoff, not install or
+          setup language. The container selects the runtime-safe destination.
+          https://github.com/Brevilabs/obsidian-copilot-private/issues/280 */}
+      {isNotIndexed && (
+        <Button
+          variant="default"
+          size="sm"
+          onClick={canOpenMiyoApp ? onOpenMiyoApp : onOpenMiyoSettings}
+        >
+          {canOpenMiyoApp ? "Open Miyo" : "Review Miyo connection"}
+        </Button>
+      )}
     </div>
   ) : null;
 
@@ -99,7 +97,7 @@ export function RelevantNotesPane({
     return (
       <div
         data-relevant-notes-empty-state
-        className="tw-flex tw-h-full tw-items-center tw-justify-center tw-px-4"
+        className="tw-flex tw-h-full tw-items-center tw-justify-center"
       >
         {guidancePanel ?? <span className="tw-text-sm tw-text-muted">No relevant notes found</span>}
       </div>

--- a/src/components/chat-components/ui/RelevantNotesPane.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.tsx
@@ -1,15 +1,21 @@
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
 import { Download } from "lucide-react";
 import React from "react";
 
-export type RelevantNotesGuidance = "download" | "setup" | null;
+export type RelevantNotesGuidance =
+  | "download"
+  | "unavailable"
+  | "no-matches"
+  | "not-indexed"
+  | null;
 
 export interface RelevantNotesPaneProps {
   guidance: RelevantNotesGuidance;
   noteCount: number;
   noteRows: React.ReactNode;
   miyoDownloadUrl: string;
+  canOpenMiyoApp: boolean;
+  onOpenMiyoApp: (event: React.MouseEvent<HTMLButtonElement>) => void;
   onOpenMiyoSettings: (event: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
@@ -19,42 +25,72 @@ export function RelevantNotesPane({
   noteCount,
   noteRows,
   miyoDownloadUrl,
+  canOpenMiyoApp,
+  onOpenMiyoApp,
   onOpenMiyoSettings,
 }: RelevantNotesPaneProps): React.ReactElement {
   const isDownload = guidance === "download";
-  // A links-only result set must keep its rows and show the same actionable
-  // guidance as an empty semantic result. Otherwise backlinks hide Miyo setup.
+  const isNoMatches = guidance === "no-matches";
+  const isNotIndexed = guidance === "not-indexed";
+  const isInformational = isNoMatches || isNotIndexed;
+  // A links-only result set must keep its rows beneath the same centered state
+  // card as an empty semantic result. Otherwise backlinks hide Miyo's status.
   // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
   const guidancePanel = guidance ? (
-    <div
-      data-miyo-guidance={guidance}
-      className={cn(
-        "tw-flex tw-w-full tw-flex-col tw-gap-3 tw-rounded-lg tw-border tw-border-solid tw-border-border tw-bg-secondary tw-p-3",
-        noteCount === 0 && "tw-max-w-xs tw-items-center tw-p-5 tw-text-center"
-      )}
-    >
-      <div className="tw-flex tw-flex-col tw-gap-1">
-        <span className="tw-text-sm tw-font-semibold tw-text-normal">
-          {isDownload ? "Add semantic matches with Miyo" : "Check your Miyo setup"}
-        </span>
-        <span className="tw-text-xs tw-leading-normal tw-text-muted">
-          {isDownload
-            ? "Download Miyo, then connect it in Copilot settings. Links and backlinks still work without it."
-            : "Check your connection and make sure this vault is registered and indexed."}
-        </span>
-      </div>
-      <div className="tw-flex tw-flex-wrap tw-justify-center tw-gap-2">
-        {isDownload && (
-          <Button asChild variant="secondary" size="sm">
-            <a href={miyoDownloadUrl} target="_blank" rel="noopener noreferrer">
-              <Download className="tw-size-3.5" />
-              Download Miyo
-            </a>
+    <div className="tw-flex tw-w-full tw-justify-center">
+      <div
+        data-miyo-guidance={guidance}
+        className="tw-flex tw-w-full tw-max-w-xs tw-flex-col tw-items-center tw-gap-3 tw-rounded-lg tw-border tw-border-solid tw-border-border tw-bg-secondary tw-p-5 tw-text-center"
+      >
+        <div className="tw-flex tw-flex-col tw-gap-1">
+          <span className="tw-text-sm tw-font-semibold tw-text-normal">
+            {isDownload
+              ? "Add semantic matches with Miyo"
+              : isNoMatches
+                ? "No semantic matches yet"
+                : isNotIndexed
+                  ? "This note isn't indexed in Miyo"
+                  : "Check your Miyo setup"}
+          </span>
+          <span className="tw-text-xs tw-leading-normal tw-text-muted">
+            {isDownload
+              ? "Download Miyo, then connect it in Copilot settings. Links and backlinks still work without it."
+              : isNoMatches
+                ? "Miyo is connected, but no related notes were found."
+                : isNotIndexed
+                  ? canOpenMiyoApp
+                    ? "It may still be indexing or be excluded from Miyo. Open Miyo to review this folder's indexing and exclusion settings."
+                    : "It may still be indexing or be excluded from Miyo. Review the configured Miyo connection or server in Copilot."
+                  : "Check your connection and make sure this vault is registered and indexed."}
+          </span>
+        </div>
+        {!isInformational && (
+          <div className="tw-flex tw-flex-wrap tw-justify-center tw-gap-2">
+            {isDownload && (
+              <Button asChild variant="secondary" size="sm">
+                <a href={miyoDownloadUrl} target="_blank" rel="noopener noreferrer">
+                  <Download className="tw-size-3.5" />
+                  Download Miyo
+                </a>
+              </Button>
+            )}
+            <Button variant="default" size="sm" onClick={onOpenMiyoSettings}>
+              {isDownload ? "Set up in Copilot" : "Open Miyo settings"}
+            </Button>
+          </div>
+        )}
+        {/* An unindexed source needs a configuration handoff, not install or
+            setup language. The container selects the runtime-safe destination.
+            https://github.com/Brevilabs/obsidian-copilot-private/issues/280 */}
+        {isNotIndexed && (
+          <Button
+            variant="default"
+            size="sm"
+            onClick={canOpenMiyoApp ? onOpenMiyoApp : onOpenMiyoSettings}
+          >
+            {canOpenMiyoApp ? "Open Miyo" : "Review Miyo connection"}
           </Button>
         )}
-        <Button variant="default" size="sm" onClick={onOpenMiyoSettings}>
-          {isDownload ? "Set up in Copilot" : "Open Miyo settings"}
-        </Button>
       </div>
     </div>
   ) : null;

--- a/src/components/ui/setting-section.stories.tsx
+++ b/src/components/ui/setting-section.stories.tsx
@@ -16,7 +16,7 @@ export const TitleAndDescription: StoryObj<SettingSectionProps> = {
   args: {
     label: "Index scope",
     description:
-      "Which notes Copilot searches and shows in Relevant Notes; your Copilot folder is always excluded. Miyo's own index keeps the scope it was registered with until you re-add this folder in the Miyo app.",
+      "Which notes Copilot searches and shows in Relevant Notes; your Copilot folder is always excluded. Folder and file-extension changes also update this vault's Miyo index without widening stricter filters set in Miyo.",
     children: (
       <SettingItem
         type="custom"

--- a/src/components/ui/setting-section.stories.tsx
+++ b/src/components/ui/setting-section.stories.tsx
@@ -1,0 +1,30 @@
+import { SettingItem } from "@/components/ui/setting-item";
+import type { Meta, StoryObj } from "@/lib/story";
+import * as React from "react";
+import { SettingSection } from "./setting-section";
+
+type SettingSectionProps = React.ComponentProps<typeof SettingSection>;
+
+const meta = {
+  title: "UI/Setting Section",
+  component: SettingSection,
+  parameters: { gallery: { host: "settings-tab", layout: "padded" } },
+} satisfies Meta<SettingSectionProps>;
+export default meta;
+
+export const TitleAndDescription: StoryObj<SettingSectionProps> = {
+  args: {
+    label: "Index scope",
+    description:
+      "Which notes Copilot searches and shows in Relevant Notes; your Copilot folder is always excluded. Miyo's own index keeps the scope it was registered with until you re-add this folder in the Miyo app.",
+    children: (
+      <SettingItem
+        type="custom"
+        title="Exclusions"
+        description="Skip these folders, tags, notes, or file extensions."
+      >
+        <div />
+      </SettingItem>
+    ),
+  },
+};

--- a/src/components/ui/setting-section.test.tsx
+++ b/src/components/ui/setting-section.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { SettingSection } from "./setting-section";
+
+describe("setting-section", () => {
+  describe("SettingSection()", () => {
+    it("renders the section title larger than its supporting description", () => {
+      render(
+        <SettingSection label="Index scope" description="Which notes Copilot searches.">
+          <div>Settings</div>
+        </SettingSection>
+      );
+
+      expect(screen.getByText("Index scope").className).toContain("tw-text-sm");
+      expect(screen.getByText("Which notes Copilot searches.").className).toContain("tw-text-xs");
+    });
+  });
+});

--- a/src/components/ui/setting-section.tsx
+++ b/src/components/ui/setting-section.tsx
@@ -52,8 +52,8 @@ export function SettingSection({
     <div className={cn("tw-space-y-2", className)}>
       {(label || description) && (
         <div className="tw-space-y-1">
-          {label && <div className="tw-text-xs tw-font-semibold tw-text-muted">{label}</div>}
-          {description && <div className="tw-text-sm tw-text-muted">{description}</div>}
+          {label && <div className="tw-text-sm tw-font-semibold tw-text-muted">{label}</div>}
+          {description && <div className="tw-text-xs tw-text-muted">{description}</div>}
         </div>
       )}
       {gated && gateNotice && (

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1001,6 +1001,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   miyoSearchAll: false,
   miyoServerUrl: "",
   miyoSyncedExclusions: "",
+  miyoSyncedIndexScope: "",
   selfHostSearchProvider: "firecrawl",
   firecrawlApiKey: "",
   perplexityApiKey: "",

--- a/src/contexts/TabContext.tsx
+++ b/src/contexts/TabContext.tsx
@@ -7,8 +7,14 @@ interface TabContextType {
 
 const TabContext = createContext<TabContextType | undefined>(undefined);
 
-export const TabProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [selectedTab, setSelectedTab] = useState("basic");
+export const TabProvider: React.FC<{ children: React.ReactNode; initialTab?: string }> = ({
+  children,
+  initialTab = "basic",
+}) => {
+  // Obsidian creates a fresh settings tree for a one-shot Relevant Notes
+  // handoff, so that tree must be able to start on Miyo instead of Basic.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+  const [selectedTab, setSelectedTab] = useState(initialTab);
 
   const value = useMemo(() => ({ selectedTab, setSelectedTab }), [selectedTab]);
 

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -23,6 +23,7 @@ jest.mock("@/logger", () => ({
 jest.mock("@/miyo/miyoResync", () => ({
   resetMiyoMutations: jest.fn(),
   startMiyoMutationSession: jest.fn(),
+  syncMiyoIndexScopeChange: jest.fn().mockResolvedValue("unchanged"),
 }));
 jest.mock("@/services/settingsPersistence", () => ({
   flushPersistence: jest.fn().mockResolvedValue(undefined),

--- a/src/main.ts
+++ b/src/main.ts
@@ -72,7 +72,11 @@ import {
   updateSetting,
 } from "@/settings/model";
 import { didMiyoSyncedRootsChange, shouldSurfaceMiyoResync } from "@/miyo/miyoUtils";
-import { type MiyoMutationSession, resetMiyoMutations } from "@/miyo/miyoResync";
+import {
+  type MiyoMutationSession,
+  resetMiyoMutations,
+  syncMiyoIndexScopeChange,
+} from "@/miyo/miyoResync";
 import { ensureCopilotSubfolders, getEffectiveConversationsFolder } from "@/settings/copilotFolder";
 import { buildUpgradeRelocationEntries } from "@/settings/upgradeNotice";
 import { dehydrateDeviceProfile, hydrateDeviceProfile } from "@/settings/deviceProfiles";
@@ -234,6 +238,11 @@ export default class CopilotPlugin extends Plugin {
     // from disk without firing the subscription, so register on load.
     syncPlus(getSettings().isPaidUser, getSettings().plusLicenseKey);
     this.settingsUnsubscriber = subscribeToSettingsChange((prev, next) => {
+      // Keep the registered Miyo folder aligned even when this change came from
+      // Obsidian Sync or another settings surface while the Miyo tab was closed.
+      // The reconciler no-ops for unrelated settings and unconfigured Miyo.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/310
+      void syncMiyoIndexScopeChange(this.app, prev, next, this.miyoMutationSession);
       void (async () => {
         try {
           await persistSettings(next, (data) => this.saveData(data), prev);

--- a/src/miyo/MiyoClient.test.ts
+++ b/src/miyo/MiyoClient.test.ts
@@ -1,5 +1,5 @@
 import { logInfo } from "@/logger";
-import { MiyoClient } from "@/miyo/MiyoClient";
+import { MiyoClient, MiyoRequestError } from "@/miyo/MiyoClient";
 import { MiyoServiceDiscovery } from "@/miyo/MiyoServiceDiscovery";
 import { getSettings } from "@/settings/model";
 import { requestUrl, type RequestUrlResponse } from "obsidian";
@@ -44,6 +44,24 @@ describe("MiyoClient", () => {
     mockResolveBaseUrl.mockResolvedValue("http://127.0.0.1:8742");
     mockedGetInstance.mockReturnValue({
       resolveBaseUrl: mockResolveBaseUrl,
+    });
+  });
+
+  describe("MiyoRequestError", () => {
+    describe("constructor()", () => {
+      it("preserves the Miyo status and detail without changing the request message (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
+        const error = new MiyoRequestError(404, "folder not registered");
+        const errorWithoutDetail = new MiyoRequestError(503, "");
+
+        expect(error).toBeInstanceOf(Error);
+        expect(error).toMatchObject({
+          name: "MiyoRequestError",
+          status: 404,
+          detail: "folder not registered",
+          message: "Miyo request failed with status 404: folder not registered",
+        });
+        expect(errorWithoutDetail.message).toBe("Miyo request failed with status 503");
+      });
     });
   });
 
@@ -160,7 +178,7 @@ describe("MiyoClient", () => {
     );
   });
 
-  it("throws detailed errors when a request fails", async () => {
+  it("throws a structured request error with the response status and detail (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
     mockedRequestUrl.mockResolvedValue({
       status: 404,
       text: "not found",
@@ -169,9 +187,12 @@ describe("MiyoClient", () => {
 
     const client = new MiyoClient();
 
-    await expect(client.getFolder("http://127.0.0.1:8742", "/vault")).rejects.toThrow(
-      "Miyo request failed with status 404: folder not registered"
-    );
+    await expect(client.getFolder("http://127.0.0.1:8742", "/vault")).rejects.toMatchObject({
+      name: "MiyoRequestError",
+      status: 404,
+      detail: "folder not registered",
+      message: "Miyo request failed with status 404: folder not registered",
+    });
   });
 
   describe("checkFolderRegistration", () => {

--- a/src/miyo/MiyoClient.test.ts
+++ b/src/miyo/MiyoClient.test.ts
@@ -403,6 +403,49 @@ describe("MiyoClient", () => {
     });
   });
 
+  describe("updateFolder()", () => {
+    it("PATCHes the registered folder with only the supplied scope fields (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)", async () => {
+      const folderRecord = { path: "my-vault", exclude_folders: ["copilot", "private"] };
+      mockedRequestUrl.mockResolvedValue({
+        status: 200,
+        json: folderRecord,
+        text: "",
+      } as RequestUrlResponse);
+
+      const client = new MiyoClient();
+      const result = await client.updateFolder({
+        path: "my-vault",
+        exclude_folders: ["copilot", "private"],
+      });
+
+      expect(result).toEqual(folderRecord);
+      expect(mockedRequestUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "http://127.0.0.1:8742/v0/folder",
+          method: "PATCH",
+          contentType: "application/json",
+          body: JSON.stringify({
+            path: "my-vault",
+            exclude_folders: ["copilot", "private"],
+          }),
+        })
+      );
+    });
+
+    it("does not PATCH after the caller's lifecycle guard expires (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)", async () => {
+      const client = new MiyoClient();
+
+      await expect(
+        client.updateFolder({ path: "my-vault", exclude_folders: ["Private"] }, undefined, () => {
+          throw new Error("lifecycle expired");
+        })
+      ).rejects.toThrow("lifecycle expired");
+
+      expect(mockResolveBaseUrl).toHaveBeenCalled();
+      expect(mockedRequestUrl).not.toHaveBeenCalled();
+    });
+  });
+
   describe("deleteFolder", () => {
     it("DELETEs /v0/folder with the folder name in the JSON body", async () => {
       mockedRequestUrl.mockResolvedValue({

--- a/src/miyo/MiyoClient.ts
+++ b/src/miyo/MiyoClient.ts
@@ -83,6 +83,16 @@ export interface MiyoAddFolderRequest {
   allow_remote_read?: boolean;
 }
 
+/** Index-scope fields accepted by Miyo's in-place folder update endpoint. */
+export interface MiyoUpdateFolderRequest {
+  path: string;
+  include_extensions?: string[];
+  include_folders?: string[];
+  exclude_folders?: string[];
+  include_patterns?: string[];
+  exclude_patterns?: string[];
+}
+
 /**
  * Whether a vault folder is registered with Miyo, as a discriminated result
  * rather than a thrown error — so the connect flow can branch on it directly:
@@ -367,6 +377,27 @@ export class MiyoClient {
         ? `Miyo add-folder failed with status ${response.status}: ${detail}`
         : `Miyo add-folder failed with status ${response.status}`
     );
+  }
+
+  /**
+   * Update a registered folder's index scope without replacing its registration.
+   *
+   * @param request - Folder identifier and only the scope fields to change.
+   * @param overrideUrl - Explicit base URL or empty for local service discovery.
+   * @param beforeRequest - Final lifecycle guard before the request leaves.
+   * @returns The updated folder record.
+   */
+  public async updateFolder(
+    request: MiyoUpdateFolderRequest,
+    overrideUrl?: string,
+    beforeRequest?: () => void
+  ): Promise<MiyoFolderEntry> {
+    const baseUrl = await this.resolveBaseUrl(overrideUrl);
+    return this.requestJson<MiyoFolderEntry>(baseUrl, "/v0/folder", {
+      method: "PATCH",
+      body: request,
+      beforeRequest,
+    });
   }
 
   /**
@@ -677,9 +708,10 @@ export class MiyoClient {
     baseUrl: string,
     path: string,
     options: {
-      method: "GET" | "POST" | "DELETE";
+      method: "GET" | "POST" | "PATCH" | "DELETE";
       body?: unknown;
       query?: Record<string, string | number | boolean | undefined>;
+      beforeRequest?: () => void;
     }
   ): Promise<T> {
     const url = new URL(path, baseUrl);
@@ -693,6 +725,11 @@ export class MiyoClient {
 
     const body = options.body ? JSON.stringify(options.body) : undefined;
     const headers = await this.buildHeaders();
+    // Folder mutations can outlive their vault while URL and credentials
+    // resolve. Give their lifecycle owner the final refusal point before the
+    // uncancellable request leaves.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/310
+    options.beforeRequest?.();
     logInfo("Miyo request:", {
       method: options.method,
       url: url.toString(),

--- a/src/miyo/MiyoClient.ts
+++ b/src/miyo/MiyoClient.ts
@@ -13,6 +13,27 @@ export type {
 } from "@/miyo/miyoHealth";
 
 /**
+ * Represents an HTTP error returned by Miyo while leaving transport and
+ * endpoint-specific recovery decisions to the caller.
+ */
+export class MiyoRequestError extends Error {
+  public constructor(
+    public readonly status: number,
+    public readonly detail: string
+  ) {
+    // Some Miyo failures have no response body; retaining the prior status-only
+    // message keeps those callers stable while exposing structured fields.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+    super(
+      detail
+        ? `Miyo request failed with status ${status}: ${detail}`
+        : `Miyo request failed with status ${status}`
+    );
+    this.name = "MiyoRequestError";
+  }
+}
+
+/**
  * Indexed file entry returned by Miyo.
  */
 export interface MiyoIndexedFileEntry {
@@ -696,11 +717,10 @@ export class MiyoClient {
       );
       const errorText = errorPayload?.detail || response.text || "";
       logWarn(`Miyo request failed (${response.status}): ${errorText}`);
-      throw new Error(
-        errorText
-          ? `Miyo request failed with status ${response.status}: ${errorText}`
-          : `Miyo request failed with status ${response.status}`
-      );
+      // Relevant Notes must distinguish an unindexed source from a service
+      // outage without parsing human-readable error messages.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+      throw new MiyoRequestError(response.status, errorText);
     }
 
     const parsed = this.parseResponseJson<T>(response.json, response.text);

--- a/src/miyo/miyoResync.test.ts
+++ b/src/miyo/miyoResync.test.ts
@@ -15,6 +15,7 @@ const getFolder = jest.fn<Promise<unknown>, unknown[]>();
 const checkFolderRegistration = jest.fn<Promise<string>, unknown[]>();
 const deleteFolder = jest.fn<Promise<void>, unknown[]>();
 const addFolder = jest.fn<Promise<unknown>, unknown[]>();
+const updateFolder = jest.fn<Promise<unknown>, unknown[]>();
 const scanFolder = jest.fn<Promise<unknown>, unknown[]>();
 jest.mock("@/miyo/MiyoClient", () => ({
   MiyoClient: class {
@@ -32,6 +33,10 @@ jest.mock("@/miyo/MiyoClient", () => ({
     addFolder = (request: unknown, url: unknown, beforeRequest?: () => void) => {
       beforeRequest?.();
       return addFolder(request, url, beforeRequest);
+    };
+    updateFolder = (request: unknown, url: unknown, beforeRequest?: () => void) => {
+      beforeRequest?.();
+      return updateFolder(request, url, beforeRequest);
     };
     scanFolder = (...a: unknown[]) => scanFolder(...a);
   },
@@ -51,13 +56,15 @@ jest.mock("@/settings/model", () => ({
 
 jest.mock("@/utils/vaultPath", () => ({ getVaultBase: jest.fn(() => "/abs/vault") }));
 
-import type { App } from "obsidian";
+import { Notice, type App } from "obsidian";
 import type { MiyoAddFolderRequest, MiyoFolderEntry } from "@/miyo/MiyoClient";
 import {
+  buildMiyoIndexScopeReceipt,
   enqueueMiyoFolderMutation,
   miyoRecordCoversSystemRoots,
   resetMiyoMutations,
   resyncMiyoFolder,
+  syncMiyoIndexScopeChange,
   verifyMiyoScope,
 } from "@/miyo/miyoResync";
 import type { MiyoMutationSession } from "@/miyo/miyoResync";
@@ -122,6 +129,7 @@ beforeEach(() => {
   resolveBaseUrl.mockResolvedValue("http://miyo");
   deleteFolder.mockResolvedValue(undefined);
   addFolder.mockResolvedValue(record());
+  updateFolder.mockResolvedValue(record());
   scanFolder.mockResolvedValue({});
 });
 
@@ -135,6 +143,297 @@ function rootMovedSettings(): void {
 }
 
 describe("miyoResync", () => {
+  describe("buildMiyoIndexScopeReceipt()", () => {
+    it("records only Miyo-representable Copilot filters with the current registration identity (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)", () => {
+      const settings = {
+        ...currentSettings,
+        qaExclusions: "Private,*.pdf,#draft",
+        qaInclusions: "Notes,*.md",
+      } as CopilotSettings;
+
+      expect(JSON.parse(buildMiyoIndexScopeReceipt(app, settings))).toEqual({
+        device: "device-A",
+        url: "",
+        folder: "my-vault",
+        include_extensions: ["md"],
+        include_folders: ["Notes"],
+        exclude_folders: ["Private"],
+        include_patterns: [],
+        exclude_patterns: ["**/*.pdf"],
+      });
+    });
+  });
+
+  describe("syncMiyoIndexScopeChange()", () => {
+    it("replaces Copilot's prior filters while retaining Miyo-owned scope (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)", async () => {
+      const previous = {
+        ...currentSettings,
+        enableMiyo: true,
+        qaExclusions: "copilot,Private,*.pdf",
+        qaInclusions: "Notes",
+      } as unknown as CopilotSettings;
+      const next = {
+        ...previous,
+        qaExclusions: "copilot,Archive,*.canvas",
+        qaInclusions: "Projects",
+      };
+      getFolder.mockResolvedValue(
+        record({
+          exclude_folders: ["copilot", "Private", "MiyoOnly"],
+          exclude_patterns: ["**/*.pdf", "**/miyo-secret/**"],
+          include_folders: ["Notes", "MiyoPinned"],
+        })
+      );
+
+      await expect(syncMiyoIndexScopeChange(app, previous, next, session)).resolves.toBe("synced");
+
+      expect(updateFolder).toHaveBeenCalledWith(
+        {
+          path: "my-vault",
+          exclude_folders: ["MiyoOnly", "copilot", "Archive"],
+          exclude_patterns: ["**/miyo-secret/**", "**/*.canvas"],
+          include_folders: ["MiyoPinned"],
+          include_patterns: [],
+          include_extensions: [],
+        },
+        undefined,
+        expect.any(Function)
+      );
+      expect(deleteFolder).not.toHaveBeenCalled();
+      expect(addFolder).not.toHaveBeenCalled();
+      const receiptWrite = updateSetting.mock.calls.find(([key]) => key === "miyoSyncedIndexScope");
+      expect(JSON.parse(receiptWrite?.[1] as string)).toMatchObject({
+        include_folders: [],
+        include_patterns: [],
+        include_extensions: [],
+      });
+    });
+
+    it("does nothing when neither persisted scope value changed (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)", async () => {
+      const previous = { ...currentSettings, enableMiyo: true } as CopilotSettings;
+      const next = { ...previous, debug: true } as CopilotSettings;
+
+      await expect(syncMiyoIndexScopeChange(app, previous, next, session)).resolves.toBe(
+        "unchanged"
+      );
+
+      expect(getFolder).not.toHaveBeenCalled();
+      expect(updateFolder).not.toHaveBeenCalled();
+    });
+
+    it("keeps a local-only edit off the network before Miyo has been configured (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)", async () => {
+      const previous = {
+        ...currentSettings,
+        enableMiyo: false,
+        miyoSyncedExclusions: "",
+      } as CopilotSettings;
+      const next = { ...previous, qaExclusions: "copilot,Private" };
+
+      await expect(syncMiyoIndexScopeChange(app, previous, next, session)).resolves.toBe(
+        "not-configured"
+      );
+
+      expect(resolveBaseUrl).not.toHaveBeenCalled();
+      expect(updateFolder).not.toHaveBeenCalled();
+    });
+
+    it("does not treat another device's synced receipts as a local Miyo registration (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)", async () => {
+      const previous = {
+        ...currentSettings,
+        enableMiyo: false,
+        miyoSyncedExclusions: receiptFor({ device: "device-B" }),
+        miyoSyncedIndexScope: JSON.stringify({
+          device: "device-B",
+          url: "",
+          folder: "my-vault",
+          exclude_folders: ["copilot"],
+          exclude_patterns: [],
+          include_folders: [],
+          include_patterns: [],
+          include_extensions: [],
+        }),
+      } as unknown as CopilotSettings;
+      const next = { ...previous, qaExclusions: "copilot,Private" };
+
+      await expect(syncMiyoIndexScopeChange(app, previous, next, session)).resolves.toBe(
+        "not-configured"
+      );
+
+      expect(resolveBaseUrl).not.toHaveBeenCalled();
+      expect(updateFolder).not.toHaveBeenCalled();
+    });
+
+    it("keeps tag and note changes local because Miyo cannot represent them (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)", async () => {
+      const previous = {
+        ...currentSettings,
+        enableMiyo: true,
+        qaExclusions: "copilot,#draft",
+        qaInclusions: "[[Roadmap]]",
+      } as CopilotSettings;
+      const next = {
+        ...previous,
+        qaExclusions: "copilot,#private",
+        qaInclusions: "[[Launch plan]]",
+      };
+
+      await expect(syncMiyoIndexScopeChange(app, previous, next, session)).resolves.toBe(
+        "unchanged"
+      );
+
+      expect(getFolder).not.toHaveBeenCalled();
+      expect(updateFolder).not.toHaveBeenCalled();
+    });
+
+    it("reports a failed sync without rolling back the Copilot setting (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)", async () => {
+      const previous = { ...currentSettings, enableMiyo: true } as CopilotSettings;
+      const next = { ...previous, qaExclusions: "copilot,Private" };
+      getFolder.mockRejectedValue(new Error("Miyo unavailable"));
+
+      await expect(syncMiyoIndexScopeChange(app, previous, next, session)).resolves.toBe("failed");
+
+      expect(Notice).toHaveBeenCalledWith(
+        "Index scope was saved in Copilot, but Miyo couldn't be updated. Make sure Miyo is running, then change the scope again."
+      );
+      expect(updateSetting).not.toHaveBeenCalledWith("qaExclusions", expect.anything());
+      expect(updateFolder).not.toHaveBeenCalled();
+    });
+
+    it("applies rapid scope edits in settings order (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)", async () => {
+      const first = {
+        ...currentSettings,
+        enableMiyo: true,
+        qaExclusions: "copilot,Private",
+      } as CopilotSettings;
+      const second = { ...first, qaExclusions: "copilot,Archive" };
+      const third = { ...second, qaExclusions: "copilot,Final" };
+      let liveRecord = record({ exclude_folders: ["copilot", "Private"] });
+      getFolder.mockImplementation(async () => liveRecord);
+      const firstPatch = deferred<void>();
+      updateFolder
+        .mockImplementationOnce(async (request) => {
+          await firstPatch.promise;
+          liveRecord = { ...liveRecord, ...(request as MiyoFolderEntry) };
+          return liveRecord;
+        })
+        .mockImplementationOnce(async (request) => {
+          liveRecord = { ...liveRecord, ...(request as MiyoFolderEntry) };
+          return liveRecord;
+        });
+
+      const firstSync = syncMiyoIndexScopeChange(app, first, second, session);
+      await new Promise((resolve) => window.setTimeout(resolve, 0));
+      const secondSync = syncMiyoIndexScopeChange(app, second, third, session);
+
+      expect(updateFolder).toHaveBeenCalledTimes(1);
+      firstPatch.resolve();
+      await expect(Promise.all([firstSync, secondSync])).resolves.toEqual(["synced", "synced"]);
+
+      expect(updateFolder).toHaveBeenCalledTimes(2);
+      expect((updateFolder.mock.calls[1][0] as MiyoFolderEntry).exclude_folders).toEqual([
+        "copilot",
+        "Final",
+      ]);
+    });
+
+    it("reconciles from the last successful server scope after an earlier edit failed (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)", async () => {
+      const previous = {
+        ...currentSettings,
+        enableMiyo: true,
+        qaExclusions: "copilot,Unsynced",
+        miyoSyncedIndexScope: JSON.stringify({
+          device: "device-A",
+          url: "",
+          folder: "my-vault",
+          exclude_folders: ["copilot", "LastSynced"],
+          exclude_patterns: [],
+          include_folders: [],
+          include_patterns: [],
+          include_extensions: [],
+        }),
+      } as unknown as CopilotSettings;
+      const next = { ...previous, qaExclusions: "copilot,Final" };
+      getFolder.mockResolvedValue(
+        record({ exclude_folders: ["copilot", "LastSynced", "MiyoOnly"] })
+      );
+
+      await expect(syncMiyoIndexScopeChange(app, previous, next, session)).resolves.toBe("synced");
+
+      expect((updateFolder.mock.calls[0][0] as MiyoFolderEntry).exclude_folders).toEqual([
+        "MiyoOnly",
+        "copilot",
+        "Final",
+      ]);
+      expect(updateSetting).toHaveBeenCalledWith(
+        "miyoSyncedIndexScope",
+        expect.stringContaining('"exclude_folders":["copilot","Final"]')
+      );
+    });
+
+    it("does not show a failure notice after the originating vault lifecycle ended (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)", async () => {
+      const staleSession = session;
+      resetMiyoMutations();
+      const previous = { ...currentSettings, enableMiyo: true } as CopilotSettings;
+      const next = { ...previous, qaExclusions: "copilot,Private" };
+
+      await expect(syncMiyoIndexScopeChange(app, previous, next, staleSession)).resolves.toBe(
+        "failed"
+      );
+
+      expect(Notice).not.toHaveBeenCalled();
+      expect(updateFolder).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ["malformed", "not-json"],
+      [
+        "invalid",
+        JSON.stringify({
+          device: "device-A",
+          url: "",
+          folder: "my-vault",
+          include_folders: "not-an-array",
+        }),
+      ],
+      [
+        "foreign-device",
+        JSON.stringify({
+          device: "device-B",
+          url: "",
+          folder: "my-vault",
+          exclude_folders: ["LastSynced"],
+          exclude_patterns: [],
+          include_folders: [],
+          include_patterns: [],
+          include_extensions: [],
+        }),
+      ],
+    ])(
+      "ignores a %s ownership receipt and falls back to the prior local scope (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)",
+      async (_label, miyoSyncedIndexScope) => {
+        const previous = {
+          ...currentSettings,
+          enableMiyo: true,
+          qaExclusions: "copilot,ImmediatePrevious",
+          miyoSyncedIndexScope,
+        } as unknown as CopilotSettings;
+        const next = { ...previous, qaExclusions: "copilot,Final" };
+        getFolder.mockResolvedValue(
+          record({ exclude_folders: ["copilot", "ImmediatePrevious", "MiyoOnly"] })
+        );
+
+        await expect(syncMiyoIndexScopeChange(app, previous, next, session)).resolves.toBe(
+          "synced"
+        );
+
+        expect((updateFolder.mock.calls[0][0] as MiyoFolderEntry).exclude_folders).toEqual([
+          "MiyoOnly",
+          "copilot",
+          "Final",
+        ]);
+      }
+    );
+  });
+
   describe("miyoRecordCoversSystemRoots()", () => {
     const movedRootSettings = () =>
       ({

--- a/src/miyo/miyoResync.ts
+++ b/src/miyo/miyoResync.ts
@@ -1,5 +1,10 @@
 import { logInfo, logWarn } from "@/logger";
-import { MiyoClient, type MiyoAddFolderRequest, type MiyoFolderEntry } from "@/miyo/MiyoClient";
+import {
+  MiyoClient,
+  type MiyoAddFolderRequest,
+  type MiyoFolderEntry,
+  type MiyoUpdateFolderRequest,
+} from "@/miyo/MiyoClient";
 import {
   buildMiyoSyncReceipt,
   getMiyoCustomUrl,
@@ -15,16 +20,15 @@ import { type CopilotSettings, getSettings, updateSetting } from "@/settings/mod
 import { err2String } from "@/utils";
 import { getDeviceId } from "@/utils/deviceId";
 import { getVaultBase } from "@/utils/vaultPath";
-import type { App } from "obsidian";
+import { Notice, type App } from "obsidian";
 
 /**
  * Resynchronize the vault's Miyo registration with the current Copilot scope.
  *
- * Miyo only receives exclusions as a registration-time snapshot, so a Copilot
- * root change leaves the server indexing content that should be excluded (and
- * readable via Relay). This module owns the reconcile: verify the live record,
- * and only when it genuinely diverges, delete + re-register with the fresh
- * scope (deletion also purges the folder's index, verified empirically).
+ * Copilot patches user-edited inclusion and exclusion patterns in place. A
+ * Copilot root change still needs the stronger reconcile here: verify the live
+ * record, and only when it genuinely diverges, delete + re-register with the
+ * fresh scope (deletion also purges the folder's index, verified empirically).
  *
  * All Miyo folder mutations — resync runs AND the register flow — must pass
  * through {@link enqueueMiyoFolderMutation} so a resync can never interleave
@@ -291,7 +295,7 @@ function withLookupTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
  */
 function receiptMatchesIdentity(
   app: App,
-  receipt: MiyoSyncReceipt,
+  receipt: Pick<MiyoSyncReceipt, "device" | "url" | "folder">,
   settings: { miyoServerUrl?: string },
   folderName: string
 ): boolean {
@@ -306,6 +310,83 @@ function receiptMatchesIdentity(
 function recordArray(record: MiyoFolderEntry, key: string): string[] {
   const value = record[key];
   return Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
+}
+
+interface MiyoIndexScopeReceipt {
+  device: string;
+  url: string;
+  folder: string;
+  include_extensions: string[];
+  include_folders: string[];
+  exclude_folders: string[];
+  include_patterns: string[];
+  exclude_patterns: string[];
+}
+
+type MiyoScopeField = Exclude<keyof MiyoUpdateFolderRequest, "path">;
+
+function parseMiyoIndexScopeReceipt(stored: unknown): MiyoIndexScopeReceipt | null {
+  // Synced or hand-edited data can carry a receipt from another schema version.
+  // Treat anything incomplete as unknown ownership instead of removing filters
+  // from Miyo based on untrusted local metadata.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/310
+  if (typeof stored !== "string" || stored.length === 0) return null;
+  try {
+    const parsed = JSON.parse(stored) as Partial<MiyoIndexScopeReceipt>;
+    const arrayFields: Array<keyof MiyoIndexScopeReceipt> = [
+      "include_extensions",
+      "include_folders",
+      "exclude_folders",
+      "include_patterns",
+      "exclude_patterns",
+    ];
+    if (
+      typeof parsed.device !== "string" ||
+      typeof parsed.url !== "string" ||
+      typeof parsed.folder !== "string" ||
+      !arrayFields.every(
+        (key) =>
+          Array.isArray(parsed[key]) &&
+          (parsed[key] as unknown[]).every((value) => typeof value === "string")
+      )
+    ) {
+      return null;
+    }
+    return parsed as MiyoIndexScopeReceipt;
+  } catch {
+    return null;
+  }
+}
+
+function commitIndexScopeReceipt(lifecycle: number, receipt: string): void {
+  assertCurrentLifecycle(lifecycle);
+  updateSetting("miyoSyncedIndexScope", receipt);
+}
+
+/**
+ * Record the Copilot-owned subset of a Miyo folder's index filters.
+ *
+ * The identity prevents a receipt synced through data.json from claiming scope
+ * on another device, endpoint, or vault registration.
+ *
+ * @param app - Active Obsidian app, used for device and folder identity.
+ * @param settings - Settings snapshot whose representable QA scope was synced.
+ */
+export function buildMiyoIndexScopeReceipt(app: App, settings: CopilotSettings): string {
+  const scope = {
+    ...getMiyoFolderInclusions(settings.qaInclusions),
+    ...getMiyoFolderExclusions(settings.qaExclusions),
+  };
+  return JSON.stringify({
+    device: getDeviceId(app),
+    url: getMiyoCustomUrl(settings),
+    folder: getMiyoFolderName(app),
+    include_extensions: scope.include_extensions ?? [],
+    include_folders: scope.include_folders ?? [],
+    exclude_folders: scope.exclude_folders ?? [],
+    include_patterns: scope.include_patterns ?? [],
+    exclude_patterns: scope.exclude_patterns ?? [],
+  } satisfies MiyoIndexScopeReceipt);
 }
 
 function isSuperset(container: readonly string[], required: readonly string[]): boolean {
@@ -325,10 +406,10 @@ function isSuperset(container: readonly string[], required: readonly string[]): 
  * Exclusions union: excludes always win server-side, so adding is always safe.
  * Include filters do NOT union — they are an OR whitelist (see
  * {@link getMiyoFolderInclusions}), so unioning would WIDEN scope. When the
- * record carries one, it is kept verbatim and ours is dropped; the cost is that
- * a `qaInclusions` edit stops propagating through a rebuild, which changes
- * nothing in practice since staleness detection is roots-only and never fires on
- * qa* drift anyway. When the record carries none, ours applies — a narrowing.
+ * record carries one, it is kept verbatim and ours is dropped. Ordinary
+ * `qaInclusions` edits use the in-place scope PATCH and never reach this
+ * destructive root-rebuild path. When the record carries none, ours applies —
+ * a narrowing.
  *
  * @param desired - Replacement body built from the current Copilot scope; mutated.
  * @param record - Live folder entry the rebuild is replacing.
@@ -399,6 +480,169 @@ function buildDesiredScope(app: App, settings = getSettings()): MiyoAddFolderReq
       ...extractAppIgnoreSettings(app),
     ]),
   };
+}
+
+/** Result of applying one Copilot index-scope settings change to Miyo. */
+export type MiyoIndexScopeSyncOutcome = "synced" | "unchanged" | "not-configured" | "failed";
+
+/**
+ * Apply a Copilot inclusion/exclusion edit to the registered Miyo folder.
+ *
+ * Copilot removes only the filter values derived from its previous settings and
+ * adds the new values. This keeps filters configured directly in Miyo intact,
+ * and PATCH avoids the destructive delete/re-register path used for root moves.
+ * https://github.com/Brevilabs/obsidian-copilot-private/issues/310
+ *
+ * @param app - Active Obsidian app, used to resolve the registered vault folder.
+ * @param previous - Settings snapshot immediately before the scope edit.
+ * @param next - Settings snapshot containing the new scope.
+ * @param session - Current plugin lifecycle's Miyo mutation session.
+ */
+export function syncMiyoIndexScopeChange(
+  app: App,
+  previous: CopilotSettings,
+  next: CopilotSettings,
+  session: MiyoMutationSession
+): Promise<MiyoIndexScopeSyncOutcome> {
+  // The central settings subscription invokes this for every persisted change;
+  // exact scope equality must stay off the mutation queue and network.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/310
+  if (previous.qaInclusions === next.qaInclusions && previous.qaExclusions === next.qaExclusions) {
+    return Promise.resolve("unchanged");
+  }
+  const previousQaScope = {
+    ...getMiyoFolderInclusions(previous.qaInclusions),
+    ...getMiyoFolderExclusions(previous.qaExclusions),
+  };
+  const nextQaScope = {
+    ...getMiyoFolderInclusions(next.qaInclusions),
+    ...getMiyoFolderExclusions(next.qaExclusions),
+  };
+  // Tags and individual-note patterns have no Miyo folder-API representation;
+  // Copilot continues enforcing those changes when it consumes search results.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/310
+  if (JSON.stringify(previousQaScope) === JSON.stringify(nextQaScope)) {
+    return Promise.resolve("unchanged");
+  }
+  const folderName = getMiyoFolderName(app);
+  const previousIndexReceipt = parseMiyoIndexScopeReceipt(previous.miyoSyncedIndexScope);
+  const nextIndexReceipt = parseMiyoIndexScopeReceipt(next.miyoSyncedIndexScope);
+  const previousRootReceipt = parseMiyoSyncReceipt(previous.miyoSyncedExclusions);
+  const nextRootReceipt = parseMiyoSyncReceipt(next.miyoSyncedExclusions);
+  const hasMiyoRegistrationEvidence =
+    previous.enableMiyo ||
+    next.enableMiyo ||
+    (previousIndexReceipt !== null &&
+      receiptMatchesIdentity(app, previousIndexReceipt, previous, folderName)) ||
+    (nextIndexReceipt !== null &&
+      receiptMatchesIdentity(app, nextIndexReceipt, next, folderName)) ||
+    (previousRootReceipt !== null &&
+      receiptMatchesIdentity(app, previousRootReceipt, previous, folderName)) ||
+    (nextRootReceipt !== null && receiptMatchesIdentity(app, nextRootReceipt, next, folderName));
+  // A synced receipt from another device does not prove this device owns a
+  // reachable registration, so local-only setups never gain surprise traffic.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/310
+  if (!hasMiyoRegistrationEvidence) {
+    return Promise.resolve("not-configured");
+  }
+  return enqueueMiyoFolderMutation<MiyoIndexScopeSyncOutcome>(async (lifecycle) => {
+    const ignoreFolders = extractAppIgnoreSettings(app);
+    // A failed PATCH leaves the receipt pointing at the last server state. Use
+    // that state, not merely the immediately previous local setting, or a later
+    // inclusion edit can leave an older OR-whitelist active in Miyo.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/310
+    const previousUserScope =
+      previousIndexReceipt && receiptMatchesIdentity(app, previousIndexReceipt, next, folderName)
+        ? previousIndexReceipt
+        : previousQaScope;
+    const previousSystemExclusions = getMiyoFolderExclusions("", [
+      ...getSystemExcludedFolders(previous),
+      ...ignoreFolders,
+    ]);
+    const previousScope = {
+      ...previousUserScope,
+      exclude_folders: [
+        ...new Set([
+          ...(previousUserScope.exclude_folders ?? []),
+          ...(previousSystemExclusions.exclude_folders ?? []),
+        ]),
+      ],
+      exclude_patterns: [
+        ...new Set([
+          ...(previousUserScope.exclude_patterns ?? []),
+          ...(previousSystemExclusions.exclude_patterns ?? []),
+        ]),
+      ],
+    };
+    const nextScope = {
+      ...nextQaScope,
+      ...getMiyoFolderExclusions(next.qaExclusions, [
+        ...getSystemExcludedFolders(next),
+        ...ignoreFolders,
+      ]),
+    };
+    const customUrl = getMiyoCustomUrl(next) || undefined;
+    const client = new MiyoClient({ plusLicenseKey: next.plusLicenseKey });
+    const baseUrl = await client.resolveBaseUrl(customUrl);
+    const record = await withLookupTimeout(client.getFolder(baseUrl, folderName), "folder lookup");
+    const reconcile = (key: MiyoScopeField): string[] => {
+      const prior = new Set(previousScope[key] ?? []);
+      return [
+        ...new Set([
+          ...recordArray(record, key).filter((value) => !prior.has(value)),
+          ...(nextScope[key] ?? []),
+        ]),
+      ];
+    };
+    const directIncludeScope = {
+      include_folders: reconcile("include_folders").filter(
+        (value) => !(nextScope.include_folders ?? []).includes(value)
+      ),
+      include_patterns: reconcile("include_patterns").filter(
+        (value) => !(nextScope.include_patterns ?? []).includes(value)
+      ),
+      include_extensions: reconcile("include_extensions").filter(
+        (value) => !(nextScope.include_extensions ?? []).includes(value)
+      ),
+    };
+    const hasDirectIncludeScope = Object.values(directIncludeScope).some(
+      (values) => values.length > 0
+    );
+    // Include arrays form one OR-whitelist. Unioning a Miyo-owned whitelist
+    // with Copilot's new whitelist would broaden what Miyo can index, so direct
+    // Miyo scope wins when both exist. Copilot still applies its own scope to
+    // every result it consumes.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/310
+    const includeScope = hasDirectIncludeScope ? directIncludeScope : nextScope;
+    await client.updateFolder(
+      {
+        path: record.path || folderName,
+        exclude_folders: reconcile("exclude_folders"),
+        exclude_patterns: reconcile("exclude_patterns"),
+        include_folders: includeScope.include_folders ?? [],
+        include_patterns: includeScope.include_patterns ?? [],
+        include_extensions: includeScope.include_extensions ?? [],
+      },
+      customUrl,
+      () => assertCurrentLifecycle(lifecycle)
+    );
+    const receiptSettings = hasDirectIncludeScope ? { ...next, qaInclusions: "" } : next;
+    commitIndexScopeReceipt(lifecycle, buildMiyoIndexScopeReceipt(app, receiptSettings));
+    return "synced";
+  }, session).catch((error) => {
+    // The Copilot setting is already committed when this background PATCH runs.
+    // Keep it and make the server-side drift visible instead of rolling local
+    // filtering back after the user saw their edit land.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/310
+    logWarn(`Miyo index-scope sync failed: ${err2String(error)}`);
+    if (session.lifecycle === mutationLifecycle) {
+      new Notice(
+        "Index scope was saved in Copilot, but Miyo couldn't be updated. " +
+          "Make sure Miyo is running, then change the scope again."
+      );
+    }
+    return "failed";
+  });
 }
 
 /**

--- a/src/search/findRelevantNotes.test.ts
+++ b/src/search/findRelevantNotes.test.ts
@@ -1,4 +1,5 @@
-import { MiyoClient } from "@/miyo/MiyoClient";
+import { logError } from "@/logger";
+import { MiyoClient, MiyoRequestError } from "@/miyo/MiyoClient";
 import {
   getMiyoFilePath,
   getMiyoFolderName,
@@ -21,13 +22,19 @@ jest.mock("@/search/searchUtils", () => ({ createCopilotPatternFilter: jest.fn()
 
 const mockResolveBaseUrl = jest.fn();
 const mockSearchRelated = jest.fn();
+const mockGetFolder = jest.fn();
 
-jest.mock("@/miyo/MiyoClient", () => ({
-  MiyoClient: jest.fn().mockImplementation(() => ({
-    resolveBaseUrl: (...args: unknown[]) => mockResolveBaseUrl(...args) as unknown,
-    searchRelated: (...args: unknown[]) => mockSearchRelated(...args) as unknown,
-  })),
-}));
+jest.mock("@/miyo/MiyoClient", () => {
+  const actual = jest.requireActual<typeof import("@/miyo/MiyoClient")>("@/miyo/MiyoClient");
+  return {
+    MiyoRequestError: actual.MiyoRequestError,
+    MiyoClient: jest.fn().mockImplementation(() => ({
+      resolveBaseUrl: (...args: unknown[]) => mockResolveBaseUrl(...args) as unknown,
+      searchRelated: (...args: unknown[]) => mockSearchRelated(...args) as unknown,
+      getFolder: (...args: unknown[]) => mockGetFolder(...args) as unknown,
+    })),
+  };
+});
 
 jest.mock("@/miyo/miyoUtils", () => ({
   getMiyoFolderName: jest.fn(),
@@ -65,6 +72,7 @@ describe("findRelevantNotes", () => {
     typeof getVaultRelativeMiyoPath
   >;
   const mockedMiyoClient = MiyoClient as unknown as jest.Mock;
+  const mockedLogError = logError as jest.MockedFunction<typeof logError>;
 
   describe("findRelevantNotes()", () => {
     beforeEach(() => {
@@ -85,9 +93,11 @@ describe("findRelevantNotes", () => {
       );
       mockResolveBaseUrl.mockResolvedValue("http://127.0.0.1:8742");
       mockSearchRelated.mockResolvedValue({ results: [] });
+      mockGetFolder.mockResolvedValue({ path: "vault" });
       mockedMiyoClient.mockImplementation(() => ({
         resolveBaseUrl: mockResolveBaseUrl,
         searchRelated: mockSearchRelated,
+        getFolder: mockGetFolder,
       }));
 
       const paths = [
@@ -105,6 +115,7 @@ describe("findRelevantNotes", () => {
 
     it("uses Miyo as the only semantic scorer and preserves vault-scoped path stripping (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
       mockedGetSearchBackend.mockReturnValue("miyo");
+      mockedGetSettings.mockReturnValue({ enableMiyo: true, debug: false } as CopilotSettings);
       mockSearchRelated.mockResolvedValue({
         results: [
           { path: "vault/source.md", score: 0.99 },
@@ -116,10 +127,11 @@ describe("findRelevantNotes", () => {
 
       const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
 
-      expect(result.map((entry) => entry.note.path)).toEqual(["beta.md", "alpha.md"]);
-      expect(result.find((entry) => entry.note.path === "alpha.md")?.metadata.similarityScore).toBe(
-        0.6
-      );
+      expect(result.notes.map((entry) => entry.note.path)).toEqual(["beta.md", "alpha.md"]);
+      expect(
+        result.notes.find((entry) => entry.note.path === "alpha.md")?.metadata.similarityScore
+      ).toBe(0.6);
+      expect(result.semanticState).toBe("ready");
       expect(mockSearchRelated).toHaveBeenCalledWith("http://127.0.0.1:8742", "vault/source.md", {
         folderName: "vault",
         limit: 20,
@@ -138,21 +150,25 @@ describe("findRelevantNotes", () => {
 
       const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
 
-      expect(result.map((entry) => entry.note.path)).toEqual([
+      expect(result.notes.map((entry) => entry.note.path)).toEqual([
         "linked-only.md",
         "alpha.md",
         "beta.md",
       ]);
-      expect(result.every((entry) => entry.metadata.similarityScore === undefined)).toBe(true);
-      expect(result[1].metadata).toMatchObject({
+      expect(result.notes.every((entry) => entry.metadata.similarityScore === undefined)).toBe(
+        true
+      );
+      expect(result.notes[1].metadata).toMatchObject({
         hasOutgoingLinks: true,
         hasBacklinks: true,
       });
       expect(mockSearchRelated).not.toHaveBeenCalled();
+      expect(result.semanticState).toBe("disabled");
     });
 
     it("ranks by Miyo similarity without boosting a backlinked lower-scoring note", async () => {
       mockedGetSearchBackend.mockReturnValue("miyo");
+      mockedGetSettings.mockReturnValue({ enableMiyo: true, debug: false } as CopilotSettings);
       mockSearchRelated.mockResolvedValue({
         results: [
           { path: "vault/alpha.md", score: 0.6 },
@@ -163,12 +179,13 @@ describe("findRelevantNotes", () => {
 
       const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
 
-      expect(result.map((entry) => entry.note.path)).toEqual(["alpha.md", "beta.md"]);
-      expect(result[1].metadata.hasBacklinks).toBe(true);
+      expect(result.notes.map((entry) => entry.note.path)).toEqual(["alpha.md", "beta.md"]);
+      expect(result.notes[1].metadata.hasBacklinks).toBe(true);
     });
 
     it("applies the live Copilot scope to Miyo and linked candidates", async () => {
       mockedGetSearchBackend.mockReturnValue("miyo");
+      mockedGetSettings.mockReturnValue({ enableMiyo: true, debug: false } as CopilotSettings);
       mockSearchRelated.mockResolvedValue({
         results: [
           { path: "vault/beta.md", score: 0.8 },
@@ -181,7 +198,7 @@ describe("findRelevantNotes", () => {
 
       const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
 
-      expect(result.map((entry) => entry.note.path)).toEqual(["beta.md"]);
+      expect(result.notes.map((entry) => entry.note.path)).toEqual(["beta.md"]);
       expect(isAllowed.mock.calls.map(([path]) => path)).toEqual([
         "beta.md",
         "alpha.md",
@@ -191,6 +208,7 @@ describe("findRelevantNotes", () => {
 
     it("caps Miyo results at the existing 20-note limit", async () => {
       mockedGetSearchBackend.mockReturnValue("miyo");
+      mockedGetSettings.mockReturnValue({ enableMiyo: true, debug: false } as CopilotSettings);
       mockSearchRelated.mockResolvedValue({
         results: Array.from({ length: 25 }, (_, index) => ({
           path: `vault/note-${index}.md`,
@@ -200,22 +218,115 @@ describe("findRelevantNotes", () => {
 
       const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
 
-      expect(result).toHaveLength(20);
-      expect(result[0].note.path).toBe("note-24.md");
-      expect(result[19].note.path).toBe("note-5.md");
+      expect(result.notes).toHaveLength(20);
+      expect(result.notes[0].note.path).toBe("note-24.md");
+      expect(result.notes[19].note.path).toBe("note-5.md");
     });
 
-    it("keeps links without scores when Miyo search fails (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+    it("reports ready when a successful Miyo search has no semantic matches (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
       mockedGetSearchBackend.mockReturnValue("miyo");
-      mockSearchRelated.mockRejectedValue(new Error("Miyo unavailable"));
+      mockedGetSettings.mockReturnValue({
+        debug: false,
+        miyoServerUrl: "",
+        enableMiyo: true,
+      } as CopilotSettings);
+
+      const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
+
+      expect(result).toEqual({ notes: [], semanticState: "ready" });
+      expect(mockGetFolder).not.toHaveBeenCalled();
+    });
+
+    it("keeps links and reports not-indexed when the specific no-chunks response still finds the registered folder (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      mockedGetSearchBackend.mockReturnValue("miyo");
+      mockedGetSettings.mockReturnValue({
+        debug: false,
+        miyoServerUrl: "",
+        enableMiyo: true,
+      } as CopilotSettings);
+      mockSearchRelated.mockRejectedValue(
+        new MiyoRequestError(404, "No indexed chunks found for file_path")
+      );
       mockedGetLinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);
 
       const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
 
-      expect(result).toHaveLength(1);
-      expect(result[0].note.path).toBe("linked-only.md");
-      expect(result[0].metadata.similarityScore).toBeUndefined();
-      expect(result[0].metadata.hasOutgoingLinks).toBe(true);
+      expect(result.notes).toHaveLength(1);
+      expect(result.notes[0].note.path).toBe("linked-only.md");
+      expect(result.notes[0].metadata.similarityScore).toBeUndefined();
+      expect(result.semanticState).toBe("not-indexed");
+      expect(mockGetFolder).toHaveBeenCalledWith("http://127.0.0.1:8742", "vault");
+      expect(mockedLogError).not.toHaveBeenCalled();
+    });
+
+    it("keeps links and reports unavailable when the no-chunks response cannot confirm folder registration (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      mockedGetSearchBackend.mockReturnValue("miyo");
+      mockedGetSettings.mockReturnValue({
+        debug: false,
+        miyoServerUrl: "",
+        enableMiyo: true,
+      } as CopilotSettings);
+      mockSearchRelated.mockRejectedValue(
+        new MiyoRequestError(404, "No indexed chunks found for file_path")
+      );
+      mockGetFolder.mockRejectedValue(new MiyoRequestError(404, "Folder unavailable"));
+      mockedGetBacklinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);
+
+      const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
+
+      expect(result.notes[0].metadata.hasBacklinks).toBe(true);
+      expect(result.semanticState).toBe("unavailable");
+      expect(mockedLogError).toHaveBeenCalledTimes(1);
+    });
+
+    it("reports unavailable when the no-chunks registration probe times out instead of hanging the pane (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      jest.useFakeTimers();
+      try {
+        mockedGetSearchBackend.mockReturnValue("miyo");
+        mockedGetSettings.mockReturnValue({
+          debug: false,
+          miyoServerUrl: "",
+          enableMiyo: true,
+        } as CopilotSettings);
+        mockSearchRelated.mockRejectedValue(
+          new MiyoRequestError(404, "No indexed chunks found for file_path")
+        );
+        mockGetFolder.mockReturnValue(new Promise(() => undefined));
+
+        const resultPromise = findRelevantNotes({ app: window.app, filePath: "source.md" });
+        await jest.advanceTimersByTimeAsync(0);
+        await jest.advanceTimersByTimeAsync(8000);
+
+        await expect(resultPromise).resolves.toMatchObject({ semanticState: "unavailable" });
+        expect(mockedLogError).toHaveBeenCalledTimes(1);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it("reports a 503 related-search outage as unavailable without trusting a registered folder (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      mockedGetSearchBackend.mockReturnValue("miyo");
+      mockedGetSettings.mockReturnValue({
+        debug: false,
+        miyoServerUrl: "",
+        enableMiyo: true,
+      } as CopilotSettings);
+      mockSearchRelated.mockRejectedValue(new MiyoRequestError(503, "Service unavailable"));
+
+      const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
+
+      expect(result.semanticState).toBe("unavailable");
+      expect(mockGetFolder).not.toHaveBeenCalled();
+      expect(mockedLogError).toHaveBeenCalledTimes(1);
+    });
+
+    it("reports unavailable when Miyo is enabled but the runtime cannot use it (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      mockedGetSettings.mockReturnValue({ enableMiyo: true } as CopilotSettings);
+
+      const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
+
+      expect(result).toEqual({ notes: [], semanticState: "unavailable" });
+      expect(mockResolveBaseUrl).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/search/findRelevantNotes.test.ts
+++ b/src/search/findRelevantNotes.test.ts
@@ -304,6 +304,54 @@ describe("findRelevantNotes", () => {
       }
     });
 
+    it("keeps links and reports unavailable when the primary related search never settles (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      jest.useFakeTimers();
+      try {
+        mockedGetSearchBackend.mockReturnValue("miyo");
+        mockedGetSettings.mockReturnValue({
+          debug: false,
+          miyoServerUrl: "",
+          enableMiyo: true,
+        } as CopilotSettings);
+        mockSearchRelated.mockReturnValue(new Promise(() => undefined));
+        mockedGetLinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);
+
+        const resultPromise = findRelevantNotes({ app: window.app, filePath: "source.md" });
+        await jest.advanceTimersByTimeAsync(0);
+        await jest.advanceTimersByTimeAsync(8000);
+
+        await expect(resultPromise).resolves.toMatchObject({
+          notes: [{ note: { path: "linked-only.md" } }],
+          semanticState: "unavailable",
+        });
+        expect(mockGetFolder).not.toHaveBeenCalled();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it("reports unavailable when Miyo endpoint resolution never settles (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      jest.useFakeTimers();
+      try {
+        mockedGetSearchBackend.mockReturnValue("miyo");
+        mockedGetSettings.mockReturnValue({
+          debug: false,
+          miyoServerUrl: "",
+          enableMiyo: true,
+        } as CopilotSettings);
+        mockResolveBaseUrl.mockReturnValue(new Promise(() => undefined));
+
+        const resultPromise = findRelevantNotes({ app: window.app, filePath: "source.md" });
+        await jest.advanceTimersByTimeAsync(0);
+        await jest.advanceTimersByTimeAsync(8000);
+
+        await expect(resultPromise).resolves.toMatchObject({ semanticState: "unavailable" });
+        expect(mockSearchRelated).not.toHaveBeenCalled();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
     it("reports a 503 related-search outage as unavailable without trusting a registered folder (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
       mockedGetSearchBackend.mockReturnValue("miyo");
       mockedGetSettings.mockReturnValue({

--- a/src/search/findRelevantNotes.test.ts
+++ b/src/search/findRelevantNotes.test.ts
@@ -1,50 +1,23 @@
-import { TFile } from "obsidian";
-import { getBacklinkedNotes, getLinkedNotes } from "@/noteUtils";
-import { findRelevantNotes } from "@/search/findRelevantNotes";
 import { MiyoClient } from "@/miyo/MiyoClient";
 import {
   getMiyoFilePath,
   getMiyoFolderName,
-  getVaultRelativeMiyoPath,
   getSearchBackend,
+  getVaultRelativeMiyoPath,
 } from "@/miyo/miyoUtils";
+import { getBacklinkedNotes, getLinkedNotes } from "@/noteUtils";
+import { findRelevantNotes } from "@/search/findRelevantNotes";
 import { createCopilotPatternFilter } from "@/search/searchUtils";
 import { getSettings, type CopilotSettings } from "@/settings/model";
-import VectorStoreManager from "@/search/vectorStoreManager";
+import { TFile } from "obsidian";
 
 jest.mock("@/noteUtils", () => ({
   getLinkedNotes: jest.fn(),
   getBacklinkedNotes: jest.fn(),
 }));
 
-jest.mock("@/settings/model", () => ({
-  getSettings: jest.fn(),
-}));
-
-jest.mock("@/search/searchUtils", () => ({
-  createCopilotPatternFilter: jest.fn(),
-}));
-
-const mockGetDocumentsByPath = jest.fn();
-const mockGetDb = jest.fn();
-
-jest.mock("@/search/vectorStoreManager", () => ({
-  __esModule: true,
-  default: {
-    getInstance: () => ({
-      getDocumentsByPath: mockGetDocumentsByPath,
-      getDb: mockGetDb,
-    }),
-  },
-}));
-
-const mockGetDocsByEmbedding = jest.fn();
-
-jest.mock("@/search/dbOperations", () => ({
-  DBOperations: {
-    getDocsByEmbedding: (...args: unknown[]) => mockGetDocsByEmbedding(...args) as unknown,
-  },
-}));
+jest.mock("@/settings/model", () => ({ getSettings: jest.fn() }));
+jest.mock("@/search/searchUtils", () => ({ createCopilotPatternFilter: jest.fn() }));
 
 const mockResolveBaseUrl = jest.fn();
 const mockSearchRelated = jest.fn();
@@ -66,16 +39,9 @@ jest.mock("@/miyo/miyoUtils", () => ({
 
 jest.mock("@/logger", () => ({
   logInfo: jest.fn(),
-  logWarn: jest.fn(),
   logError: jest.fn(),
 }));
 
-/**
- * Create a markdown file mock with Obsidian's TFile class.
- *
- * @param path - Vault-relative markdown path.
- * @returns Mock TFile instance.
- */
 function createMarkdownFile(path: string): TFile {
   const TFileConstructor = TFile as unknown as new (filePath: string) => TFile;
   return new TFileConstructor(path);
@@ -98,12 +64,6 @@ describe("findRelevantNotes", () => {
   const mockedGetVaultRelativeMiyoPath = getVaultRelativeMiyoPath as jest.MockedFunction<
     typeof getVaultRelativeMiyoPath
   >;
-  const mockedVectorStoreManager = VectorStoreManager as unknown as {
-    getInstance: () => {
-      getDocumentsByPath: jest.Mock;
-      getDb: jest.Mock;
-    };
-  };
   const mockedMiyoClient = MiyoClient as unknown as jest.Mock;
 
   describe("findRelevantNotes()", () => {
@@ -115,7 +75,6 @@ describe("findRelevantNotes", () => {
         debug: false,
         miyoServerUrl: "",
         enableMiyo: false,
-        enableSemanticSearchV3: false,
       } as CopilotSettings);
       mockedGetLinkedNotes.mockReturnValue([]);
       mockedGetBacklinkedNotes.mockReturnValue([]);
@@ -124,131 +83,34 @@ describe("findRelevantNotes", () => {
       mockedGetVaultRelativeMiyoPath.mockImplementation((_: unknown, path: string) =>
         path.replace(/^vault\//, "")
       );
-
-      const source = createMarkdownFile("source.md");
-      const first = createMarkdownFile("first.md");
-      const second = createMarkdownFile("second.md");
-      const alpha = createMarkdownFile("alpha.md");
-      const beta = createMarkdownFile("beta.md");
-      const linkedOnly = createMarkdownFile("linked-only.md");
-
-      const filesByPath = new Map<string, TFile>([
-        ["source.md", source],
-        ["first.md", first],
-        ["second.md", second],
-        ["alpha.md", alpha],
-        ["beta.md", beta],
-        ["linked-only.md", linkedOnly],
-      ]);
-
-      (window.app.vault.getAbstractFileByPath as jest.Mock).mockImplementation((path: string) => {
-        return filesByPath.get(path) ?? null;
-      });
-
-      mockedVectorStoreManager
-        .getInstance()
-        .getDocumentsByPath.mockImplementation(mockGetDocumentsByPath);
-      mockedVectorStoreManager.getInstance().getDb.mockImplementation(mockGetDb);
+      mockResolveBaseUrl.mockResolvedValue("http://127.0.0.1:8742");
+      mockSearchRelated.mockResolvedValue({ results: [] });
       mockedMiyoClient.mockImplementation(() => ({
         resolveBaseUrl: mockResolveBaseUrl,
         searchRelated: mockSearchRelated,
       }));
-    });
 
-    it("uses Orama similarity scoring when source note has embeddings", async () => {
-      mockGetDocumentsByPath.mockResolvedValue([
-        {
-          id: "chunk-1",
-          path: "source.md",
-          content: "chunk one",
-          embedding: [0.1, 0.2],
-        },
-        {
-          id: "chunk-2",
-          path: "source.md",
-          content: "chunk two",
-          embedding: [0.3, 0.4],
-        },
-      ]);
-      mockGetDb.mockResolvedValue({ db: "orama" });
-      mockGetDocsByEmbedding
-        .mockResolvedValueOnce([
-          { score: 0.82, document: { path: "second.md" } },
-          { score: 0.5, document: { path: "source.md" } },
-        ])
-        .mockResolvedValueOnce([
-          { score: 0.79, document: { path: "first.md" } },
-          { score: 0.66, document: { path: "second.md" } },
-        ]);
-      mockedGetBacklinkedNotes.mockReturnValue([createMarkdownFile("second.md")]);
-      mockedGetLinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);
-
-      const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
-
-      expect(result.map((entry) => entry.note.path)).toEqual([
-        "second.md",
-        "first.md",
+      const paths = [
+        "source.md",
+        "alpha.md",
+        "beta.md",
         "linked-only.md",
-      ]);
-      expect(
-        result.find((entry) => entry.note.path === "second.md")?.metadata.similarityScore
-      ).toBe(0.82);
-      expect(mockGetDb).toHaveBeenCalledTimes(1);
-      expect(mockGetDocsByEmbedding).toHaveBeenCalledTimes(2);
-      expect(mockSearchRelated).not.toHaveBeenCalled();
-    });
-
-    it("ranks by similarity only — a backlink does not boost a lower-similarity note above a higher one", async () => {
-      mockGetDocumentsByPath.mockResolvedValue([
-        { id: "chunk-1", path: "source.md", content: "chunk one", embedding: [0.1, 0.2] },
-      ]);
-      mockGetDb.mockResolvedValue({ db: "orama" });
-      // alpha (0.6) has no links; beta (0.58) is backlinked. The old merged-score
-      // ranking boosted beta above alpha despite its lower similarity.
-      mockGetDocsByEmbedding.mockResolvedValueOnce([
-        { score: 0.6, document: { path: "alpha.md" } },
-        { score: 0.58, document: { path: "beta.md" } },
-      ]);
-      mockedGetBacklinkedNotes.mockReturnValue([createMarkdownFile("beta.md")]);
-
-      const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
-
-      expect(result.map((entry) => entry.note.path)).toEqual(["alpha.md", "beta.md"]);
-      expect(result[0].metadata.similarityScore).toBe(0.6);
-      expect(result.find((entry) => entry.note.path === "beta.md")?.metadata.hasBacklinks).toBe(
-        true
+        ...Array.from({ length: 25 }, (_, index) => `note-${index}.md`),
+      ];
+      const filesByPath = new Map(paths.map((path) => [path, createMarkdownFile(path)]));
+      (window.app.vault.getAbstractFileByPath as jest.Mock).mockImplementation(
+        (path: string) => filesByPath.get(path) ?? null
       );
     });
 
-    it("uses Miyo when shouldUseMiyoForRelevantNotes is true (enableMiyo=true and valid self-host)", async () => {
+    it("uses Miyo as the only semantic scorer and preserves vault-scoped path stripping (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
       mockedGetSearchBackend.mockReturnValue("miyo");
-      mockedGetSettings.mockReturnValue({
-        debug: false,
-        miyoServerUrl: "http://127.0.0.1:8742",
-        enableMiyo: true,
-        enableSemanticSearchV3: true,
-      } as CopilotSettings);
-      mockGetDocumentsByPath.mockResolvedValue([
-        {
-          id: "chunk-a",
-          path: "source.md",
-          content: "source chunk A",
-          embedding: [],
-        },
-        {
-          id: "chunk-b",
-          path: "source.md",
-          content: "source chunk B",
-          embedding: [],
-        },
-      ]);
-      mockResolveBaseUrl.mockResolvedValue("http://127.0.0.1:8742");
       mockSearchRelated.mockResolvedValue({
         results: [
-          { id: "self", path: "vault/source.md", score: 0.99, chunk_text: "self" },
-          { id: "a-1", path: "vault/alpha.md", score: 0.45, chunk_text: "alpha1" },
-          { id: "b-1", path: "vault/beta.md", score: 0.88, chunk_text: "beta" },
-          { id: "a-2", path: "vault/alpha.md", score: 0.6, chunk_text: "alpha2" },
+          { path: "vault/source.md", score: 0.99 },
+          { path: "vault/alpha.md", score: 0.45 },
+          { path: "vault/beta.md", score: 0.88 },
+          { path: "vault/alpha.md", score: 0.6 },
         ],
       });
 
@@ -258,22 +120,59 @@ describe("findRelevantNotes", () => {
       expect(result.find((entry) => entry.note.path === "alpha.md")?.metadata.similarityScore).toBe(
         0.6
       );
-      expect(mockGetDb).not.toHaveBeenCalled();
-      expect(mockGetDocumentsByPath).not.toHaveBeenCalled();
-      expect(mockSearchRelated).toHaveBeenCalledTimes(1);
       expect(mockSearchRelated).toHaveBeenCalledWith("http://127.0.0.1:8742", "vault/source.md", {
         folderName: "vault",
         limit: 20,
       });
     });
 
-    it("applies the live Copilot scope to semantic and linked candidates", async () => {
+    it("returns stable links without semantic scores when Miyo is disabled instead of reading the local index (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      mockedGetLinkedNotes.mockReturnValue([
+        createMarkdownFile("linked-only.md"),
+        createMarkdownFile("alpha.md"),
+      ]);
+      mockedGetBacklinkedNotes.mockReturnValue([
+        createMarkdownFile("alpha.md"),
+        createMarkdownFile("beta.md"),
+      ]);
+
+      const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
+
+      expect(result.map((entry) => entry.note.path)).toEqual([
+        "linked-only.md",
+        "alpha.md",
+        "beta.md",
+      ]);
+      expect(result.every((entry) => entry.metadata.similarityScore === undefined)).toBe(true);
+      expect(result[1].metadata).toMatchObject({
+        hasOutgoingLinks: true,
+        hasBacklinks: true,
+      });
+      expect(mockSearchRelated).not.toHaveBeenCalled();
+    });
+
+    it("ranks by Miyo similarity without boosting a backlinked lower-scoring note", async () => {
       mockedGetSearchBackend.mockReturnValue("miyo");
-      mockResolveBaseUrl.mockResolvedValue("http://127.0.0.1:8742");
       mockSearchRelated.mockResolvedValue({
         results: [
-          { id: "allowed", path: "vault/beta.md", score: 0.8 },
-          { id: "excluded", path: "vault/alpha.md", score: 0.9 },
+          { path: "vault/alpha.md", score: 0.6 },
+          { path: "vault/beta.md", score: 0.58 },
+        ],
+      });
+      mockedGetBacklinkedNotes.mockReturnValue([createMarkdownFile("beta.md")]);
+
+      const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
+
+      expect(result.map((entry) => entry.note.path)).toEqual(["alpha.md", "beta.md"]);
+      expect(result[1].metadata.hasBacklinks).toBe(true);
+    });
+
+    it("applies the live Copilot scope to Miyo and linked candidates", async () => {
+      mockedGetSearchBackend.mockReturnValue("miyo");
+      mockSearchRelated.mockResolvedValue({
+        results: [
+          { path: "vault/beta.md", score: 0.8 },
+          { path: "vault/alpha.md", score: 0.9 },
         ],
       });
       mockedGetLinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);
@@ -283,7 +182,6 @@ describe("findRelevantNotes", () => {
       const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
 
       expect(result.map((entry) => entry.note.path)).toEqual(["beta.md"]);
-      expect(mockedCreateCopilotPatternFilter).toHaveBeenCalledWith(window.app);
       expect(isAllowed.mock.calls.map(([path]) => path)).toEqual([
         "beta.md",
         "alpha.md",
@@ -291,52 +189,24 @@ describe("findRelevantNotes", () => {
       ]);
     });
 
-    it("falls back to Miyo when Orama docs exist but have no embeddings and have content", async () => {
-      // enableMiyo=false ensures shouldUseMiyoForRelevantNotes() returns false,
-      // so the no-embeddings fallback path (line 212 of findRelevantNotes.ts) is exercised.
-      mockedGetSettings.mockReturnValue({
-        debug: false,
-        miyoServerUrl: "http://127.0.0.1:8742",
-        enableMiyo: false,
-        enableSemanticSearchV3: true,
-      } as CopilotSettings);
-      mockGetDocumentsByPath.mockResolvedValue([
-        { id: "chunk-a", path: "source.md", content: "source chunk content", embedding: [] },
-      ]);
-      mockResolveBaseUrl.mockResolvedValue("http://127.0.0.1:8742");
+    it("caps Miyo results at the existing 20-note limit", async () => {
+      mockedGetSearchBackend.mockReturnValue("miyo");
       mockSearchRelated.mockResolvedValue({
-        results: [
-          { id: "a-1", path: "vault/alpha.md", score: 0.75, chunk_text: "alpha chunk" },
-          { id: "self", path: "vault/source.md", score: 0.99, chunk_text: "self" },
-        ],
+        results: Array.from({ length: 25 }, (_, index) => ({
+          path: `vault/note-${index}.md`,
+          score: index / 100,
+        })),
       });
 
       const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
 
-      expect(result.map((e) => e.note.path)).toEqual(["alpha.md"]);
-      expect(result[0].metadata.similarityScore).toBe(0.75);
-      // Orama path not taken (no embeddings); Miyo called as fallback
-      expect(mockGetDocsByEmbedding).not.toHaveBeenCalled();
-      expect(mockSearchRelated).toHaveBeenCalledTimes(1);
+      expect(result).toHaveLength(20);
+      expect(result[0].note.path).toBe("note-24.md");
+      expect(result[19].note.path).toBe("note-5.md");
     });
 
-    it("falls back to link-only relevance when Miyo related-note search fails", async () => {
+    it("keeps links without scores when Miyo search fails (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
       mockedGetSearchBackend.mockReturnValue("miyo");
-      mockedGetSettings.mockReturnValue({
-        debug: false,
-        miyoServerUrl: "http://127.0.0.1:8742",
-        enableMiyo: true,
-        enableSemanticSearchV3: true,
-      } as CopilotSettings);
-      mockGetDocumentsByPath.mockResolvedValue([
-        {
-          id: "chunk-a",
-          path: "source.md",
-          content: "source chunk A",
-          embedding: [],
-        },
-      ]);
-      mockResolveBaseUrl.mockResolvedValue("http://127.0.0.1:8742");
       mockSearchRelated.mockRejectedValue(new Error("Miyo unavailable"));
       mockedGetLinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);
 
@@ -346,7 +216,6 @@ describe("findRelevantNotes", () => {
       expect(result[0].note.path).toBe("linked-only.md");
       expect(result[0].metadata.similarityScore).toBeUndefined();
       expect(result[0].metadata.hasOutgoingLinks).toBe(true);
-      expect(mockGetDocumentsByPath).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/search/findRelevantNotes.ts
+++ b/src/search/findRelevantNotes.ts
@@ -1,4 +1,4 @@
-import { logError, logInfo, logWarn } from "@/logger";
+import { logError, logInfo } from "@/logger";
 import { MiyoClient } from "@/miyo/MiyoClient";
 import {
   getMiyoCustomUrl,
@@ -8,48 +8,11 @@ import {
   getSearchBackend,
 } from "@/miyo/miyoUtils";
 import { getBacklinkedNotes, getLinkedNotes } from "@/noteUtils";
-import { DBOperations, type CopilotOrama } from "@/search/dbOperations";
-import type { SemanticIndexDocument } from "@/search/indexBackend/SemanticIndexBackend";
 import { createCopilotPatternFilter } from "@/search/searchUtils";
-import VectorStoreManager from "@/search/vectorStoreManager";
 import { getSettings } from "@/settings/model";
-import { Result } from "@orama/orama";
 import { App, TFile } from "obsidian";
 
 const MAX_K = 20;
-
-/**
- * Determine whether Miyo-backed relevant-note scoring should be used.
- *
- * @returns True when Miyo mode and self-host access validation are active.
- */
-function shouldUseMiyoForRelevantNotes(): boolean {
-  return getSearchBackend(getSettings()) === "miyo";
-}
-
-/**
- * Gets the highest score hits for each note and removes the current file path
- * from the results.
- * @param hits - The hits to get the highest score for.
- * @param currentFilePath - The current file path.
- * @returns A map of the highest score hits for each note.
- */
-function getHighestScoreHits(hits: Result<{ path: string }>[], currentFilePath: string) {
-  const hitMap = new Map<string, number>();
-  for (const hit of hits) {
-    const path = hit.document.path;
-    const matchingScore = hitMap.get(path);
-    if (matchingScore) {
-      if (hit.score > matchingScore) {
-        hitMap.set(path, hit.score);
-      }
-    } else {
-      hitMap.set(path, hit.score);
-    }
-  }
-  hitMap.delete(currentFilePath);
-  return hitMap;
-}
 
 /**
  * Normalize a score map to the top K entries, ordered by score descending.
@@ -67,55 +30,6 @@ function capToTopK(scoreMap: Map<string, number>): Map<string, number> {
     .slice(0, MAX_K);
 
   return new Map(topK);
-}
-
-/**
- * Return true when a semantic document has a usable embedding vector.
- *
- * @param doc - Semantic document candidate.
- * @returns True when embedding data exists and is non-empty.
- */
-function hasUsableEmbedding(doc: SemanticIndexDocument): boolean {
-  return Array.isArray(doc.embedding) && doc.embedding.length > 0;
-}
-
-/**
- * Return true when the source note has non-empty chunk content.
- *
- * @param docs - Source note semantic chunks.
- * @returns True when at least one chunk has content.
- */
-function hasSourceChunkContent(docs: SemanticIndexDocument[]): boolean {
-  return docs.some((doc) => doc.content.trim().length > 0);
-}
-
-/**
- * Calculate similarity scores using the legacy Orama vector path.
- *
- * @param db - The Orama database.
- * @param filePath - The file path to calculate similarity scores for.
- * @param currentNoteEmbeddings - Embedding vectors of the source note.
- * @returns A map of note paths to their highest similarity scores.
- */
-async function calculateSimilarityScoreFromOrama({
-  db,
-  filePath,
-  currentNoteEmbeddings,
-}: {
-  db: CopilotOrama;
-  filePath: string;
-  currentNoteEmbeddings: number[][];
-}): Promise<Map<string, number>> {
-  const searchPromises = currentNoteEmbeddings.map((embedding) =>
-    DBOperations.getDocsByEmbedding(db, embedding, {
-      limit: MAX_K,
-      similarity: 0,
-    })
-  );
-  const searchResults = await Promise.all(searchPromises);
-  const allHits = searchResults.flat();
-  const aggregatedHits = getHighestScoreHits(allHits, filePath);
-  return capToTopK(aggregatedHits);
 }
 
 /**
@@ -180,44 +94,19 @@ async function calculateSimilarityScoreFromMiyo(
 }
 
 /**
- * Calculate similarity scores by selecting the best available backend strategy.
+ * Calculate Relevant Notes similarity scores through Miyo.
  *
  * @param app - The Obsidian app instance.
  * @param filePath - Source note path.
  * @returns Map of note paths to max similarity score.
  */
 async function calculateSimilarityScore(app: App, filePath: string): Promise<Map<string, number>> {
-  if (shouldUseMiyoForRelevantNotes()) {
-    return calculateSimilarityScoreFromMiyo(app, filePath);
-  }
-
-  const currentNoteDocs = await VectorStoreManager.getInstance().getDocumentsByPath(filePath);
-  if (currentNoteDocs.length === 0) {
+  // Links and backlinks remain useful without Miyo, but the legacy local index
+  // must not assign them semantic scores or trigger a hidden Miyo fallback.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+  if (getSearchBackend(getSettings()) !== "miyo") {
     return new Map();
   }
-
-  const currentNoteEmbeddings = currentNoteDocs
-    .filter((doc) => hasUsableEmbedding(doc))
-    .map((doc) => doc.embedding);
-
-  if (currentNoteEmbeddings.length > 0) {
-    try {
-      const db = await VectorStoreManager.getInstance().getDb();
-      return calculateSimilarityScoreFromOrama({
-        db,
-        filePath,
-        currentNoteEmbeddings,
-      });
-    } catch (error) {
-      logWarn("RelevantNotes(Orama): failed to compute similarity scores", error);
-      return new Map();
-    }
-  }
-
-  if (!hasSourceChunkContent(currentNoteDocs)) {
-    return new Map();
-  }
-
   return calculateSimilarityScoreFromMiyo(app, filePath);
 }
 
@@ -269,7 +158,7 @@ export type RelevantNoteEntry = {
  * @param app - The Obsidian app instance.
  * @param filePath - The file path to find relevant notes for.
  * @returns Relevant-note hits allowed by the current inclusion/exclusion rules.
- *   Empty when no allowed notes are found or the index does not exist.
+ *   Empty when no allowed notes are found.
  */
 export async function findRelevantNotes({
   app,

--- a/src/search/findRelevantNotes.ts
+++ b/src/search/findRelevantNotes.ts
@@ -144,6 +144,7 @@ async function calculateSimilarityScoreFromMiyo(
 }
 
 export type RelevantNotesSemanticState =
+  | "idle"
   | "loading"
   | "disabled"
   | "ready"

--- a/src/search/findRelevantNotes.ts
+++ b/src/search/findRelevantNotes.ts
@@ -1,5 +1,5 @@
 import { logError, logInfo } from "@/logger";
-import { MiyoClient } from "@/miyo/MiyoClient";
+import { MiyoClient, MiyoRequestError } from "@/miyo/MiyoClient";
 import {
   getMiyoCustomUrl,
   getMiyoFilePath,
@@ -10,9 +10,12 @@ import {
 import { getBacklinkedNotes, getLinkedNotes } from "@/noteUtils";
 import { createCopilotPatternFilter } from "@/search/searchUtils";
 import { getSettings } from "@/settings/model";
+import { withTimeout } from "@/utils";
 import { App, TFile } from "obsidian";
 
 const MAX_K = 20;
+const MIYO_FOLDER_LOOKUP_TIMEOUT_MS = 8000;
+const MIYO_UNINDEXED_SOURCE_DETAIL = "No indexed chunks found for file_path";
 
 /**
  * Normalize a score map to the top K entries, ordered by score descending.
@@ -37,18 +40,25 @@ function capToTopK(scoreMap: Map<string, number>): Map<string, number> {
  *
  * @param app - The Obsidian app instance.
  * @param filePath - Source note path.
- * @returns Map of note paths to max similarity score.
+ * @returns Semantic scores and the Miyo state established by the request.
  */
 async function calculateSimilarityScoreFromMiyo(
   app: App,
   filePath: string
-): Promise<Map<string, number>> {
+): Promise<SemanticSearchResult> {
   const settings = getSettings();
   const miyoClient = new MiyoClient();
   const folderName = getMiyoFolderName(app);
   const miyoFilePath = getMiyoFilePath(app, filePath);
+  let baseUrl: string;
   try {
-    const baseUrl = await miyoClient.resolveBaseUrl(getMiyoCustomUrl(settings));
+    baseUrl = await miyoClient.resolveBaseUrl(getMiyoCustomUrl(settings));
+  } catch (error) {
+    logError(`RelevantNotes(Miyo): could not resolve Miyo: ${(error as Error).message}`);
+    return { similarityScoreMap: new Map(), semanticState: "unavailable" };
+  }
+
+  try {
     const response = await miyoClient.searchRelated(baseUrl, miyoFilePath, {
       folderName,
       limit: MAX_K,
@@ -82,15 +92,54 @@ async function calculateSimilarityScoreFromMiyo(
       );
     }
 
-    return capToTopK(similarityScoreMap);
+    return { similarityScoreMap: capToTopK(similarityScoreMap), semanticState: "ready" };
   } catch (error) {
-    logError(
-      `RelevantNotes(Miyo): searchRelated failed for file_path=${miyoFilePath} folder_name=${folderName}: ${
-        (error as Error).message
-      }`
-    );
-    return new Map();
+    // Miyo uses this one response for a source that has no indexed chunks,
+    // including a new note and a note excluded by Miyo. Only that response
+    // merits a bounded registration probe; an outage must remain unavailable.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+    if (
+      !(error instanceof MiyoRequestError) ||
+      error.status !== 404 ||
+      error.detail !== MIYO_UNINDEXED_SOURCE_DETAIL
+    ) {
+      logError(
+        `RelevantNotes(Miyo): searchRelated failed for file_path=${miyoFilePath} folder_name=${folderName}: ${
+          (error as Error).message
+        }`
+      );
+      return { similarityScoreMap: new Map(), semanticState: "unavailable" };
+    }
+
+    try {
+      // A registered folder proves setup is healthy, but Miyo cannot tell
+      // whether this particular path is still indexing or excluded.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+      await withTimeout(
+        () => miyoClient.getFolder(baseUrl, folderName),
+        MIYO_FOLDER_LOOKUP_TIMEOUT_MS,
+        "Relevant Notes Miyo folder lookup"
+      );
+      return { similarityScoreMap: new Map(), semanticState: "not-indexed" };
+    } catch (folderError) {
+      logError(
+        `RelevantNotes(Miyo): source has no indexed chunks and folder lookup failed for folder_name=${folderName}: ${(folderError as Error).message}`
+      );
+      return { similarityScoreMap: new Map(), semanticState: "unavailable" };
+    }
   }
+}
+
+export type RelevantNotesSemanticState =
+  | "loading"
+  | "disabled"
+  | "ready"
+  | "not-indexed"
+  | "unavailable";
+
+interface SemanticSearchResult {
+  similarityScoreMap: Map<string, number>;
+  semanticState: RelevantNotesSemanticState;
 }
 
 /**
@@ -98,14 +147,21 @@ async function calculateSimilarityScoreFromMiyo(
  *
  * @param app - The Obsidian app instance.
  * @param filePath - Source note path.
- * @returns Map of note paths to max similarity score.
+ * @returns Semantic scores and the Miyo state established by the request.
  */
-async function calculateSimilarityScore(app: App, filePath: string): Promise<Map<string, number>> {
+async function calculateSimilarityScore(app: App, filePath: string): Promise<SemanticSearchResult> {
   // Links and backlinks remain useful without Miyo, but the legacy local index
   // must not assign them semantic scores or trigger a hidden Miyo fallback.
   // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
-  if (getSearchBackend(getSettings()) !== "miyo") {
-    return new Map();
+  const settings = getSettings();
+  if (!settings.enableMiyo) {
+    return { similarityScoreMap: new Map(), semanticState: "disabled" };
+  }
+  // An enabled Miyo that cannot run in this environment still needs the setup
+  // handoff, including mobile without a configured remote endpoint.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+  if (getSearchBackend(settings) !== "miyo") {
+    return { similarityScoreMap: new Map(), semanticState: "unavailable" };
   }
   return calculateSimilarityScoreFromMiyo(app, filePath);
 }
@@ -151,6 +207,11 @@ export type RelevantNoteEntry = {
   };
 };
 
+export interface RelevantNotesResult {
+  notes: RelevantNoteEntry[];
+  semanticState: RelevantNotesSemanticState;
+}
+
 /**
  * Finds relevant notes for a file while enforcing Copilot's live search scope
  * across semantic and link-derived candidates.
@@ -166,13 +227,16 @@ export async function findRelevantNotes({
 }: {
   app: App;
   filePath: string;
-}): Promise<RelevantNoteEntry[]> {
+}): Promise<RelevantNotesResult> {
   const file = app.vault.getAbstractFileByPath(filePath);
   if (!(file instanceof TFile)) {
-    return [];
+    return {
+      notes: [],
+      semanticState: getSettings().enableMiyo ? "unavailable" : "disabled",
+    };
   }
 
-  const similarityScoreMap = await calculateSimilarityScore(app, filePath);
+  const { similarityScoreMap, semanticState } = await calculateSimilarityScore(app, filePath);
   const noteLinks = getNoteLinks(app, file);
 
   // Rank purely by semantic similarity so the displayed percentages stay
@@ -191,7 +255,7 @@ export async function findRelevantNotes({
       if (bScore == null) return -1;
       return bScore - aScore;
     });
-  return sortedPaths
+  const notes = sortedPaths
     .map((path) => {
       const file = app.vault.getAbstractFileByPath(path);
       if (!(file instanceof TFile) || file.extension !== "md") {
@@ -212,4 +276,5 @@ export async function findRelevantNotes({
       };
     })
     .filter((entry) => entry !== null);
+  return { notes, semanticState };
 }

--- a/src/search/findRelevantNotes.ts
+++ b/src/search/findRelevantNotes.ts
@@ -14,6 +14,7 @@ import { withTimeout } from "@/utils";
 import { App, TFile } from "obsidian";
 
 const MAX_K = 20;
+const MIYO_RELATED_SEARCH_TIMEOUT_MS = 8000;
 const MIYO_FOLDER_LOOKUP_TIMEOUT_MS = 8000;
 const MIYO_UNINDEXED_SOURCE_DETAIL = "No indexed chunks found for file_path";
 
@@ -52,17 +53,29 @@ async function calculateSimilarityScoreFromMiyo(
   const miyoFilePath = getMiyoFilePath(app, filePath);
   let baseUrl: string;
   try {
-    baseUrl = await miyoClient.resolveBaseUrl(getMiyoCustomUrl(settings));
+    baseUrl = await withTimeout(
+      () => miyoClient.resolveBaseUrl(getMiyoCustomUrl(settings)),
+      MIYO_RELATED_SEARCH_TIMEOUT_MS,
+      "Relevant Notes Miyo endpoint resolution"
+    );
   } catch (error) {
     logError(`RelevantNotes(Miyo): could not resolve Miyo: ${(error as Error).message}`);
     return { similarityScoreMap: new Map(), semanticState: "unavailable" };
   }
 
   try {
-    const response = await miyoClient.searchRelated(baseUrl, miyoFilePath, {
-      folderName,
-      limit: MAX_K,
-    });
+    // Obsidian's requestUrl can stay pending after a connection is accepted.
+    // Bound the primary request so graph rows and unavailable guidance return.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+    const response = await withTimeout(
+      () =>
+        miyoClient.searchRelated(baseUrl, miyoFilePath, {
+          folderName,
+          limit: MAX_K,
+        }),
+      MIYO_RELATED_SEARCH_TIMEOUT_MS,
+      "Relevant Notes Miyo related search"
+    );
     const similarityScoreMap = new Map<string, number>();
     const results = response.results || [];
 

--- a/src/settings/SettingsPage.tsx
+++ b/src/settings/SettingsPage.tsx
@@ -2,6 +2,7 @@ import CopilotView from "@/components/CopilotView";
 import { CHAT_VIEWTYPE } from "@/constants";
 import CopilotPlugin from "@/main";
 import { getSettings } from "@/settings/model";
+import { consumeRequestedCopilotSettingsTab } from "@/settings/openSettings";
 import { logInfo, logError } from "@/logger";
 import { App, Notice, PluginSettingTab } from "obsidian";
 import React from "react";
@@ -67,6 +68,8 @@ export class CopilotSettingTab extends PluginSettingTab {
     const div = containerEl.createDiv("div");
     const sections = createPluginRoot(div, this.app);
 
-    sections.render(<SettingsMainV2 plugin={this.plugin} />);
+    sections.render(
+      <SettingsMainV2 plugin={this.plugin} initialTab={consumeRequestedCopilotSettingsTab()} />
+    );
   }
 }

--- a/src/settings/model.test.ts
+++ b/src/settings/model.test.ts
@@ -421,7 +421,7 @@ describe("sanitizeSettings - legacy Miyo settings cleanup", () => {
     expect("enableMiyoSearch" in sanitizedRecord).toBe(false);
   });
 
-  it("defaults a missing or malformed miyoSyncedExclusions to an empty receipt", () => {
+  it("defaults missing or malformed Miyo sync receipts while preserving strings (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)", () => {
     const withoutReceipt = {
       ...DEFAULT_SETTINGS,
       miyoSyncedExclusions: undefined,
@@ -439,6 +439,26 @@ describe("sanitizeSettings - legacy Miyo settings cleanup", () => {
       miyoSyncedExclusions: '{"device":"d","roots":[]}',
     };
     expect(sanitizeSettings(preserved).miyoSyncedExclusions).toBe('{"device":"d","roots":[]}');
+
+    const withoutIndexScopeReceipt = {
+      ...DEFAULT_SETTINGS,
+      miyoSyncedIndexScope: undefined,
+    } as unknown as CopilotSettings;
+    expect(sanitizeSettings(withoutIndexScopeReceipt).miyoSyncedIndexScope).toBe("");
+
+    const malformedIndexScopeReceipt = {
+      ...DEFAULT_SETTINGS,
+      miyoSyncedIndexScope: 42,
+    } as unknown as CopilotSettings;
+    expect(sanitizeSettings(malformedIndexScopeReceipt).miyoSyncedIndexScope).toBe("");
+
+    const preservedIndexScopeReceipt = {
+      ...DEFAULT_SETTINGS,
+      miyoSyncedIndexScope: '{"device":"d","exclude_folders":[]}',
+    };
+    expect(sanitizeSettings(preservedIndexScopeReceipt).miyoSyncedIndexScope).toBe(
+      '{"device":"d","exclude_folders":[]}'
+    );
   });
 
   it("assigns a userId while stripping obsolete Miyo keys", () => {

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -174,6 +174,12 @@ export interface CopilotSettings {
    * Copilot root change; see `getMiyoExclusionsFingerprint` in miyoUtils.
    */
   miyoSyncedExclusions: string;
+  /**
+   * Device-identified receipt of the Copilot-owned Miyo folder filters last
+   * patched successfully. Used to preserve filters configured directly in Miyo
+   * across later Copilot index-scope edits.
+   */
+  miyoSyncedIndexScope: string;
   /** Which provider to use for self-host web search */
   selfHostSearchProvider: SelfHostSearchProvider;
   /** Firecrawl API key for self-host web search */
@@ -1036,6 +1042,13 @@ export function sanitizeSettings(settings: CopilotSettings): CopilotSettings {
   // Ensure miyoSyncedExclusions has a default value
   if (typeof sanitizedSettings.miyoSyncedExclusions !== "string") {
     sanitizedSettings.miyoSyncedExclusions = DEFAULT_SETTINGS.miyoSyncedExclusions;
+  }
+  // Old data.json files predate the device-scoped ownership receipt. An empty
+  // value makes the first PATCH fall back to the immediately previous Copilot
+  // scope without claiming filters configured directly in Miyo.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/310
+  if (typeof sanitizedSettings.miyoSyncedIndexScope !== "string") {
+    sanitizedSettings.miyoSyncedIndexScope = DEFAULT_SETTINGS.miyoSyncedIndexScope;
   }
 
   // Ensure selfHostSearchProvider is a valid value

--- a/src/settings/openSettings.test.ts
+++ b/src/settings/openSettings.test.ts
@@ -1,0 +1,71 @@
+import { consumeRequestedCopilotSettingsTab, openMiyoSettings } from "@/settings/openSettings";
+import type { App } from "obsidian";
+
+describe("openSettings", () => {
+  afterEach(() => {
+    consumeRequestedCopilotSettingsTab();
+    jest.restoreAllMocks();
+  });
+
+  describe("openMiyoSettings()", () => {
+    it("uses the first Copilot display without rendering the tab twice (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
+      const consumedTabs: string[] = [];
+      const openTabById = jest.fn(() => consumedTabs.push(consumeRequestedCopilotSettingsTab()));
+      const open = jest.fn(() => consumedTabs.push(consumeRequestedCopilotSettingsTab()));
+      let deferredHandoff: FrameRequestCallback | undefined;
+      const ownerWindow = {
+        requestAnimationFrame: jest.fn((callback: FrameRequestCallback) => {
+          deferredHandoff = callback;
+          return 1;
+        }),
+      } as unknown as Window;
+      const app = { setting: { open, openTabById } } as unknown as App;
+
+      openMiyoSettings(app, ownerWindow);
+
+      expect(open).toHaveBeenCalledTimes(1);
+      expect(consumedTabs).toEqual(["miyo"]);
+
+      deferredHandoff?.(0);
+
+      expect(openTabById).not.toHaveBeenCalled();
+    });
+
+    it("hands off after another settings tab opens and schedules from the initiating window (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
+      const consumedTabs: string[] = [];
+      const openTabById = jest.fn(() => consumedTabs.push(consumeRequestedCopilotSettingsTab()));
+      const open = jest.fn();
+      let deferredHandoff: FrameRequestCallback | undefined;
+      const ownerWindow = {
+        requestAnimationFrame: jest.fn((callback: FrameRequestCallback) => {
+          deferredHandoff = callback;
+          return 1;
+        }),
+      } as unknown as Window;
+      const app = { setting: { open, openTabById } } as unknown as App;
+
+      openMiyoSettings(app, ownerWindow);
+
+      expect(open).toHaveBeenCalledTimes(1);
+      expect(openTabById).not.toHaveBeenCalled();
+
+      deferredHandoff?.(0);
+
+      expect(openTabById).toHaveBeenCalledWith("copilot");
+      expect(consumedTabs).toEqual(["miyo"]);
+    });
+  });
+
+  describe("consumeRequestedCopilotSettingsTab()", () => {
+    it("consumes a requested tab once and defaults later ordinary opens to Basic (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
+      const ownerWindow = { requestAnimationFrame: jest.fn() } as unknown as Window;
+      const app = {
+        setting: { open: jest.fn(), openTabById: jest.fn() },
+      } as unknown as App;
+
+      openMiyoSettings(app, ownerWindow);
+      expect(consumeRequestedCopilotSettingsTab()).toBe("miyo");
+      expect(consumeRequestedCopilotSettingsTab()).toBe("basic");
+    });
+  });
+});

--- a/src/settings/openSettings.ts
+++ b/src/settings/openSettings.ts
@@ -1,0 +1,37 @@
+import type { App } from "obsidian";
+
+let isMiyoTabRequested = false;
+
+interface ObsidianSettingsController {
+  open: () => void;
+  openTabById: (id: string) => void;
+}
+
+/**
+ * Open Copilot settings directly on its existing Miyo connection flow.
+ *
+ * @param app - The Obsidian app whose settings modal should open.
+ * @param ownerWindow - The window containing the control that initiated the handoff.
+ */
+export function openMiyoSettings(app: App, ownerWindow: Window): void {
+  const settings = (app as unknown as { setting: ObsidianSettingsController }).setting;
+  isMiyoTabRequested = true;
+  settings.open();
+  // Opening settings consumes the request immediately when Copilot was already
+  // selected. Otherwise hand off on the next paint, after the modal opens, so
+  // Copilot renders only once and no detached React tree is left behind.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+  ownerWindow.requestAnimationFrame(() => {
+    if (isMiyoTabRequested) settings.openTabById("copilot");
+  });
+}
+
+/** Consume the next requested Copilot tab, defaulting to Basic for ordinary settings opens. */
+export function consumeRequestedCopilotSettingsTab(): "basic" | "miyo" {
+  // A one-shot Relevant Notes handoff must not change where ordinary Copilot
+  // settings opens land after it has been consumed.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+  const requestedTab = isMiyoTabRequested ? "miyo" : "basic";
+  isMiyoTabRequested = false;
+  return requestedTab;
+}

--- a/src/settings/v2/SettingsMainV2.test.tsx
+++ b/src/settings/v2/SettingsMainV2.test.tsx
@@ -13,7 +13,9 @@ import React from "react";
 // Every tab body is stubbed empty. The real panels reach for the keychain, Node,
 // and the network, none of which has any bearing on the strip above them.
 jest.mock("@/settings/v2/components/BasicSettings", () => ({ BasicSettings: () => null }));
-jest.mock("@/settings/v2/components/MiyoSettings", () => ({ MiyoSettings: () => null }));
+jest.mock("@/settings/v2/components/MiyoSettings", () => ({
+  MiyoSettings: () => <div>Miyo settings content</div>,
+}));
 jest.mock("@/settings/v2/components/SelfHostSettings", () => ({ SelfHostSettings: () => null }));
 jest.mock("@/settings/v2/components/CommandSettings", () => ({ CommandSettings: () => null }));
 jest.mock("@/settings/v2/components/AdvancedSettings", () => ({ AdvancedSettings: () => null }));
@@ -53,6 +55,13 @@ describe("SettingsMainV2", () => {
       render(<SettingsMainV2 plugin={plugin} />);
 
       expect(screen.queryByRole("tab", { name: /agents/i })).toBeNull();
+    });
+
+    it("opens on Miyo when Relevant Notes requests the existing setup flow (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
+      render(<SettingsMainV2 plugin={plugin} initialTab="miyo" />);
+
+      expect(screen.getByRole("tab", { name: "Miyo" }).getAttribute("aria-selected")).toBe("true");
+      expect(screen.getByText("Miyo settings content")).toBeTruthy();
     });
   });
 });

--- a/src/settings/v2/SettingsMainV2.tsx
+++ b/src/settings/v2/SettingsMainV2.tsx
@@ -133,9 +133,10 @@ const SettingsContent: React.FC = () => {
 
 interface SettingsMainV2Props {
   plugin: CopilotPlugin;
+  initialTab?: TabId;
 }
 
-const SettingsMainV2: React.FC<SettingsMainV2Props> = ({ plugin }) => {
+const SettingsMainV2: React.FC<SettingsMainV2Props> = ({ plugin, initialTab = "basic" }) => {
   // Add a key state that we'll change when resetting
   const [resetKey, setResetKey] = React.useState(0);
   const { latestVersion, hasUpdate } = useLatestVersion(plugin.manifest.version);
@@ -152,7 +153,7 @@ const SettingsMainV2: React.FC<SettingsMainV2Props> = ({ plugin }) => {
   return (
     <PluginProvider plugin={plugin}>
       <ModelManagementProvider api={plugin.modelManagement}>
-        <TabProvider>
+        <TabProvider initialTab={initialTab}>
           {/* Obsidian 1.13 made the settings window resizable, and the panel has
               no width of its own — without a cap the rows stretch to whatever
               the user dragged the window to and every control drifts far from

--- a/src/settings/v2/SettingsMainV2.tsx
+++ b/src/settings/v2/SettingsMainV2.tsx
@@ -27,8 +27,8 @@ import { SelfHostSettings } from "./components/SelfHostSettings";
 //     (LegacyVaultIndexSetting), the off switch a vault not using Miyo needs to
 //     stop indexing; it reads as the legacy index because that is all the flag
 //     still controls once Miyo owns semantic search.
-//   - qaInclusions/qaExclusions — still consumed (Miyo registration snapshot);
-//     their edit UI is deferred per issue #195 ("defer include/exclude").
+//   - qaInclusions/qaExclusions — edited from the Miyo tab's "Index scope"
+//     section, which is where semantic search now lives.
 //   - embeddingModelKey / maxSourceChunks / enableInlineCitations / indexing
 //     limits — still read at runtime (embeddingManager, SearchTools,
 //     VaultQAChainRunner, CopilotPlusChainRunner) with their defaults; a

--- a/src/settings/v2/components/MiyoSettings.searchSkill.test.tsx
+++ b/src/settings/v2/components/MiyoSettings.searchSkill.test.tsx
@@ -95,6 +95,7 @@ const enqueuedSessions: unknown[] = [];
 const verifyMiyoScope = jest.fn<Promise<string>, unknown[]>(async () => "unknown");
 jest.mock("@/miyo/miyoResync", () => ({
   assertCurrentLifecycle: () => undefined,
+  buildMiyoIndexScopeReceipt: () => "index-scope-receipt",
   enqueueMiyoFolderMutation: (task: (lifecycle: number) => Promise<unknown>, session: unknown) => {
     enqueuedSessions.push(session);
     return task(0);
@@ -186,7 +187,7 @@ beforeEach(() => {
   enqueuedSessions.length = 0;
 });
 
-it("registers through the queue with the plugin's session", async () => {
+it("registers through the queue with the plugin's session and records its initial index scope (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)", async () => {
   // The Connect modal is a standalone Obsidian Modal that outlives onunload, so
   // its Add-this-vault callback is the producer most able to act for a closed
   // lifecycle. It must hand the queue the plugin's session, not a fresh one.
@@ -200,6 +201,7 @@ it("registers through the queue with the plugin's session", async () => {
   await lastModalOptions?.onAddVault?.();
 
   expect(enqueuedSessions).toEqual([mockPluginInstance.miyoMutationSession]);
+  expect(updateSetting).toHaveBeenCalledWith("miyoSyncedIndexScope", "index-scope-receipt");
 });
 
 it("verifies scope with the plugin's session, not one this tab obtained itself", async () => {

--- a/src/settings/v2/components/MiyoSettings.searchSkill.test.tsx
+++ b/src/settings/v2/components/MiyoSettings.searchSkill.test.tsx
@@ -147,7 +147,12 @@ jest.mock("@/plusUtils", () => ({ createPlusPageUrl: () => "https://example.com"
 jest.mock("@/utils/vaultPath", () => ({ getVaultBase: () => "/vault" }));
 
 const NoticeMock = jest.fn();
+// Keep the shared mock's classes (Modal / FuzzySuggestModal) — the Index scope
+// editor pulls the pattern-picker modals into this module graph, and they extend
+// those at import time. Only Notice and Platform are overridden, so the tests can
+// read back messages and pin the platform.
 jest.mock("obsidian", () => ({
+  ...jest.requireActual<Record<string, unknown>>("obsidian"),
   Notice: class {
     constructor(message: string) {
       NoticeMock(message);
@@ -600,5 +605,66 @@ describe("scope resync banner", () => {
     fireEvent.click(await screen.findByText("Connect"));
 
     await waitFor(() => expect(verifyMiyoScope).toHaveBeenCalledTimes(2));
+  });
+});
+
+describe("index scope", () => {
+  it("renders the persisted exclusion and inclusion patterns as removable badges", async () => {
+    currentSettings = {
+      ...DEFAULT_SETTINGS,
+      qaExclusions: "notes/private,*.pdf",
+      qaInclusions: "wiki",
+    };
+    render(<MiyoSettings />);
+
+    expect(await screen.findByLabelText("Remove notes/private")).toBeTruthy();
+    expect(screen.getByLabelText("Remove *.pdf")).toBeTruthy();
+    expect(screen.getByLabelText("Remove wiki")).toBeTruthy();
+  });
+
+  it("persists the narrowed list to qaExclusions when an exclusion is removed", async () => {
+    currentSettings = {
+      ...DEFAULT_SETTINGS,
+      qaExclusions: "notes/private,*.pdf",
+      qaInclusions: "wiki",
+    };
+    render(<MiyoSettings />);
+
+    fireEvent.click(await screen.findByLabelText("Remove notes/private"));
+
+    expect(updateSetting).toHaveBeenCalledWith("qaExclusions", "*.pdf");
+  });
+
+  it("persists to qaInclusions when an inclusion is removed, leaving exclusions untouched", async () => {
+    currentSettings = {
+      ...DEFAULT_SETTINGS,
+      qaExclusions: "notes/private",
+      qaInclusions: "wiki",
+    };
+    render(<MiyoSettings />);
+
+    fireEvent.click(await screen.findByLabelText("Remove wiki"));
+
+    expect(updateSetting).toHaveBeenCalledWith("qaInclusions", "");
+    expect(updateSetting).not.toHaveBeenCalledWith("qaExclusions", expect.anything());
+  });
+
+  it("stays editable while Miyo is disconnected", async () => {
+    // These patterns filter Copilot's own retrieval and Relevant Notes whether
+    // or not Miyo is reachable, and the Relevant Notes "This note is excluded"
+    // state points here for the fix — gating them on the connection would
+    // strand a user with an excluded note and no way to include it.
+    mockMiyoBackend = "unavailable";
+    currentSettings = {
+      ...DEFAULT_SETTINGS,
+      enableMiyo: false,
+      qaExclusions: "notes/private",
+      qaInclusions: "",
+    };
+    render(<MiyoSettings />);
+
+    fireEvent.click(await screen.findByLabelText("Remove notes/private"));
+
+    expect(updateSetting).toHaveBeenCalledWith("qaExclusions", "");
   });
 });

--- a/src/settings/v2/components/MiyoSettings.tsx
+++ b/src/settings/v2/components/MiyoSettings.tsx
@@ -38,6 +38,7 @@ import {
   MiyoConnectModal,
 } from "@/settings/v2/components/MiyoConnectModal";
 import { MiyoStatusRow } from "@/settings/v2/components/MiyoStatusRow";
+import { PatternListEditor } from "@/settings/v2/components/PatternListEditor";
 import { err2String } from "@/utils";
 import { getVaultBase } from "@/utils/vaultPath";
 import { extractAppIgnoreSettings, getSystemExcludedFolders } from "@/search/searchUtils";
@@ -1045,6 +1046,38 @@ export const MiyoSettings: React.FC = () => {
           </div>
         </div>
       </div>
+
+      {/* Index scope — `qaExclusions` / `qaInclusions`. Deliberately NOT
+          connection-gated: these patterns filter Copilot's own retrieval,
+          Relevant Notes, and project context whether or not Miyo is reachable,
+          so gating them would strand a user whose note is excluded with no way
+          to include it. */}
+      <SettingSection
+        label="Index scope"
+        description="Which notes Copilot searches and shows in Relevant Notes; your Copilot folder is always excluded. Miyo's own index keeps the scope it was registered with until you re-add this folder in the Miyo app."
+      >
+        <SettingItem
+          type="custom"
+          title="Exclusions"
+          description="Skip these folders, tags, notes, or file extensions."
+        >
+          <PatternListEditor
+            value={settings.qaExclusions}
+            onChange={(value) => updateSetting("qaExclusions", value)}
+          />
+        </SettingItem>
+
+        <SettingItem
+          type="custom"
+          title="Inclusions"
+          description="Search only these folders, tags, or notes. Leave empty to cover the whole vault; exclusions take precedence."
+        >
+          <PatternListEditor
+            value={settings.qaInclusions}
+            onChange={(value) => updateSetting("qaInclusions", value)}
+          />
+        </SettingItem>
+      </SettingSection>
     </div>
   );
 };

--- a/src/settings/v2/components/MiyoSettings.tsx
+++ b/src/settings/v2/components/MiyoSettings.tsx
@@ -14,6 +14,7 @@ import { MiyoClient } from "@/miyo/MiyoClient";
 import { type CapabilityStatus, refreshMiyoStatus } from "@/miyo/miyoStatusStore";
 import {
   assertCurrentLifecycle,
+  buildMiyoIndexScopeReceipt,
   enqueueMiyoFolderMutation,
   resyncMiyoFolder,
   verifyMiyoScope,
@@ -434,13 +435,12 @@ export const MiyoSettings: React.FC = () => {
     const attempt = (connectAttemptRef.current += 1);
     const superseded = () => connectAttemptRef.current !== attempt || !mountedRef.current;
     try {
-      // DESIGN NOTE: the filters below are a REGISTRATION-TIME SNAPSHOT of the
-      // current scope, sent only on this first POST; registered folders are never
-      // PATCHed when scope changes later. The two sources drift differently:
-      //   - qaInclusions/qaExclusions: SAFE to snapshot. MiyoSemanticRetriever
-      //     re-applies the LIVE qa* scope at query time (filterByCopilotPatterns),
-      //     so even if Miyo's index drifts after a qa* change, retrieval results
-      //     still honor the current scope.
+      // DESIGN NOTE: the filters below seed the registration's initial scope.
+      // The two sources update differently afterward:
+      //   - Representable qaInclusions/qaExclusions changes are PATCHed through
+      //     the settings-store subscriber. Tags and individual notes have no
+      //     Miyo folder-API equivalent, so MiyoSemanticRetriever re-applies the
+      //     live qa* scope at query time for those patterns.
       //   - Obsidian userIgnoreFilters (extractAppIgnoreSettings): NOT re-applied
       //     at query time (shouldIndexFile ignores them), so this snapshot is the
       //     ONLY thing that scopes them. Editing Obsidian's "Excluded files" after
@@ -448,7 +448,7 @@ export const MiyoSettings: React.FC = () => {
       //     content from Miyo until re-registration — a real (if narrow) gap for a
       //     path excluded post-registration while Relay is on. Closing it properly
       //     needs either a query-time userIgnoreFilters filter in the retriever or
-      //     an idempotent folder-filter re-sync; both are out of this PR's scope.
+      //     its own settings-change trigger; both are outside this boundary.
       //     If a review flags this again, point them at this note.
       // Serialized with resync runs: the Resync button's DELETE/POST must never
       // interleave with this registration. The task reads settings when it RUNS,
@@ -510,7 +510,11 @@ export const MiyoSettings: React.FC = () => {
           freshUrl || undefined,
           () => assertCurrentLifecycle(lifecycle)
         );
-        return { created, receipt: buildMiyoSyncReceipt(app, fresh) };
+        return {
+          created,
+          receipt: buildMiyoSyncReceipt(app, fresh),
+          indexScopeReceipt: buildMiyoIndexScopeReceipt(app, fresh),
+        };
       }, miyoMutationSession);
       // Record the sync receipt only for a fresh 201 — a 409 (already
       // registered) means the server holds an EARLIER snapshot whose exclusions
@@ -518,8 +522,10 @@ export const MiyoSettings: React.FC = () => {
       // resync prompt over a stale scope. Written before the enable step and
       // regardless of `superseded()`: the server-side registration DID happen
       // with this exact body, whatever the UI does afterwards.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/310
       if (submission.created !== null) {
         updateSetting("miyoSyncedExclusions", submission.receipt);
+        updateSetting("miyoSyncedIndexScope", submission.indexScopeReceipt);
       }
     } catch (error) {
       logWarn(`Miyo add-folder failed: ${err2String(error)}`);
@@ -1054,7 +1060,7 @@ export const MiyoSettings: React.FC = () => {
           to include it. */}
       <SettingSection
         label="Index scope"
-        description="Which notes Copilot searches and shows in Relevant Notes; your Copilot folder is always excluded. Miyo's own index keeps the scope it was registered with until you re-add this folder in the Miyo app."
+        description="Which notes Copilot searches and shows in Relevant Notes; your Copilot folder is always excluded. Folder and file-extension changes also update this vault's Miyo index without widening stricter filters set in Miyo."
       >
         <SettingItem
           type="custom"

--- a/src/settings/v2/components/PatternListEditor.stories.tsx
+++ b/src/settings/v2/components/PatternListEditor.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@/lib/story";
+import { PatternListEditor, type PatternListEditorProps } from "./PatternListEditor";
+
+const meta = {
+  title: "Settings/Pattern List Editor",
+  component: PatternListEditor,
+  args: {
+    value: "",
+    onChange: () => {},
+  },
+  parameters: { gallery: { host: "settings-tab", layout: "padded" } },
+} satisfies Meta<PatternListEditorProps>;
+export default meta;
+
+/** No patterns yet — the state a vault with an untouched Index scope shows. */
+export const Empty: StoryObj<PatternListEditorProps> = {};
+
+/** One badge per pattern kind, so the icon and colour of each stays checkable. */
+export const AllPatternKinds: StoryObj<PatternListEditorProps> = {
+  args: { value: "notes/private,#archive,[[Daily Note]],*.pdf" },
+};
+
+/** A path long enough to truncate inside its badge rather than widen the row. */
+export const LongPatternTruncates: StoryObj<PatternListEditorProps> = {
+  args: { value: "Archive/2024/Quarterly Reviews/Engineering/Retrospectives" },
+};
+
+/** Past the collapsed height the list fades out and offers "Show N items". */
+export const OverflowsCollapsed: StoryObj<PatternListEditorProps> = {
+  args: {
+    value: [
+      "copilot",
+      "Archive",
+      "Templates",
+      "Attachments",
+      "Journal/2023",
+      "Journal/2024",
+      "#draft",
+      "#private",
+      "*.pdf",
+      "*.canvas",
+      "[[Scratchpad]]",
+      "[[Inbox]]",
+    ].join(","),
+  },
+};

--- a/src/settings/v2/components/PatternListEditor.tsx
+++ b/src/settings/v2/components/PatternListEditor.tsx
@@ -37,7 +37,7 @@ const PATTERN_TYPE_CONFIG = {
 
 type PatternType = keyof typeof PATTERN_TYPE_CONFIG;
 
-interface PatternListEditorProps {
+export interface PatternListEditorProps {
   value: string;
   onChange: (value: string) => void;
   maxCollapsedHeight?: number;


### PR DESCRIPTION
Fixes Brevilabs/obsidian-copilot-private#280

## Why

Relevant Notes still mixes Miyo with Copilot's legacy local embedding index and exposes a local **Build index** flow. It can also hide setup guidance when links or backlinks survive, then incorrectly suggest setup when Miyo is already configured but the active note is new or excluded from indexing.

## What

Relevant Notes now uses Miyo as its only semantic scorer while preserving links and backlinks independently.

| State | Result | Action |
| --- | --- | --- |
| Miyo is disabled | The shared setup card appears even when graph rows exist | **Download Miyo** or **Set up in Copilot** |
| Miyo is unavailable or the vault is not registered | Graph rows remain visible with connection guidance | Review Copilot's Miyo settings |
| The vault is registered but Miyo has no chunks for the active note | The pane says the note is not indexed and explains that it may still be indexing or excluded | Open local Miyo, or review the configured connection on mobile and remote endpoints |
| Copilot excludes the active note | The pane identifies the Copilot exclusion instead of suggesting Miyo setup | Adjust Index scope in Copilot's Miyo settings |
| Miyo succeeds with no usable matches | The pane reports **No semantic matches yet** without setup guidance | None |
| Miyo returns matches | Miyo supplies similarity percentages; graph relationships remain included | None |

Slow or stalled Miyo requests are bounded, and an older request cannot replace results for a newer note or endpoint.

## Non goal

- Distinguishing a newly added note from a Miyo-excluded note when Miyo returns the same no-chunks response for both.
- Changing Miyo's API or its indexing and exclusion controls.
- Changing the ranking formula, result cap, or link and backlink collection.
- Building an in-plugin fallback embedding path.
- Changing the other Relevant Notes controls tracked by Brevilabs/obsidian-copilot-private#282.

## Screenshot

| State | Rendered evidence |
| --- | --- |
| Before: links survived, but the pane offered only the legacy local-index action | ![Before: links and backlinks without Miyo guidance](https://github.com/user-attachments/assets/ea8cd153-f65e-4022-80e2-c739314080c5) |
| After: Miyo disabled, no graph rows | ![No-Miyo empty state with download and setup actions](https://github.com/user-attachments/assets/6656033c-c368-4939-bd87-53e30963fe5c) |
| After: Miyo disabled, links and backlinks retained | ![Links and backlinks retained below the same no-Miyo card](https://github.com/user-attachments/assets/1c0a94b0-9323-4cbb-a808-feb43acd386c) |
| Miyo unavailable, links and backlinks retained | ![Unavailable Miyo guidance with graph rows](https://github.com/user-attachments/assets/5ea8ed0e-6e9e-49be-841c-db23cec60e2b) |
| Setup handoff | ![Copilot settings open directly on the Miyo tab](https://github.com/user-attachments/assets/0ed87f84-2482-460a-8fc4-409c6952f7b8) |
| Installed Miyo returns scored results | ![Relevant Notes with Miyo similarity scores](https://github.com/user-attachments/assets/9a796b08-fa97-445e-8371-859ccf1d8440) |
| Registered vault, active note not indexed | ![Not-indexed guidance with Open Miyo action and graph rows](https://github.com/user-attachments/assets/d8cd3ef3-fe28-49fa-84f3-dc0e277992d5) |
| Copilot excludes the active note | ![Explicit Copilot exclusion guidance](https://github.com/user-attachments/assets/5ae5b267-fd0a-4686-90fd-e5299e6db024) |
| Healthy Miyo query with no usable semantic matches | ![No semantic matches state without a setup action](https://github.com/user-attachments/assets/e4b23592-5f36-4e90-8df2-ed2122a8d302) |

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Deterministic tests cover scoring, state classification, timeouts, stale responses, guidance, and settings handoff |
| A defect would fail CI or be obvious on first use | ✅ | State and pane tests run in CI, while layout and actions appear on the next pane open |
| A revert fully restores prior state, including persisted data | ✅ | No settings schema, vault data, or migration changes |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Existing Miyo connection settings and credentials are unchanged |
| No public API, plugin API, message, or on-disk contract changes | ✅ | The changed result states are internal to Relevant Notes and Copilot settings |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Request cancellation and bounded waits are contained to this optional side pane and deterministically covered |
| No hot-path behavior lacks deterministic coverage | ✅ | Success, disabled, unavailable, timeout, not-indexed, excluded, empty, links-only, and stale-request paths are covered |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Layout and navigation results appear immediately in Relevant Notes and Copilot settings |

Review: run Verification steps 2–5, focusing on the links-only, not-indexed, excluded, and healthy-empty states.

## Verification

1. Load the branch in an Obsidian test vault, register that vault with the installed Miyo app, and prepare a source note with an outgoing link plus a backlink.
2. Disable Miyo and open Relevant Notes for that source. Confirm the centered download/setup card appears above both graph rows and no **Build index** action remains.
3. Enable Miyo, keep the vault registered, and open a source Miyo has not indexed. Confirm the pane says the note is not indexed, preserves graph rows, and **Open Miyo** opens the installed desktop app. Confirm a remote endpoint instead offers **Review Miyo connection** and opens Copilot's Miyo tab.
4. Add the active source to the exclusions under Index scope in Copilot's Miyo settings. Confirm the pane identifies the Copilot exclusion and does not ask the user to install or set up Miyo.
5. Open an indexed source and confirm scored Miyo results. Then restrict Copilot's search scope so Miyo succeeds but no candidate can render; confirm **No semantic matches yet** appears with no setup action.
6. Make Miyo unavailable and confirm graph rows remain with connection guidance. Open the settings action from another Copilot settings tab and confirm it lands directly on Miyo.

