### PR TITLE
Use Copilot branding on the docs site

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -58,5 +58,16 @@ const sidebar = [
 export default defineConfig({
   site: "https://docs.obsidiancopilot.com",
   markdown: { remarkPlugins: [remarkPublishedDocs] },
-  integrations: [starlight({ title: "Copilot for Obsidian", sidebar })],
+  integrations: [
+    starlight({
+      title: "Copilot for Obsidian",
+      favicon: "/favicon.svg",
+      logo: {
+        dark: "./src/assets/copilot-mark-cream.svg",
+        light: "./src/assets/copilot-icon-dark.svg",
+        alt: "",
+      },
+      sidebar,
+    }),
+  ],
 });

--- a/docs/public/favicon.svg
+++ b/docs/public/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200" role="img" aria-label="Obsidian Copilot icon">
+  <title>Obsidian Copilot v4 — app icon (dark)</title>
+  <defs>
+    <clipPath id="idc"><path d="M75.9 6.9c-6.8 1.4-12.5 6-35.5 29.3-33.5 33.8-33.5 33.9-34.2 62.2-0.3 12.4 0 20.2 0.7 22.7 2.4 7.8 10.8 11.2 17.6 7.1 1.7-1.1 14.9-14.1 29.5-29.1 14.5-14.9 26.7-27 27-26.9 0.3 0.2 12.4 12.4 27 27.3 14.6 14.8 27.6 27.8 29 28.7 5.1 3.6 13.6 1.4 16.5-4.2 1.2-2.3 1.5-6.9 1.5-22.3 0-22.9-1.2-28.6-8.3-37.9-7.6-10.2-50-52.3-54.9-54.6-5.1-2.4-10.9-3.2-15.9-2.3z"/></clipPath>
+    <linearGradient id="ids" gradientUnits="userSpaceOnUse" x1="86" y1="64" x2="148" y2="124"><stop offset="0" stop-color="#B8B8B8"/><stop offset="0.05" stop-color="#BEBEBE"/><stop offset="0.21" stop-color="#CECECE"/><stop offset="0.38" stop-color="#DBDBDB"/><stop offset="0.54" stop-color="#E8E8E8"/><stop offset="0.71" stop-color="#F0F0F0"/><stop offset="1" stop-color="#F4F4F4"/></linearGradient>
+    <filter id="idb" x="-20%" y="-20%" width="140%" height="140%"><feGaussianBlur stdDeviation="1.0"/></filter>
+    <clipPath id="idr"><rect width="200" height="200" rx="44"/></clipPath>
+  </defs>
+  <g clip-path="url(#idr)"><rect width="200" height="200" fill="#181931"/><g transform="translate(20,32.5)"><g clip-path="url(#idc)"><path d="M75.9 6.9c-6.8 1.4-12.5 6-35.5 29.3-33.5 33.8-33.5 33.9-34.2 62.2-0.3 12.4 0 20.2 0.7 22.7 2.4 7.8 10.8 11.2 17.6 7.1 1.7-1.1 14.9-14.1 29.5-29.1 14.5-14.9 26.7-27 27-26.9 0.3 0.2 12.4 12.4 27 27.3 14.6 14.8 27.6 27.8 29 28.7 5.1 3.6 13.6 1.4 16.5-4.2 1.2-2.3 1.5-6.9 1.5-22.3 0-22.9-1.2-28.6-8.3-37.9-7.6-10.2-50-52.3-54.9-54.6-5.1-2.4-10.9-3.2-15.9-2.3z" fill="#FFFFFF"/><path d="M79 72 C92.2 58.8 105.5 42.8 124 39 L160 39 L160 135 L137 128 Z" fill="url(#ids)" filter="url(#idb)"/></g></g></g>
+</svg>

--- a/docs/src/assets/copilot-icon-dark.svg
+++ b/docs/src/assets/copilot-icon-dark.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200" role="img" aria-label="Obsidian Copilot icon">
+  <title>Obsidian Copilot v4 — app icon (dark)</title>
+  <defs>
+    <clipPath id="idc"><path d="M75.9 6.9c-6.8 1.4-12.5 6-35.5 29.3-33.5 33.8-33.5 33.9-34.2 62.2-0.3 12.4 0 20.2 0.7 22.7 2.4 7.8 10.8 11.2 17.6 7.1 1.7-1.1 14.9-14.1 29.5-29.1 14.5-14.9 26.7-27 27-26.9 0.3 0.2 12.4 12.4 27 27.3 14.6 14.8 27.6 27.8 29 28.7 5.1 3.6 13.6 1.4 16.5-4.2 1.2-2.3 1.5-6.9 1.5-22.3 0-22.9-1.2-28.6-8.3-37.9-7.6-10.2-50-52.3-54.9-54.6-5.1-2.4-10.9-3.2-15.9-2.3z"/></clipPath>
+    <linearGradient id="ids" gradientUnits="userSpaceOnUse" x1="86" y1="64" x2="148" y2="124"><stop offset="0" stop-color="#B8B8B8"/><stop offset="0.05" stop-color="#BEBEBE"/><stop offset="0.21" stop-color="#CECECE"/><stop offset="0.38" stop-color="#DBDBDB"/><stop offset="0.54" stop-color="#E8E8E8"/><stop offset="0.71" stop-color="#F0F0F0"/><stop offset="1" stop-color="#F4F4F4"/></linearGradient>
+    <filter id="idb" x="-20%" y="-20%" width="140%" height="140%"><feGaussianBlur stdDeviation="1.0"/></filter>
+    <clipPath id="idr"><rect width="200" height="200" rx="44"/></clipPath>
+  </defs>
+  <g clip-path="url(#idr)"><rect width="200" height="200" fill="#181931"/><g transform="translate(20,32.5)"><g clip-path="url(#idc)"><path d="M75.9 6.9c-6.8 1.4-12.5 6-35.5 29.3-33.5 33.8-33.5 33.9-34.2 62.2-0.3 12.4 0 20.2 0.7 22.7 2.4 7.8 10.8 11.2 17.6 7.1 1.7-1.1 14.9-14.1 29.5-29.1 14.5-14.9 26.7-27 27-26.9 0.3 0.2 12.4 12.4 27 27.3 14.6 14.8 27.6 27.8 29 28.7 5.1 3.6 13.6 1.4 16.5-4.2 1.2-2.3 1.5-6.9 1.5-22.3 0-22.9-1.2-28.6-8.3-37.9-7.6-10.2-50-52.3-54.9-54.6-5.1-2.4-10.9-3.2-15.9-2.3z" fill="#FFFFFF"/><path d="M79 72 C92.2 58.8 105.5 42.8 124 39 L160 39 L160 135 L137 128 Z" fill="url(#ids)" filter="url(#idb)"/></g></g></g>
+</svg>

--- a/docs/src/assets/copilot-mark-cream.svg
+++ b/docs/src/assets/copilot-mark-cream.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="4 4 152 127" width="152" height="127" role="img" aria-label="Obsidian Copilot mark">
+  <title>Obsidian Copilot v4 — mark (cream)</title>
+  <defs>
+    <clipPath id="mcc"><path d="M75.9 6.9c-6.8 1.4-12.5 6-35.5 29.3-33.5 33.8-33.5 33.9-34.2 62.2-0.3 12.4 0 20.2 0.7 22.7 2.4 7.8 10.8 11.2 17.6 7.1 1.7-1.1 14.9-14.1 29.5-29.1 14.5-14.9 26.7-27 27-26.9 0.3 0.2 12.4 12.4 27 27.3 14.6 14.8 27.6 27.8 29 28.7 5.1 3.6 13.6 1.4 16.5-4.2 1.2-2.3 1.5-6.9 1.5-22.3 0-22.9-1.2-28.6-8.3-37.9-7.6-10.2-50-52.3-54.9-54.6-5.1-2.4-10.9-3.2-15.9-2.3z"/></clipPath>
+    <linearGradient id="mcs" gradientUnits="userSpaceOnUse" x1="86" y1="64" x2="148" y2="124"><stop offset="0" stop-color="#B8B8B8"/><stop offset="0.05" stop-color="#BEBEBE"/><stop offset="0.21" stop-color="#CECECE"/><stop offset="0.38" stop-color="#DBDBDB"/><stop offset="0.54" stop-color="#E8E8E8"/><stop offset="0.71" stop-color="#F0F0F0"/><stop offset="1" stop-color="#F4F4F4"/></linearGradient>
+    <filter id="mcb" x="-20%" y="-20%" width="140%" height="140%"><feGaussianBlur stdDeviation="1.0"/></filter>
+  </defs>
+  <g clip-path="url(#mcc)"><path d="M75.9 6.9c-6.8 1.4-12.5 6-35.5 29.3-33.5 33.8-33.5 33.9-34.2 62.2-0.3 12.4 0 20.2 0.7 22.7 2.4 7.8 10.8 11.2 17.6 7.1 1.7-1.1 14.9-14.1 29.5-29.1 14.5-14.9 26.7-27 27-26.9 0.3 0.2 12.4 12.4 27 27.3 14.6 14.8 27.6 27.8 29 28.7 5.1 3.6 13.6 1.4 16.5-4.2 1.2-2.3 1.5-6.9 1.5-22.3 0-22.9-1.2-28.6-8.3-37.9-7.6-10.2-50-52.3-54.9-54.6-5.1-2.4-10.9-3.2-15.9-2.3z" fill="#FFFFFF"/><path d="M79 72 C92.2 58.8 105.5 42.8 124 39 L160 39 L160 135 L137 128 Z" fill="url(#mcs)" filter="url(#mcb)"/></g>
+</svg>


### PR DESCRIPTION
## Why

The documentation site still shows Starlight's default favicon and a text-only “Copilot for Obsidian” title. It should carry the same Copilot identity as the product landing site.

## What

The docs header now places the official Copilot mark beside “Copilot for Obsidian.” It uses the cream mark in dark mode and the dark app icon in light mode for clear contrast. Browser tabs now use the official Copilot app icon.

## Non goal

This does not restyle Starlight, change documentation copy, or alter navigation.

## Screenshot

Before: the header was text-only and the browser tab used Starlight's default favicon.

After: the official Copilot logo appears beside the site name in dark, light, and mobile layouts, and the browser tab uses the Copilot app icon.

The before and after captures were verified locally, but GitHub's attachment endpoint returned HTTP 422 while uploading them.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | This is a cosmetic Starlight configuration change using existing official brand assets |
| A defect would fail CI or be obvious on first use | ✅ | The docs build resolves both logo imports, and missing or incorrect artwork is visible in the header or browser tab |
| A revert fully restores prior state, including persisted data | ✅ | No persisted data changes |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Static public assets and site configuration only |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Published page routes and content are unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | No runtime logic changes |
| No hot-path behavior lacks deterministic coverage | ✅ | No hot path changes |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | The complete change appears in the docs header and browser tab on page load |

Review: run Verification and check the header in both themes.

## Verification

1. From `docs/`, run `npm ci`, `npm test`, and `npm run build`.
2. Preview the built site and open the home page.
3. Confirm the Copilot logo appears beside “Copilot for Obsidian” and switch between dark and light themes.
4. Confirm the browser tab uses the Copilot app icon and the mobile header remains balanced.
