### PR TITLE
Scope Agent Miyo search to the active vault

### DIFF
--- a/src/agentMode/acp/AcpBackendProcess.test.ts
+++ b/src/agentMode/acp/AcpBackendProcess.test.ts
@@ -69,7 +69,9 @@ jest.mock("./AcpProcessManager", () => ({
 
 function buildApp(basePath = "/vault"): App {
   const adapter = new (FileSystemAdapter as unknown as new (basePath: string) => unknown)(basePath);
-  return { vault: { adapter } } as unknown as App;
+  return {
+    vault: { adapter, getName: () => basePath.split(/[/\\]/).filter(Boolean).at(-1) ?? "" },
+  } as unknown as App;
 }
 
 function buildStubBackend(overrides: Partial<AcpBackend> = {}): AcpBackend {
@@ -115,6 +117,25 @@ describe("AcpBackendProcess", () => {
     mockResumeSession.mockResolvedValue({});
     mockLoadSession.mockClear();
     mockLoadSession.mockResolvedValue({});
+  });
+
+  describe("start()", () => {
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/121 passes the active vault identity to the shared process used by global and Project sessions", async () => {
+      const agentBackend = buildStubBackend();
+      const backend = new AcpBackendProcess(
+        buildApp("/Volumes/Notes/Main Vault"),
+        agentBackend,
+        "1.0.0",
+        buildStubDescriptor()
+      );
+
+      await backend.start();
+
+      expect(agentBackend.buildSpawnDescriptor).toHaveBeenCalledWith({
+        vaultBasePath: "/Volumes/Notes/Main Vault",
+        vaultName: "Main Vault",
+      });
+    });
   });
 
   describe("routeSessionUpdate()", () => {

--- a/src/agentMode/acp/AcpBackendProcess.ts
+++ b/src/agentMode/acp/AcpBackendProcess.ts
@@ -41,6 +41,7 @@ import type {
 } from "@/agentMode/session/types";
 import { wrapStreamsForDebug } from "./debugTap";
 import { AcpBackend } from "./types";
+import { getMiyoFolderName } from "@/miyo/miyoUtils";
 import {
   withoutExpiredWindows,
   type PlanUsage,
@@ -222,6 +223,7 @@ export class AcpBackendProcess implements BackendProcess {
     }
     const descriptor = await this.backend.buildSpawnDescriptor({
       vaultBasePath: adapter.getBasePath(),
+      vaultName: getMiyoFolderName(this.app),
     });
 
     const procOpts: AcpProcessManagerOptions = {

--- a/src/agentMode/acp/AcpBackendProcess.ts
+++ b/src/agentMode/acp/AcpBackendProcess.ts
@@ -41,7 +41,6 @@ import type {
 } from "@/agentMode/session/types";
 import { wrapStreamsForDebug } from "./debugTap";
 import { AcpBackend } from "./types";
-import { getMiyoFolderName } from "@/miyo/miyoUtils";
 import {
   withoutExpiredWindows,
   type PlanUsage,
@@ -223,7 +222,7 @@ export class AcpBackendProcess implements BackendProcess {
     }
     const descriptor = await this.backend.buildSpawnDescriptor({
       vaultBasePath: adapter.getBasePath(),
-      vaultName: getMiyoFolderName(this.app),
+      vaultName: this.app.vault.getName(),
     });
 
     const procOpts: AcpProcessManagerOptions = {

--- a/src/agentMode/acp/types.ts
+++ b/src/agentMode/acp/types.ts
@@ -24,7 +24,11 @@ export interface AcpBackend {
   /** Human-readable name surfaced in the UI. */
   readonly displayName: string;
   /** Build the spawn descriptor (BYOK keys decrypted, env composed). */
-  buildSpawnDescriptor(ctx: { vaultBasePath: string }): Promise<AcpSpawnDescriptor>;
+  buildSpawnDescriptor(ctx: {
+    vaultBasePath: string;
+    /** Human-readable name of the active vault, independent of session cwd. */
+    vaultName?: string;
+  }): Promise<AcpSpawnDescriptor>;
   /** Return false to keep backend-owned agent-message text out of the session. */
   readonly shouldRouteAgentMessageText?: (text: string) => boolean;
   /**

--- a/src/agentMode/backends/claude/descriptor.test.ts
+++ b/src/agentMode/backends/claude/descriptor.test.ts
@@ -1,6 +1,12 @@
 import type { AgentSession } from "@/agentMode/session/AgentSession";
 import type { BackendState, InstallState } from "@/agentMode/session/types";
-import { resetSettings, type CopilotSettings } from "@/settings/model";
+import { resetSettings, setSettings, type CopilotSettings } from "@/settings/model";
+import {
+  MIYO_SEARCH_FOLDER_ENV,
+  MIYO_SEARCH_SCOPE_ENV,
+} from "@/agentMode/skills/builtin/builtinSkills";
+import { __resetVaultBaseCache } from "@/utils/vaultPath";
+import { FileSystemAdapter, type App } from "obsidian";
 import { resolveClaudeBinary } from "./claudeBinaryResolver";
 import { claudeCompatibilityStore } from "./claudeCompatibilityStore";
 import {
@@ -57,6 +63,60 @@ function settingsWithClaudeRuntime(options: {
 describe("claude descriptor", () => {
   beforeEach(() => {
     jest.resetAllMocks();
+  });
+
+  describe("ClaudeBackendDescriptor.createBackendProcess()", () => {
+    afterEach(() => {
+      resetSettings();
+      __resetVaultBaseCache();
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/121 gives global and Project sessions the same protected active-vault Miyo identity", async () => {
+      resetSettings();
+      __resetVaultBaseCache();
+      mockResolveClaudeBinary.mockReturnValue("/usr/local/bin/claude");
+      setSettings({
+        miyoSearchAll: false,
+        agentMode: {
+          byok: {},
+          activeBackend: "claude",
+          debugFullFrames: false,
+          welcomeDismissed: false,
+          skills: { folder: "copilot/skills" },
+          backends: {
+            claude: {
+              envOverrides: {
+                [MIYO_SEARCH_SCOPE_ENV]: "unrestricted",
+                [MIYO_SEARCH_FOLDER_ENV]: "other-vault",
+              },
+            },
+          },
+        },
+      });
+      const adapter = Object.create(FileSystemAdapter.prototype) as FileSystemAdapter;
+      adapter.getBasePath = () => "/active-vault";
+      const app = { vault: { adapter, getName: () => "active-vault" } } as unknown as App;
+
+      const process = ClaudeBackendDescriptor.createBackendProcess({
+        plugin: {} as never,
+        app,
+        clientVersion: "4.0.0",
+        descriptor: ClaudeBackendDescriptor,
+      }) as unknown as {
+        opts: {
+          getEnvOverrides?: () => Record<string, string> | undefined;
+          getManagedEnv?: () => Promise<Readonly<Record<string, string>>>;
+        };
+      };
+
+      expect(process.opts.getEnvOverrides?.()).toEqual({});
+      await expect(process.opts.getManagedEnv?.()).resolves.toEqual(
+        expect.objectContaining({
+          [MIYO_SEARCH_SCOPE_ENV]: "current",
+          [MIYO_SEARCH_FOLDER_ENV]: "active-vault",
+        })
+      );
+    });
   });
 
   describe("getClaudeInstallState()", () => {

--- a/src/agentMode/backends/claude/descriptor.ts
+++ b/src/agentMode/backends/claude/descriptor.ts
@@ -19,8 +19,12 @@ import { agentOriginEnabledModelEntries } from "@/agentMode/backends/shared/agen
 import { ClaudeSdkBackendProcess } from "@/agentMode/sdk/ClaudeSdkBackendProcess";
 import { getCachedSdkCatalog, synthesizeEffortConfigOption } from "@/agentMode/sdk/effortOption";
 import { buildAgentSystemPrompt } from "@/agentMode/backends/shared/agentSystemPrompt";
-import { buildBuiltinSkillEnv } from "@/agentMode/backends/shared/builtinSkillEnv";
+import {
+  buildBuiltinSkillEnv,
+  sanitizeBuiltinSkillEnvOverrides,
+} from "@/agentMode/backends/shared/builtinSkillEnv";
 import { getVaultBase } from "@/utils/vaultPath";
+import { getMiyoFolderName } from "@/miyo/miyoUtils";
 import type {
   BackendAuth,
   BackendConfigOption,
@@ -330,10 +334,16 @@ export const ClaudeBackendDescriptor: ClaudeDescriptor = {
       clientVersion: args.clientVersion,
       descriptor: args.descriptor,
       getEnableThinking: () => Boolean(getSettings().agentMode?.backends?.claude?.enableThinking),
-      getEnvOverrides: () => getSettings().agentMode?.backends?.claude?.envOverrides,
+      getEnvOverrides: () =>
+        sanitizeBuiltinSkillEnvOverrides(getSettings().agentMode?.backends?.claude?.envOverrides),
       // Plugin-managed runtime paths and credentials for builtin skills.
       // Passed as a callback so `sdk/` need not import `backends/` (lint boundary).
-      getManagedEnv: () => buildBuiltinSkillEnv(args.clientVersion, getVaultBase(args.app) ?? ""),
+      getManagedEnv: () =>
+        buildBuiltinSkillEnv(
+          args.clientVersion,
+          getVaultBase(args.app) ?? "",
+          getMiyoFolderName(args.app)
+        ),
       checkAuth: async () =>
         (await getClaudeAuthStatus(claudePath, claudeChildEnv(getSettings()))).loggedIn,
       checkCompatibility: () =>

--- a/src/agentMode/backends/codex/CodexBackend.test.ts
+++ b/src/agentMode/backends/codex/CodexBackend.test.ts
@@ -8,6 +8,10 @@ import {
 import type { UserSystemPrompt } from "@/system-prompts/type";
 import { SYMPOSIUM_WORKSPACE_ROOT_ENV } from "@/symposium/constants";
 import { buildAgentSystemPrompt } from "@/agentMode/backends/shared/agentSystemPrompt";
+import {
+  MIYO_SEARCH_FOLDER_ENV,
+  MIYO_SEARCH_SCOPE_ENV,
+} from "@/agentMode/skills/builtin/builtinSkills";
 import { CodexBackend, toTomlBasicString } from "./CodexBackend";
 
 jest.mock("@/logger", () => ({
@@ -103,6 +107,36 @@ describe("CodexBackend.buildSpawnDescriptor", () => {
     });
 
     expect(desc.env.COPILOT_CLIENT_VERSION).toBe("4.0.0-preview-260802");
+  });
+
+  it("https://github.com/Brevilabs/obsidian-copilot-private/issues/121 gives global and Project sessions the same protected active-vault Miyo identity", async () => {
+    setSettings({
+      miyoSearchAll: false,
+      agentMode: {
+        byok: {},
+        activeBackend: "codex",
+        debugFullFrames: false,
+        welcomeDismissed: false,
+        skills: { folder: "copilot/skills" },
+        backends: {
+          codex: {
+            binaryPath: "/usr/local/bin/codex-acp",
+            envOverrides: {
+              [MIYO_SEARCH_SCOPE_ENV]: "unrestricted",
+              [MIYO_SEARCH_FOLDER_ENV]: "other-vault",
+            },
+          },
+        },
+      },
+    });
+
+    const desc = await new CodexBackend().buildSpawnDescriptor({
+      vaultBasePath: "/active-vault",
+      vaultName: "active-vault",
+    });
+
+    expect(desc.env[MIYO_SEARCH_SCOPE_ENV]).toBe("current");
+    expect(desc.env[MIYO_SEARCH_FOLDER_ENV]).toBe("active-vault");
   });
 
   it("encodes the shared product prompt into both paths, byte for byte", async () => {

--- a/src/agentMode/backends/codex/CodexBackend.ts
+++ b/src/agentMode/backends/codex/CodexBackend.ts
@@ -2,7 +2,10 @@ import { getSettings } from "@/settings/model";
 import { AcpBackend, AcpSpawnDescriptor } from "@/agentMode/acp/types";
 import { buildSimpleSpawnDescriptor } from "@/agentMode/backends/shared/simpleBinaryBackend";
 import { buildAgentSystemPrompt } from "@/agentMode/backends/shared/agentSystemPrompt";
-import { buildBuiltinSkillEnv } from "@/agentMode/backends/shared/builtinSkillEnv";
+import {
+  buildBuiltinSkillEnv,
+  sanitizeBuiltinSkillEnvOverrides,
+} from "@/agentMode/backends/shared/builtinSkillEnv";
 import type { PlanUsageReading } from "@/agentMode/session/planUsage";
 import { defaultCodexHome, readCodexPlanUsage } from "./codexPlanUsage";
 import { mergeCodexConfigEnv } from "./codexConfigEnv";
@@ -30,14 +33,18 @@ export class CodexBackend implements AcpBackend {
 
   constructor(private readonly clientVersion = "") {}
 
-  async buildSpawnDescriptor(ctx: { vaultBasePath: string }): Promise<AcpSpawnDescriptor> {
+  async buildSpawnDescriptor(ctx: {
+    vaultBasePath: string;
+    vaultName?: string;
+  }): Promise<AcpSpawnDescriptor> {
+    const settings = getSettings();
     const descriptor = buildSimpleSpawnDescriptor(
-      getSettings().agentMode?.backends?.codex?.binaryPath,
+      settings.agentMode?.backends?.codex?.binaryPath,
       "Codex binary path not configured. Open Agent Mode settings and set the path to codex-acp.",
-      getSettings().agentMode?.backends?.codex?.envOverrides,
+      sanitizeBuiltinSkillEnvOverrides(settings.agentMode?.backends?.codex?.envOverrides),
       {
         // Builtin skills consume plugin-managed runtime paths and credentials.
-        ...(await buildBuiltinSkillEnv(this.clientVersion, ctx.vaultBasePath)),
+        ...(await buildBuiltinSkillEnv(this.clientVersion, ctx.vaultBasePath, ctx.vaultName)),
         // Newer adapters derive the initial ACP mode from this variable rather
         // than Codex's approval/sandbox config. User env overrides still win.
         INITIAL_AGENT_MODE: "agent",

--- a/src/agentMode/backends/opencode/OpencodeBackend.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.test.ts
@@ -28,6 +28,10 @@ import {
   buildAgentSystemPrompt,
   COPILOT_PROMPT_BASE,
 } from "@/agentMode/backends/shared/agentSystemPrompt";
+import {
+  MIYO_SEARCH_FOLDER_ENV,
+  MIYO_SEARCH_SCOPE_ENV,
+} from "@/agentMode/skills/builtin/builtinSkills";
 
 function makeSystemPrompt(title: string, content: string): UserSystemPrompt {
   return { title, content, createdMs: 0, modifiedMs: 0, lastUsedMs: 0 };
@@ -989,6 +993,35 @@ describe("OpencodeBackend.buildSpawnDescriptor", () => {
     const desc = await backend.buildSpawnDescriptor({ vaultBasePath: "/vault/abs" });
 
     expect(desc.env.COPILOT_CLIENT_VERSION).toBe("4.0.0-preview-260802");
+  });
+
+  it("https://github.com/Brevilabs/obsidian-copilot-private/issues/121 gives global and Project sessions the same protected active-vault Miyo identity", async () => {
+    setSettings({ miyoSearchAll: false });
+    updateSetting("agentMode", {
+      byok: {},
+      activeBackend: "opencode",
+      debugFullFrames: false,
+      welcomeDismissed: false,
+      skills: { folder: "copilot/skills" },
+      backends: {
+        opencode: {
+          binaryPath: "/path/to/opencode",
+          envOverrides: {
+            [MIYO_SEARCH_SCOPE_ENV]: "unrestricted",
+            [MIYO_SEARCH_FOLDER_ENV]: "other-vault",
+          },
+        },
+      },
+    });
+
+    const desc = await new OpencodeBackend(NO_MODELS_DEPS).buildSpawnDescriptor({
+      vaultBasePath: "/active-vault",
+      vaultName: "active-vault",
+    });
+
+    expect(desc.args).toEqual(["acp", "--cwd", "/active-vault"]);
+    expect(desc.env[MIYO_SEARCH_SCOPE_ENV]).toBe("current");
+    expect(desc.env[MIYO_SEARCH_FOLDER_ENV]).toBe("active-vault");
   });
 
   it("threads the injected getCacheRoot into the spawned external_directory allow", async () => {

--- a/src/agentMode/backends/opencode/OpencodeBackend.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.ts
@@ -9,7 +9,10 @@ import { AcpBackend, AcpSpawnDescriptor } from "@/agentMode/acp/types";
 import type { CopilotMode } from "@/agentMode/session/types";
 import { composeDenyList, getManagedSkills, SkillManager } from "@/agentMode/skills";
 import { buildAgentSystemPrompt } from "@/agentMode/backends/shared/agentSystemPrompt";
-import { buildBuiltinSkillEnv } from "@/agentMode/backends/shared/builtinSkillEnv";
+import {
+  buildBuiltinSkillEnv,
+  sanitizeBuiltinSkillEnvOverrides,
+} from "@/agentMode/backends/shared/builtinSkillEnv";
 import { OpencodeBackendDescriptor } from "./descriptor";
 import { copilotPlusModelId, mapProviderToOpencodeId } from "./opencodeModelResolve";
 import type { PlanUsageReading } from "@/agentMode/session/planUsage";
@@ -111,7 +114,10 @@ export class OpencodeBackend implements AcpBackend {
     return this.#copilotPlus.readContextWindow(copilotPlusModelId(wireModelId));
   }
 
-  async buildSpawnDescriptor(ctx: { vaultBasePath: string }): Promise<AcpSpawnDescriptor> {
+  async buildSpawnDescriptor(ctx: {
+    vaultBasePath: string;
+    vaultName?: string;
+  }): Promise<AcpSpawnDescriptor> {
     const settings = getSettings();
     const binaryPath = settings.agentMode?.backends?.opencode?.binaryPath;
     if (!binaryPath) {
@@ -133,7 +139,9 @@ export class OpencodeBackend implements AcpBackend {
     // rather than leaning on downstream truthiness.
     const cacheRoot = normalizeCacheRoot(this.#deps.getCacheRoot?.());
     const config = await buildOpencodeConfig(settings, this.#deps, cacheRoot);
-    const envOverrides = settings.agentMode?.backends?.opencode?.envOverrides ?? {};
+    const envOverrides = sanitizeBuiltinSkillEnvOverrides(
+      settings.agentMode?.backends?.opencode?.envOverrides
+    );
     // Accepted degradation: a user `OPENCODE_CONFIG_CONTENT` override (spread
     // last below) replaces the whole generated config, dropping the allow rule.
     // opencode then prompts on every snapshot read; the sources still appear in
@@ -149,7 +157,11 @@ export class OpencodeBackend implements AcpBackend {
       );
     }
     // Builtin skills consume plugin-managed runtime paths and credentials.
-    const builtinSkillEnv = await buildBuiltinSkillEnv(this.#deps.clientVersion, ctx.vaultBasePath);
+    const builtinSkillEnv = await buildBuiltinSkillEnv(
+      this.#deps.clientVersion,
+      ctx.vaultBasePath,
+      ctx.vaultName
+    );
 
     return {
       command: binaryPath,
@@ -158,8 +170,8 @@ export class OpencodeBackend implements AcpBackend {
         ...process.env,
         OPENCODE_CONFIG_CONTENT: JSON.stringify(config),
         ...builtinSkillEnv,
-        // User overrides last — they can replace OPENCODE_CONFIG_CONTENT
-        // intentionally if they need to point opencode at a different config.
+        // User overrides stay last for ordinary values. Copilot-owned Miyo
+        // scope keys were removed above so they cannot widen Current vault.
         ...envOverrides,
       },
     };

--- a/src/agentMode/backends/shared/builtinSkillEnv.test.ts
+++ b/src/agentMode/backends/shared/builtinSkillEnv.test.ts
@@ -1,8 +1,16 @@
-import { buildBuiltinSkillEnv } from "./builtinSkillEnv";
+import {
+  buildBuiltinSkillEnv,
+  getBuiltinSkillEnvRestartPolicy,
+  sanitizeBuiltinSkillEnvOverrides,
+} from "./builtinSkillEnv";
 import { getSettings } from "@/settings/model";
 import { getMiyoCustomUrl } from "@/miyo/miyoUtils";
 import { BREVILABS_API_BASE_URL } from "@/constants";
-import { PLUS_ENV } from "@/agentMode/skills/builtin/builtinSkills";
+import {
+  MIYO_SEARCH_FOLDER_ENV,
+  MIYO_SEARCH_SCOPE_ENV,
+  PLUS_ENV,
+} from "@/agentMode/skills/builtin/builtinSkills";
 import { SYMPOSIUM_WORKSPACE_ROOT_ENV } from "@/symposium/constants";
 import {
   COPILOT_OBSIDIAN_CLI_ENV,
@@ -65,11 +73,32 @@ describe("builtinSkillEnv", () => {
       expect(await buildBuiltinSkillEnv()).toEqual({ MIYO_URL: "http://192.168.1.10:8742" });
     });
 
-    it("injects the host workspace root independently of Plus", async () => {
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/121 defaults scope closed when the active vault identity is unavailable", async () => {
       mockGetSettings.mockReturnValue({ isPaidUser: false });
 
       expect(await buildBuiltinSkillEnv("", "/vault")).toEqual({
         [SYMPOSIUM_WORKSPACE_ROOT_ENV]: "/vault",
+        [MIYO_SEARCH_SCOPE_ENV]: "current",
+      });
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/121 injects the active vault identity for Current vault search", async () => {
+      mockGetSettings.mockReturnValue({ isPaidUser: false, miyoSearchAll: false });
+
+      expect(await buildBuiltinSkillEnv("", "/vault/root", "root")).toEqual({
+        [SYMPOSIUM_WORKSPACE_ROOT_ENV]: "/vault/root",
+        [MIYO_SEARCH_SCOPE_ENV]: "current",
+        [MIYO_SEARCH_FOLDER_ENV]: "root",
+      });
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/121 marks Unrestricted search without replacing the active vault identity", async () => {
+      mockGetSettings.mockReturnValue({ isPaidUser: false, miyoSearchAll: true });
+
+      expect(await buildBuiltinSkillEnv("", "/vault/root", "root")).toEqual({
+        [SYMPOSIUM_WORKSPACE_ROOT_ENV]: "/vault/root",
+        [MIYO_SEARCH_SCOPE_ENV]: "unrestricted",
+        [MIYO_SEARCH_FOLDER_ENV]: "root",
       });
     });
 
@@ -97,6 +126,82 @@ describe("builtinSkillEnv", () => {
         [PLUS_ENV.userId]: "user-123",
         [PLUS_ENV.clientVersion]: "4.0.0",
       });
+    });
+  });
+
+  describe("sanitizeBuiltinSkillEnvOverrides()", () => {
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/121 prevents backend overrides from widening Current vault search", () => {
+      expect(
+        sanitizeBuiltinSkillEnvOverrides({
+          MIYO_URL: "http://override.example",
+          [MIYO_SEARCH_SCOPE_ENV]: "unrestricted",
+          [MIYO_SEARCH_FOLDER_ENV]: "other-vault",
+        })
+      ).toEqual({
+        MIYO_URL: "http://override.example",
+      });
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/121 preserves unrelated backend overrides", () => {
+      expect(sanitizeBuiltinSkillEnvOverrides({ ANTHROPIC_MODEL: "claude" })).toEqual({
+        ANTHROPIC_MODEL: "claude",
+      });
+    });
+  });
+
+  describe("getBuiltinSkillEnvRestartPolicy()", () => {
+    it.each([
+      ["isPaidUser", false, true],
+      ["plusLicenseKey", "old", "new"],
+      ["miyoServerUrl", "http://old", "http://new"],
+    ])(
+      "https://github.com/Brevilabs/obsidian-copilot-private/issues/121 defers the spawn-time refresh when %s changes",
+      (key, before, after) => {
+        const prev = { [key]: before } as unknown as ReturnType<typeof getSettings>;
+        const next = { [key]: after } as unknown as ReturnType<typeof getSettings>;
+
+        expect(getBuiltinSkillEnvRestartPolicy(prev, next)).toBe("deferred");
+      }
+    );
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/121 immediately refreshes an enabled skill when scope tightens", () => {
+      const prev = { enableMiyoSearchSkill: true, miyoSearchAll: true } as ReturnType<
+        typeof getSettings
+      >;
+      const next = { enableMiyoSearchSkill: true, miyoSearchAll: false } as ReturnType<
+        typeof getSettings
+      >;
+
+      expect(getBuiltinSkillEnvRestartPolicy(prev, next)).toBe("immediate");
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/121 defers an enabled skill refresh when scope widens", () => {
+      const prev = { enableMiyoSearchSkill: true, miyoSearchAll: false } as ReturnType<
+        typeof getSettings
+      >;
+      const next = { enableMiyoSearchSkill: true, miyoSearchAll: true } as ReturnType<
+        typeof getSettings
+      >;
+
+      expect(getBuiltinSkillEnvRestartPolicy(prev, next)).toBe("deferred");
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/121 skips scope refreshes while the skill is disabled", () => {
+      const prev = { enableMiyoSearchSkill: false, miyoSearchAll: true } as ReturnType<
+        typeof getSettings
+      >;
+      const next = { enableMiyoSearchSkill: false, miyoSearchAll: false } as ReturnType<
+        typeof getSettings
+      >;
+
+      expect(getBuiltinSkillEnvRestartPolicy(prev, next)).toBe("none");
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/121 keeps spawn-time state for unrelated settings changes", () => {
+      const prev = { miyoSearchAll: false, temperature: 0 } as ReturnType<typeof getSettings>;
+      const next = { miyoSearchAll: false, temperature: 1 } as ReturnType<typeof getSettings>;
+
+      expect(getBuiltinSkillEnvRestartPolicy(prev, next)).toBe("none");
     });
   });
 });

--- a/src/agentMode/backends/shared/builtinSkillEnv.ts
+++ b/src/agentMode/backends/shared/builtinSkillEnv.ts
@@ -1,7 +1,11 @@
 import { BREVILABS_API_BASE_URL } from "@/constants";
-import { getSettings } from "@/settings/model";
+import { type CopilotSettings, getSettings } from "@/settings/model";
 import { getMiyoCustomUrl } from "@/miyo/miyoUtils";
-import { PLUS_ENV } from "@/agentMode/skills/builtin/builtinSkills";
+import {
+  MIYO_SEARCH_FOLDER_ENV,
+  MIYO_SEARCH_SCOPE_ENV,
+  PLUS_ENV,
+} from "@/agentMode/skills/builtin/builtinSkills";
 import { SYMPOSIUM_WORKSPACE_ROOT_ENV } from "@/symposium/constants";
 import {
   COPILOT_OBSIDIAN_CLI_ENV,
@@ -12,14 +16,17 @@ import { requireNodeModule } from "@/utils/desktopRuntime";
 /** Env var the bundled `miyo` CLI reads to target a non-default Miyo service. */
 const MIYO_URL_ENV = "MIYO_URL";
 
+const PROTECTED_BUILTIN_ENV_KEYS = [MIYO_SEARCH_SCOPE_ENV, MIYO_SEARCH_FOLDER_ENV] as const;
+
 /** Frozen empty result so unmanaged spawns don't allocate a fresh object each time. */
 const EMPTY_MANAGED_ENV: Readonly<Record<string, string>> = Object.freeze({});
 
 /**
  * Build the plugin-managed environment for builtin skill scripts. Composes
- * independent contributions, all merged BEFORE the user's `envOverrides` so a
- * user can still shadow them; the credential lives only in the agent
- * subprocess env (never written to disk in the skill files):
+ * independent contributions. Ordinary values are merged before the user's
+ * `envOverrides`; the Miyo vault-isolation inputs are protected by each
+ * backend. Credentials live only in the agent subprocess env (never written to
+ * disk in the skill files):
  *
  * - **Obsidian CLI** (`COPILOT_OBSIDIAN_CLI`): terminal-capable executable
  *   shipped with the running desktop install, when present. This avoids
@@ -33,13 +40,17 @@ const EMPTY_MANAGED_ENV: Readonly<Record<string, string>> = Object.freeze({});
  * - **Miyo** (`MIYO_URL`): the user's custom/remote Miyo server URL when set, so
  *   the bundled `miyo` CLI targets their configured service instead of local
  *   loopback discovery (the only way Miyo works on mobile or against a remote
- *   host). Independent of Plus — self-host users may use Miyo without a license.
+ *   host). `COPILOT_MIYO_SEARCH_*` also carries the authoritative Search scope
+ *   and active vault name. Independent of Plus — self-host users may use Miyo
+ *   without a license.
  * @param clientVersion Version reported to the Copilot Plus relay.
  * @param workspaceRootAbs Absolute host workspace root used by portable skills.
+ * @param miyoFolderName Exact active-vault name Miyo resolves on its own host.
  */
 export async function buildBuiltinSkillEnv(
   clientVersion = "",
-  workspaceRootAbs = ""
+  workspaceRootAbs = "",
+  miyoFolderName = ""
 ): Promise<Readonly<Record<string, string>>> {
   const os = requireNodeModule<typeof import("node:os")>("os");
   const settings = getSettings();
@@ -59,6 +70,15 @@ export async function buildBuiltinSkillEnv(
   const miyoUrl = getMiyoCustomUrl(settings);
   if (miyoUrl) env[MIYO_URL_ENV] = miyoUrl;
 
+  if (workspaceRootAbs) {
+    // Only an explicit Unrestricted setting may remove the exact pre-retrieval
+    // vault boundary. The active vault identity stays independent of a Project
+    // session's cwd and remains portable to remote Miyo hosts.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/121
+    env[MIYO_SEARCH_SCOPE_ENV] = settings.miyoSearchAll === true ? "unrestricted" : "current";
+    if (miyoFolderName) env[MIYO_SEARCH_FOLDER_ENV] = miyoFolderName;
+  }
+
   // Copilot Plus relay env — gated on an active subscription with a usable key.
   if (settings.isPaidUser && settings.plusLicenseKey) {
     // Relay skills still require the raw Plus credential in the agent process.
@@ -70,4 +90,49 @@ export async function buildBuiltinSkillEnv(
   }
 
   return Object.keys(env).length === 0 ? EMPTY_MANAGED_ENV : env;
+}
+
+/**
+ * Remove Copilot-owned vault-isolation inputs from user backend overrides.
+ *
+ * Other managed values intentionally remain overridable. The Miyo scope values
+ * are different: allowing a backend override to replace `current` with
+ * `unrestricted` would silently widen a user-selected privacy boundary.
+ * https://github.com/Brevilabs/obsidian-copilot-private/issues/121
+ *
+ * @param envOverrides Optional backend-specific user overrides.
+ * @returns A copy containing only values the backend may override.
+ */
+export function sanitizeBuiltinSkillEnvOverrides(
+  envOverrides?: Readonly<Record<string, string>>
+): Record<string, string> {
+  const sanitized = { ...(envOverrides ?? {}) };
+  for (const key of PROTECTED_BUILTIN_ENV_KEYS) {
+    delete sanitized[key];
+  }
+  return sanitized;
+}
+
+/** How a persisted setting change should refresh the environment captured at spawn. */
+export function getBuiltinSkillEnvRestartPolicy(
+  prev: CopilotSettings,
+  next: CopilotSettings
+): "none" | "deferred" | "immediate" {
+  const ordinaryEnvChanged =
+    prev.isPaidUser !== next.isPaidUser ||
+    prev.plusLicenseKey !== next.plusLicenseKey ||
+    prev.miyoServerUrl !== next.miyoServerUrl;
+  // Scope changes only affect a currently enabled skill. Tightening an active
+  // boundary must cancel the current turn; widening can wait until it is idle.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/121
+  const activeMiyoScopeChanged =
+    prev.enableMiyoSearchSkill === true &&
+    next.enableMiyoSearchSkill === true &&
+    prev.miyoSearchAll !== next.miyoSearchAll;
+
+  if (!ordinaryEnvChanged && !activeMiyoScopeChanged) return "none";
+  if (activeMiyoScopeChanged && prev.miyoSearchAll === true && next.miyoSearchAll !== true) {
+    return "immediate";
+  }
+  return "deferred";
 }

--- a/src/agentMode/index.ts
+++ b/src/agentMode/index.ts
@@ -7,6 +7,7 @@ import { subscribeToSystemPromptChange } from "@/system-prompts/state";
 import { copilotAppDataDir, getVaultId } from "@/utils/appPaths";
 import { requireNodeModule } from "@/utils/desktopRuntime";
 import { buildAgentSystemPrompt } from "./backends/shared/agentSystemPrompt";
+import { getBuiltinSkillEnvRestartPolicy } from "./backends/shared/builtinSkillEnv";
 import { backendRegistry, listBackendDescriptors } from "./backends/registry";
 import type { BackendId } from "./session/types";
 import { AgentChatPersistenceManager } from "./session/AgentChatPersistenceManager";
@@ -343,19 +344,21 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
   subscribeToSettingsChange((prev, next) => {
     // The managed env injected at spawn (see `buildBuiltinSkillEnv`) changes with
     // Copilot Plus sign-in/out or license rotation (the decrypted license the
-    // builtin Plus skill scripts read) and with the Miyo server URL (the
-    // `MIYO_URL` the bundled miyo CLI reads). Either is only read on a fresh
-    // spawn, so restart every backend — otherwise a running subprocess keeps the
-    // stale license/URL until a reload. (Restarts coalesce, so this folds with
-    // any Miyo-availability re-seed restart below.)
-    if (
-      prev.isPaidUser !== next.isPaidUser ||
-      prev.plusLicenseKey !== next.plusLicenseKey ||
-      prev.miyoServerUrl !== next.miyoServerUrl
-    ) {
+    // builtin Plus skill scripts read), with the Miyo server URL (the `MIYO_URL`
+    // the bundled miyo CLI reads), or with the Miyo Search scope. These values
+    // are only read on a fresh spawn, so restart every backend — otherwise a
+    // running subprocess keeps stale policy until a reload. (Restarts coalesce,
+    // so this folds with any Miyo-availability re-seed restart below.)
+    const managedEnvRestartPolicy = getBuiltinSkillEnvRestartPolicy(prev, next);
+    if (managedEnvRestartPolicy !== "none") {
+      // Applying a new search boundary cannot wait for a running turn to finish:
+      // cancel it before it can start another search with the prior scope.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/121
       for (const descriptor of listBackendDescriptors()) {
         void manager
-          .restartBackend(descriptor.id, "managed agent env changed")
+          .restartBackend(descriptor.id, "managed agent env changed", {
+            deferWhileBusy: managedEnvRestartPolicy !== "immediate",
+          })
           .catch((e) =>
             logError(`[AgentMode] restart after managed env change failed: ${descriptor.id}`, e)
           );

--- a/src/agentMode/session/AgentSessionManager.test.ts
+++ b/src/agentMode/session/AgentSessionManager.test.ts
@@ -944,6 +944,20 @@ describe("AgentSessionManager.restartBackend", () => {
     expect(mgr.getActiveSession()?.backendId).toBe("opencode");
   });
 
+  it("https://github.com/Brevilabs/obsidian-copilot-private/issues/121 interrupts a busy turn when a privacy-boundary restart cannot be deferred", async () => {
+    const mgr = buildManager();
+    const first = await mgr.createSession();
+    getSessionTestHandle(first).setStatus("running");
+
+    await expect(
+      mgr.restartBackend("opencode", "Miyo Search scope changed", { deferWhileBusy: false })
+    ).resolves.toBe(true);
+
+    expect(mockSessionCancel).toHaveBeenCalledWith();
+    expect(mockBackendShutdown).toHaveBeenCalledTimes(1);
+    expect(mgr.getActiveSession()).not.toBe(first);
+  });
+
   it("queues a second concurrent restart so the latest settings are not lost", async () => {
     // Repro: a single BYOK save fires many provider/model events that each
     // call restartBackend. Without queueing, only the first restart's
@@ -977,6 +991,45 @@ describe("AgentSessionManager.restartBackend", () => {
     await new Promise((resolve) => window.setTimeout(resolve, 0));
 
     // First call's shutdown + the queued re-run's shutdown = 2.
+    expect(mockBackendShutdown).toHaveBeenCalledTimes(2);
+  });
+
+  it("https://github.com/Brevilabs/obsidian-copilot-private/issues/121 keeps a queued privacy-boundary restart non-deferrable", async () => {
+    const mgr = buildManager();
+    await mgr.createSession();
+
+    // The first refresh's replacement becomes busy before the queued scope
+    // refresh runs. The privacy refresh must still cancel it immediately.
+    sessionCreateSpy.mockImplementationOnce((opts) => {
+      const replacement = makeMockSession({
+        internalId: opts.internalId,
+        chatInputId: opts.chatInputId,
+        backendId: opts.backendId,
+        projectId: opts.projectId,
+      });
+      getSessionTestHandle(replacement).setStatus("running");
+      return replacement;
+    });
+    let releaseShutdown!: () => void;
+    const shutdownStarted = new Promise<void>((resolveStarted) => {
+      mockBackendShutdown.mockImplementationOnce(
+        () =>
+          new Promise<undefined>((resolve) => {
+            resolveStarted();
+            releaseShutdown = () => resolve(undefined);
+          })
+      );
+    });
+
+    const ordinaryRestart = mgr.restartBackend("opencode", "managed env changed");
+    await shutdownStarted;
+    const privacyRestart = mgr.restartBackend("opencode", "Miyo Search scope changed", {
+      deferWhileBusy: false,
+    });
+    releaseShutdown();
+    await Promise.all([ordinaryRestart, privacyRestart]);
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+
     expect(mockBackendShutdown).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -337,7 +337,10 @@ export class AgentSessionManager {
    */
   private lastErrorSeq = 0;
 
-  private readonly pendingBackendRestarts = new Map<BackendId, string>();
+  private readonly pendingBackendRestarts = new Map<
+    BackendId,
+    { reason: string; immediate: boolean }
+  >();
   private readonly restartingBackends = new Set<BackendId>();
   private readonly preloader: AgentModelPreloader;
   /**
@@ -2196,8 +2199,9 @@ export class AgentSessionManager {
 
   /**
    * Restart a backend process so spawn-time configuration, including native
-   * skill discovery and deny rules, is rebuilt from current settings. If a
-   * session on that backend is busy, the restart is deferred until it is idle.
+   * skill discovery and deny rules, is rebuilt from current settings. By
+   * default a busy backend waits until it is idle; privacy-boundary callers can
+   * disable that deferral and cancel the active turn.
    *
    * When the manager owns no process yet, a warm probe held by the preloader
    * may still carry the pre-change spawn config; we refresh it instead (see
@@ -2205,8 +2209,16 @@ export class AgentSessionManager {
    *
    * Returns `true` when a running backend was restarted, a restart was
    * scheduled, or a warm probe was refreshed; `false` when nothing exists yet.
+   *
+   * @param backendId Backend process whose spawn-time state is stale.
+   * @param reason Diagnostic reason recorded for the restart.
+   * @param options Whether a busy turn may delay the restart.
    */
-  async restartBackend(backendId: BackendId, reason: string): Promise<boolean> {
+  async restartBackend(
+    backendId: BackendId,
+    reason: string,
+    options?: { deferWhileBusy?: boolean }
+  ): Promise<boolean> {
     if (this.disposed) return false;
     const inflight = this.starting.get(backendId);
     if (inflight) {
@@ -2214,13 +2226,19 @@ export class AgentSessionManager {
     }
     const backend = this.backends.get(backendId);
     if (!backend) return this.refreshWarmProbe(backendId, reason);
-    if (this.hasBusySession(backendId)) {
+    // Most config changes preserve the current turn. A Search scope change may
+    // opt out so no later tool call uses the prior privacy boundary.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/121
+    if (options?.deferWhileBusy !== false && this.hasBusySession(backendId)) {
       const prev = this.pendingBackendRestarts.get(backendId);
-      this.pendingBackendRestarts.set(backendId, prev ? `${prev}; ${reason}` : reason);
+      this.pendingBackendRestarts.set(backendId, {
+        reason: prev ? `${prev.reason}; ${reason}` : reason,
+        immediate: prev?.immediate ?? false,
+      });
       logInfo(`[AgentMode] deferred ${backendId} backend restart: ${reason}`);
       return true;
     }
-    await this.restartBackendNow(backendId, reason);
+    await this.restartBackendNow(backendId, reason, options?.deferWhileBusy === false);
     return true;
   }
 
@@ -3506,12 +3524,12 @@ export class AgentSessionManager {
 
   /** Execute a pending backend restart once every session for that backend is idle. */
   private async flushDeferredBackendRestartIfReady(backendId: BackendId): Promise<void> {
-    const reason = this.pendingBackendRestarts.get(backendId);
-    if (!reason) return;
-    if (this.hasBusySession(backendId)) return;
+    const pending = this.pendingBackendRestarts.get(backendId);
+    if (!pending) return;
+    if (!pending.immediate && this.hasBusySession(backendId)) return;
     this.pendingBackendRestarts.delete(backendId);
     try {
-      await this.restartBackendNow(backendId, reason);
+      await this.restartBackendNow(backendId, pending.reason, pending.immediate);
     } catch (err) {
       this.setLastError(err2String(err));
       logError(`[AgentMode] deferred ${backendId} backend restart failed`, err);
@@ -3520,7 +3538,11 @@ export class AgentSessionManager {
   }
 
   /** Immediately tear down `backendId` and replace the active affected tab. */
-  private async restartBackendNow(backendId: BackendId, reason: string): Promise<void> {
+  private async restartBackendNow(
+    backendId: BackendId,
+    reason: string,
+    immediate = false
+  ): Promise<void> {
     // A restart is already running for this backend. Stash the reason so the
     // tail of the in-flight restart can re-run with the latest settings —
     // otherwise rapid-fire emits (e.g. one BYOK save touching many models)
@@ -3528,7 +3550,13 @@ export class AgentSessionManager {
     // config until something else triggered another restart.
     if (this.restartingBackends.has(backendId)) {
       const prev = this.pendingBackendRestarts.get(backendId);
-      this.pendingBackendRestarts.set(backendId, prev ? `${prev}; ${reason}` : reason);
+      this.pendingBackendRestarts.set(backendId, {
+        reason: prev ? `${prev.reason}; ${reason}` : reason,
+        immediate: (prev?.immediate ?? false) || immediate,
+      });
+      // A Search scope change queued behind another refresh must keep its
+      // non-deferrable privacy semantics when the first refresh completes.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/121
       return;
     }
     const proc = this.backends.get(backendId);
@@ -3583,14 +3611,14 @@ export class AgentSessionManager {
     const queued = this.pendingBackendRestarts.get(backendId);
     if (queued !== undefined && !this.disposed) {
       this.pendingBackendRestarts.delete(backendId);
-      if (this.hasBusySession(backendId)) {
+      if (!queued.immediate && this.hasBusySession(backendId)) {
         // A session went busy between requests; fall back to the deferral
         // path so we don't tear down mid-turn.
         this.pendingBackendRestarts.set(backendId, queued);
         return;
       }
       try {
-        await this.restartBackendNow(backendId, queued);
+        await this.restartBackendNow(backendId, queued.reason, queued.immediate);
       } catch (err) {
         this.setLastError(err2String(err));
         logError(`[AgentMode] queued ${backendId} backend restart failed`, err);

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -321,6 +321,35 @@ describe("builtinSkills", () => {
       expect(miyoScript(".cmd")).toContain("search %* -n 10 --json");
     });
 
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/121 passes the exact active-vault identity in Current vault mode on POSIX and Windows", () => {
+      const sh = miyoScript(".sh");
+      const cmd = miyoScript(".cmd");
+
+      expect(sh).toContain('case "${COPILOT_MIYO_SEARCH_SCOPE:-current}"');
+      expect(sh).toContain('--folder "$COPILOT_MIYO_SEARCH_FOLDER"');
+      expect(cmd).toContain('if /I "%COPILOT_MIYO_SEARCH_SCOPE%"=="unrestricted"');
+      expect(cmd).toContain('--folder "%COPILOT_MIYO_SEARCH_FOLDER%"');
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/121 omits the folder boundary only for explicit Unrestricted mode on POSIX and Windows", () => {
+      const sh = miyoScript(".sh");
+      const cmd = miyoScript(".cmd");
+
+      expect(sh).toContain('unrestricted)\n    OUT=$("$MIYO" search "$QUERY" -n 10 --json');
+      expect(cmd).toContain(
+        'if /I "%COPILOT_MIYO_SEARCH_SCOPE%"=="unrestricted" (\n  "%MIYO%" search %* -n 10 --json'
+      );
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/121 fails closed when Current vault scope is missing, invalid, or unsupported", () => {
+      for (const script of [miyoScript(".sh"), miyoScript(".cmd")]) {
+        expect(script).toMatch(/active vault identity is missing/i);
+        expect(script).toMatch(/invalid Search scope/i);
+        expect(script).toMatch(/Do not (retry or )?run an unrestricted search/i);
+        expect(script).toMatch(/Update Miyo/i);
+      }
+    });
+
     it("resolves the binary absolute-path-first with a PATH fallback, per OS", () => {
       // POSIX (.sh): absolute install path tried before falling back to PATH.
       expect(miyoScript(".sh")).toContain("$HOME/.miyo/bin/miyo");

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -54,6 +54,10 @@ export const PLUS_ENV = {
   clientVersion: "COPILOT_CLIENT_VERSION",
 } as const;
 
+/** Plugin-owned scope inputs consumed by the managed Miyo search wrappers. */
+export const MIYO_SEARCH_SCOPE_ENV = "COPILOT_MIYO_SEARCH_SCOPE";
+export const MIYO_SEARCH_FOLDER_ENV = "COPILOT_MIYO_SEARCH_FOLDER";
+
 /**
  * No Copilot Plus license is configured — the free-user case (a non-Plus user
  * gets no relay entries from `buildBuiltinSkillEnv`, so `KEY`/`BASE` are absent).
@@ -698,7 +702,7 @@ export const BUILTIN_SKILLS: readonly BuiltinSkill[] = [
   ...OBSIDIAN_SKILLS,
 ];
 
-const MIYO_SEARCH_VERSION = 2;
+const MIYO_SEARCH_VERSION = 3;
 const MIYO_PARSE_VERSION = 1;
 
 /** Shared by both Miyo wrappers; the host script must define `die` before it. */
@@ -743,7 +747,21 @@ QUERY="$*"
 
 ${MIYO_POSIX_RESOLVER}
 
-OUT=$("$MIYO" search "$QUERY" -n 10 --json 2>&1) || die "Miyo search failed — the Miyo app may not be running. Tell the user to open Miyo, then continue without vault search if they can't. Details: $OUT" 1
+# Default closed: only the explicit Unrestricted value may omit Miyo's exact
+# pre-retrieval folder boundary.
+# https://github.com/Brevilabs/obsidian-copilot-private/issues/121
+case "\${${MIYO_SEARCH_SCOPE_ENV}:-current}" in
+  unrestricted)
+    OUT=$("$MIYO" search "$QUERY" -n 10 --json 2>&1) || die "Miyo search failed — the Miyo app may not be running. Tell the user to open Miyo, then continue without vault search if they can't. Details: $OUT" 1
+    ;;
+  current)
+    [ -n "\${${MIYO_SEARCH_FOLDER_ENV}:-}" ] || die "Miyo search could not enforce Current vault scope because the active vault identity is missing. Do not retry or run an unrestricted search." 4
+    OUT=$("$MIYO" search "$QUERY" -n 10 --folder "$${MIYO_SEARCH_FOLDER_ENV}" --json 2>&1) || die "Miyo search could not enforce Current vault scope. Update Miyo, open it, and retry. Do not run an unrestricted search. Details: $OUT" 1
+    ;;
+  *)
+    die "Miyo search received an invalid Search scope. Do not retry or run an unrestricted search." 4
+    ;;
+esac
 printf '%s\\n' "$OUT"
 `;
 
@@ -761,7 +779,27 @@ if "%~1"=="" (
   exit /b 1
 )
 ${MIYO_WINDOWS_RESOLVER}
-"%MIYO%" search %* -n 10 --json
+rem Default closed: only the explicit Unrestricted value may omit Miyo's exact
+rem pre-retrieval folder boundary.
+rem https://github.com/Brevilabs/obsidian-copilot-private/issues/121
+if /I "%${MIYO_SEARCH_SCOPE_ENV}%"=="unrestricted" (
+  "%MIYO%" search %* -n 10 --json
+  if errorlevel 1 exit /b 1
+  exit /b 0
+)
+if not "%${MIYO_SEARCH_SCOPE_ENV}%"=="" if /I not "%${MIYO_SEARCH_SCOPE_ENV}%"=="current" (
+  echo Miyo search received an invalid Search scope. Do not retry or run an unrestricted search. 1>&2
+  exit /b 4
+)
+if not defined ${MIYO_SEARCH_FOLDER_ENV} (
+  echo Miyo search could not enforce Current vault scope because the active vault identity is missing. Do not retry or run an unrestricted search. 1>&2
+  exit /b 4
+)
+"%MIYO%" search %* -n 10 --folder "%${MIYO_SEARCH_FOLDER_ENV}%" --json
+if errorlevel 1 (
+  echo Miyo search could not enforce Current vault scope. Update Miyo, open it, and retry. Do not run an unrestricted search. 1>&2
+  exit /b 1
+)
 `;
 
 const MIYO_PARSE_SH = `#!/bin/sh
@@ -854,6 +892,10 @@ not need to know where Miyo is installed or which shell you are in. Run the
 script as your single search step; do not fall back to other search tools
 unless it reports that Miyo is unavailable. Read the JSON straight from stdout;
 do not pipe it through other tools (no \`jq\`, no \`|\`).
+
+Search scope comes from Copilot settings. **Current vault** applies Miyo's exact
+folder boundary for the active vault, including from Project chats.
+**Unrestricted** searches every folder registered with Miyo.
 
 ## Reading the results
 

--- a/src/settings/v2/components/MiyoSettings.tsx
+++ b/src/settings/v2/components/MiyoSettings.tsx
@@ -978,10 +978,9 @@ export const MiyoSettings: React.FC = () => {
               )}
               aria-disabled={!capabilitiesEnabled}
             >
-              {/* Search scope — only `true` may omit Miyo's exact folder-name
-                  boundary, including for Agent Chat. Gated on the connection so the
-                  control stays keyboard-inert while dimmed.
-                  https://github.com/Brevilabs/obsidian-copilot-private/issues/121 */}
+              {/* Search scope — bound to `miyoSearchAll` (true omits folder_name so
+                  Miyo searches everything it has indexed). Gated on the connection so
+                  the control stays keyboard-inert while dimmed. */}
               <CapabilityRow
                 indented
                 title={

--- a/src/settings/v2/components/MiyoSettings.tsx
+++ b/src/settings/v2/components/MiyoSettings.tsx
@@ -978,9 +978,10 @@ export const MiyoSettings: React.FC = () => {
               )}
               aria-disabled={!capabilitiesEnabled}
             >
-              {/* Search scope — bound to `miyoSearchAll` (true omits folder_name so
-                  Miyo searches everything it has indexed). Gated on the connection so
-                  the control stays keyboard-inert while dimmed. */}
+              {/* Search scope — only `true` may omit Miyo's exact folder-name
+                  boundary, including for Agent Chat. Gated on the connection so the
+                  control stays keyboard-inert while dimmed.
+                  https://github.com/Brevilabs/obsidian-copilot-private/issues/121 */}
               <CapabilityRow
                 indented
                 title={


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#121

## Why

Settings offers **Current vault** as the safer Miyo search scope, but Agent Chat bypasses it: the managed `miyo-search` skill calls the Miyo CLI without an exact folder boundary. In a Miyo installation with more than one registered folder, a normal or Project chat can therefore receive results from another vault.

The CLI difference is only `miyo search --folder <active-vault-name>`, but the wrapper cannot safely choose that value itself. Copilot owns the setting and active-vault identity, a Project working directory is not the vault identity, each backend receives its process environment differently, and a skill instruction is advisory rather than an isolation boundary. The change therefore carries protected scope data through all three backends and refreshes stale process scope when the setting tightens.

## What

| Search state | Agent Chat behavior |
| --- | --- |
| Current vault | OpenCode, Claude, and Codex pass the exact active Obsidian vault name to Miyo in normal and Project chats. The Project working directory does not affect scope. |
| Unrestricted | Agent Chat omits the folder boundary and may search every folder registered with Miyo. |
| Missing, invalid, ambiguous, or unsupported exact scope | Search stops. It never retries without the boundary. |
| Scope changes during a turn | Tightening to Current vault cancels and refreshes the active Agent turn immediately. Widening waits until the turn is idle. |

The scope inputs are owned by Copilot, so backend environment overrides cannot silently widen Current vault searches.

## Non goal

- Do not revive or extend V3 semantic retrieval, Orama, Vault QA, or in-plugin embeddings.
- Do not derive Miyo scope from a Project folder.
- Do not redesign Miyo indexing or access control, or implement the missing Miyo CLI flag in this repository.

## Screenshot

Not applicable. This changes headless search behavior; the existing Search scope control is visually unchanged.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Deterministic tests cover both scopes, all three backends, global and Project identity, both OS wrappers, protected overrides, and restart races. |
| A defect would fail CI or be obvious on first use | ✅ | Contract and wrapper defects fail deterministic tests; an unsupported Miyo version fails closed on the first Current-vault search. |
| A revert fully restores prior state, including persisted data | ✅ | There is no settings migration or irreversible write. |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | This enforces a privacy boundary around CLI input and prevents user environment overrides from replacing it. |
| No public API, plugin API, message, or on-disk contract changes | ❌ | The managed wrapper now consumes Miyo's pending exact `--folder` CLI contract. |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Tightening scope can cancel and restart a running backend, including when another restart is queued. |
| No hot-path behavior lacks deterministic coverage | ✅ | Every new scope and restart branch has a regression test. |
| No new dependency | ❌ | Current-vault search requires the exact Miyo CLI capability tracked in `Brevilabs/miyo-releases#11`. |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Any contract mismatch appears as a fail-closed error on the next Miyo search. |

Review: inspect `buildBuiltinSkillEnv`, `sanitizeBuiltinSkillEnvOverrides`, and `getBuiltinSkillEnvRestartPolicy` in `src/agentMode/backends/shared/builtinSkillEnv.ts`; the Miyo search wrappers in `src/agentMode/skills/builtin/builtinSkills.ts`; `AcpBackendProcess.start` in `src/agentMode/acp/AcpBackendProcess.ts`; the backend environment composition in `src/agentMode/backends/opencode/OpencodeBackend.ts`, `src/agentMode/backends/codex/CodexBackend.ts`, and `src/agentMode/backends/claude/descriptor.ts`; and `restartBackend` plus `restartBackendNow` in `src/agentMode/session/AgentSessionManager.ts`. Then run Verification steps 2-4, including the unsupported-CLI, duplicate-name, and overlapping-restart variants.

## Verification

1. Load this branch with a Miyo build that supports `miyo search --folder <exact-folder-name>` by sending `folder_name` to `/v0/search`. Register the active vault and a second folder containing a uniquely searchable note.
2. Select **Current vault**. In normal and Project chats for OpenCode, Claude, and Codex, search for the unique note. Confirm it is excluded and results belong only to the active vault.
3. Select **Unrestricted** and repeat. Confirm the second folder can appear. While an Unrestricted turn is running, switch back to **Current vault**; confirm the turn is refreshed and a retry cannot return the second folder.
4. With an older CLI, a missing active-vault identity, or two registered folders sharing the active vault name, select **Current vault** and search. Confirm the search fails without an unrestricted retry. Repeat the wrapper checks on POSIX and Windows.

## Note

Meilisearch is not involved in this path. Copilot calls the Miyo CLI, and current Miyo search uses Qdrant. The Miyo service already accepts exact `folder_name`, resolves it to one registered root, and applies an exact `folder_path` filter before retrieval.

Installed Miyo 0.2.20 and the current upstream source do not expose that exact capability in the CLI. The smallest cross-repository dependency is the CLI slice of `Brevilabs/miyo-releases#11`: add `miyo search --folder <exact-folder-name>` and serialize it as `folder_name`. This PR deliberately fails closed until that capability is available.
