### PR TITLE
Route Agent Chat web search through Self-Host providers

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -120,7 +120,7 @@ Shared Skills live under `<Copilot folder>/skills/`. Copilot links them into the
 
 Custom Skills and built-in Obsidian Skills are free. Active Plus access adds cloud-backed Skills for web research, PDF reading, YouTube transcripts, X posts, and Symposium.
 
-In Self-Host Mode, Agent Chat's built-in web-search Skill uses the search provider selected under **Settings → Copilot → Self-Host**. Provider credentials stay inside Obsidian rather than being passed to opencode. Copilot disables opencode's native web-search and web-fetch tools so they cannot bypass that route. Full-page web fetching is unavailable in Self-Host Mode because the supported search providers do not share a page-fetch interface; Agent Chat can still use the configured provider's search results.
+In Self-Host Mode with OpenCode selected, Agent Chat's built-in web-search Skill uses the search provider selected under **Settings → Copilot → Self-Host**. Provider credentials stay inside Obsidian rather than being passed to OpenCode, and the feature does not require Obsidian's command line interface. Copilot disables OpenCode's native web-search and web-fetch tools so they cannot bypass that route. Full-page web fetching is unavailable through OpenCode in Self-Host Mode because the supported search providers do not share a page-fetch interface; Agent Chat can still use the configured provider's search results.
 
 On Windows, creating the folder links may require **Developer Mode** or administrator access. If a sync service replaces a link, toggle that Skill off and on for the affected agent to recreate it.
 

--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -120,6 +120,8 @@ Shared Skills live under `<Copilot folder>/skills/`. Copilot links them into the
 
 Custom Skills and built-in Obsidian Skills are free. Active Plus access adds cloud-backed Skills for web research, PDF reading, YouTube transcripts, X posts, and Symposium.
 
+In Self-Host Mode, Agent Chat's built-in web-search Skill uses the search provider selected under **Settings → Copilot → Self-Host**. Provider credentials stay inside Obsidian rather than being passed to opencode. Copilot disables opencode's native web-search and web-fetch tools so they cannot bypass that route. Full-page web fetching is unavailable in Self-Host Mode because the supported search providers do not share a page-fetch interface; Agent Chat can still use the configured provider's search results.
+
 On Windows, creating the folder links may require **Developer Mode** or administrator access. If a sync service replaces a link, toggle that Skill off and on for the affected agent to recreate it.
 
 ## Related

--- a/docs/copilot-plus-and-self-host.md
+++ b/docs/copilot-plus-and-self-host.md
@@ -106,8 +106,8 @@ Supporter and eligible legacy licenses can open **Settings → Copilot → Self-
 When it is on, Copilot:
 
 - Lets you supply Firecrawl, Perplexity, Parallel, or Exa credentials for web search.
-- Routes Agent Chat web searches through that selected provider while keeping its API key inside Obsidian.
-- Disables opencode's native web-search and web-fetch tools so they cannot bypass the selected route. Full-page fetching is unavailable until the self-host providers share a supported fetch interface.
+- With OpenCode selected, routes Agent Chat web searches through that selected provider while keeping its API key inside Obsidian. This does not require Obsidian's command line interface.
+- Disables OpenCode's native web-search and web-fetch tools so they cannot bypass the selected route. Full-page fetching through OpenCode is unavailable until the self-host providers share a supported fetch interface.
 - Lets you supply a Supadata key for YouTube transcripts.
 - Directs you to BYOK for local or self-hosted model endpoints.
 - Flags and sorts cloud agents and models below local or self-hosted choices.

--- a/docs/copilot-plus-and-self-host.md
+++ b/docs/copilot-plus-and-self-host.md
@@ -106,6 +106,8 @@ Supporter and eligible legacy licenses can open **Settings → Copilot → Self-
 When it is on, Copilot:
 
 - Lets you supply Firecrawl, Perplexity, Parallel, or Exa credentials for web search.
+- Routes Agent Chat web searches through that selected provider while keeping its API key inside Obsidian.
+- Disables opencode's native web-search and web-fetch tools so they cannot bypass the selected route. Full-page fetching is unavailable until the self-host providers share a supported fetch interface.
 - Lets you supply a Supadata key for YouTube transcripts.
 - Directs you to BYOK for local or self-hosted model endpoints.
 - Flags and sorts cloud agents and models below local or self-hosted choices.

--- a/src/LLMProviders/selfHostServices.test.ts
+++ b/src/LLMProviders/selfHostServices.test.ts
@@ -1,4 +1,8 @@
-import { hasSelfHostSearchKey, selfHostWebSearch } from "./selfHostServices";
+import {
+  createSelfHostWebSearchAgentBridge,
+  hasSelfHostSearchKey,
+  selfHostWebSearch,
+} from "./selfHostServices";
 
 const mockGetSettings = jest.fn();
 jest.mock("@/settings/model", () => ({
@@ -88,6 +92,54 @@ describe("selfHostServices", () => {
       mockGetSettings.mockReturnValue(providerSettings("unknown", { firecrawlApiKey: "fc-key" }));
 
       expect(hasSelfHostSearchKey()).toBe(true);
+    });
+  });
+
+  describe("createSelfHostWebSearchAgentBridge()", () => {
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 routes an entitled Agent Chat query through the host search callable", async () => {
+      const search = jest.fn().mockResolvedValue({
+        content: "result",
+        citations: ["https://example.com"],
+      });
+      const bridge = createSelfHostWebSearchAgentBridge(
+        () => true,
+        () => true,
+        search
+      );
+
+      await expect(bridge.search("current facts")).resolves.toEqual({
+        content: "result",
+        citations: ["https://example.com"],
+      });
+      expect(search).toHaveBeenCalledWith("current facts");
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 fails closed when the signed Self-Host entitlement is unavailable", async () => {
+      const search = jest.fn();
+      const bridge = createSelfHostWebSearchAgentBridge(
+        () => false,
+        () => true,
+        search
+      );
+
+      await expect(bridge.search("private query")).rejects.toThrow(
+        "Self-host web search is not available"
+      );
+      expect(search).not.toHaveBeenCalled();
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 fails closed when the selected provider has no API key", async () => {
+      const search = jest.fn();
+      const bridge = createSelfHostWebSearchAgentBridge(
+        () => true,
+        () => false,
+        search
+      );
+
+      await expect(bridge.search("private query")).rejects.toThrow(
+        "Add an API key for the selected self-host search provider"
+      );
+      expect(search).not.toHaveBeenCalled();
     });
   });
 

--- a/src/LLMProviders/selfHostServices.test.ts
+++ b/src/LLMProviders/selfHostServices.test.ts
@@ -2,6 +2,8 @@ import {
   createSelfHostWebSearchAgentBridge,
   hasSelfHostSearchKey,
   selfHostWebSearch,
+  type SelfHostWebSearchAgentBridge,
+  type SelfHostWebSearchAgentChannel,
 } from "./selfHostServices";
 
 const mockGetSettings = jest.fn();
@@ -51,6 +53,44 @@ function parallelRequestBody(): { objective: string; search_queries: string[] } 
   return JSON.parse(options.body) as { objective: string; search_queries: string[] };
 }
 
+function requestAgentSearchChannel(
+  channel: Readonly<SelfHostWebSearchAgentChannel>,
+  query: string,
+  token = channel.token,
+  url = channel.url
+): Promise<{ status: number; contentType: string | undefined; body: unknown }> {
+  const http = jest.requireActual<typeof import("node:http")>("node:http");
+  return new Promise((resolve, reject) => {
+    const request = http.request(
+      url,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "text/plain; charset=utf-8",
+          "Content-Length": Buffer.byteLength(query),
+        },
+      },
+      (response) => {
+        let responseBody = "";
+        response.setEncoding("utf8");
+        response.on("data", (chunk: string) => {
+          responseBody += chunk;
+        });
+        response.on("end", () => {
+          resolve({
+            status: response.statusCode ?? 0,
+            contentType: response.headers["content-type"],
+            body: JSON.parse(responseBody) as unknown,
+          });
+        });
+      }
+    );
+    request.on("error", reject);
+    request.end(query);
+  });
+}
+
 describe("selfHostServices", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -96,50 +136,168 @@ describe("selfHostServices", () => {
   });
 
   describe("createSelfHostWebSearchAgentBridge()", () => {
-    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 routes an entitled Agent Chat query through the host search callable", async () => {
+    const bridges: SelfHostWebSearchAgentBridge[] = [];
+
+    afterEach(() => {
+      for (const bridge of bridges) bridge.dispose();
+      bridges.length = 0;
+    });
+
+    function createBridge(
+      isModeValid: () => boolean,
+      hasSearchKey: () => boolean,
+      search: (query: string) => Promise<{ content: string; citations: string[] }>
+    ): SelfHostWebSearchAgentBridge {
+      const bridge = createSelfHostWebSearchAgentBridge(isModeValid, hasSearchKey, search);
+      bridges.push(bridge);
+      return bridge;
+    }
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 routes an entitled Agent Chat query through a reusable plugin-owned channel", async () => {
       const search = jest.fn().mockResolvedValue({
-        content: "result",
+        content: "日本語の結果 ✅",
         citations: ["https://example.com"],
       });
-      const bridge = createSelfHostWebSearchAgentBridge(
+      const bridge = createBridge(
         () => true,
         () => true,
         search
       );
+      const channel = await bridge.getChannel();
 
-      await expect(bridge.search("current facts")).resolves.toEqual({
-        content: "result",
-        citations: ["https://example.com"],
+      await expect(requestAgentSearchChannel(channel, "current\nfacts ✅")).resolves.toEqual({
+        status: 200,
+        contentType: "application/json; charset=utf-8",
+        body: { content: "日本語の結果 ✅", citations: ["https://example.com"] },
       });
-      expect(search).toHaveBeenCalledWith("current facts");
+      await expect(bridge.getChannel()).resolves.toBe(channel);
+      expect(search).toHaveBeenCalledWith("current\nfacts ✅");
     });
 
     it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 fails closed when the signed Self-Host entitlement is unavailable", async () => {
       const search = jest.fn();
-      const bridge = createSelfHostWebSearchAgentBridge(
+      const bridge = createBridge(
         () => false,
         () => true,
         search
       );
+      const channel = await bridge.getChannel();
 
-      await expect(bridge.search("private query")).rejects.toThrow(
-        "Self-host web search is not available"
-      );
+      await expect(requestAgentSearchChannel(channel, "private query")).resolves.toEqual({
+        status: 500,
+        contentType: "application/json; charset=utf-8",
+        body: { error: "Self-host web search is not available for this session." },
+      });
       expect(search).not.toHaveBeenCalled();
     });
 
     it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 fails closed when the selected provider has no API key", async () => {
       const search = jest.fn();
-      const bridge = createSelfHostWebSearchAgentBridge(
+      const bridge = createBridge(
         () => true,
         () => false,
         search
       );
+      const channel = await bridge.getChannel();
 
-      await expect(bridge.search("private query")).rejects.toThrow(
-        "Add an API key for the selected self-host search provider"
-      );
+      await expect(requestAgentSearchChannel(channel, "private query")).resolves.toEqual({
+        status: 500,
+        contentType: "application/json; charset=utf-8",
+        body: { error: "Add an API key for the selected self-host search provider." },
+      });
       expect(search).not.toHaveBeenCalled();
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 rejects another local process without the per-lifecycle token", async () => {
+      const search = jest.fn();
+      const bridge = createBridge(
+        () => true,
+        () => true,
+        search
+      );
+      const channel = await bridge.getChannel();
+
+      await expect(
+        requestAgentSearchChannel(channel, "private query", "wrong-token")
+      ).resolves.toEqual({
+        status: 401,
+        contentType: "application/json; charset=utf-8",
+        body: { error: "Unauthorized." },
+      });
+      expect(search).not.toHaveBeenCalled();
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 rejects empty and oversized local search requests before provider dispatch", async () => {
+      const search = jest.fn();
+      const bridge = createBridge(
+        () => true,
+        () => true,
+        search
+      );
+      const channel = await bridge.getChannel();
+
+      await expect(requestAgentSearchChannel(channel, "   ")).resolves.toEqual({
+        status: 400,
+        contentType: "application/json; charset=utf-8",
+        body: { error: "A non-empty query is required." },
+      });
+      await expect(requestAgentSearchChannel(channel, "x".repeat(64 * 1024 + 1))).resolves.toEqual({
+        status: 413,
+        contentType: "application/json; charset=utf-8",
+        body: { error: "Request body is too large." },
+      });
+      expect(search).not.toHaveBeenCalled();
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 exposes only the search route on the local channel", async () => {
+      const search = jest.fn();
+      const bridge = createBridge(
+        () => true,
+        () => true,
+        search
+      );
+      const channel = await bridge.getChannel();
+
+      await expect(
+        requestAgentSearchChannel(
+          channel,
+          "private query",
+          channel.token,
+          channel.url.replace("/search", "/other")
+        )
+      ).resolves.toEqual({
+        status: 404,
+        contentType: "application/json; charset=utf-8",
+        body: { error: "Not found." },
+      });
+      expect(search).not.toHaveBeenCalled();
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 closes the local channel with its plugin lifecycle", async () => {
+      const bridge = createBridge(
+        () => true,
+        () => true,
+        jest.fn()
+      );
+      const channel = await bridge.getChannel();
+
+      bridge.dispose();
+
+      await expect(bridge.getChannel()).rejects.toThrow("channel is closed");
+      await expect(requestAgentSearchChannel(channel, "private query")).rejects.toThrow();
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 rejects channel startup when the plugin is disposed before listening", async () => {
+      const bridge = createBridge(
+        () => true,
+        () => true,
+        jest.fn()
+      );
+      const channel = bridge.getChannel();
+
+      bridge.dispose();
+
+      await expect(channel).rejects.toThrow("channel is closed");
     });
   });
 

--- a/src/LLMProviders/selfHostServices.ts
+++ b/src/LLMProviders/selfHostServices.ts
@@ -3,6 +3,7 @@ import { logError, logInfo } from "@/logger";
 import { isSelfHostModeValid } from "@/plusUtils";
 import { getSettings } from "@/settings/model";
 import { safeFetchNoThrow } from "@/utils";
+import { requireNodeModule } from "@/utils/desktopRuntime";
 
 const FIRECRAWL_SEARCH_URL = "https://api.firecrawl.dev/v2/search";
 const PERPLEXITY_CHAT_URL = "https://api.perplexity.ai/chat/completions";
@@ -11,6 +12,12 @@ const PARALLEL_SEARCH_QUERY_MAX_LENGTH = 200;
 const PARALLEL_OBJECTIVE_MAX_LENGTH = 5000;
 const EXA_SEARCH_URL = "https://api.exa.ai/search";
 const SUPADATA_TRANSCRIPT_URL = "https://api.supadata.ai/v1/transcript";
+/** Bounds agent-controlled input. https://github.com/Brevilabs/obsidian-copilot-private/issues/165 */
+const AGENT_SEARCH_REQUEST_MAX_LENGTH = 64 * 1024;
+
+type HttpServer = import("node:http").Server;
+type IncomingMessage = import("node:http").IncomingMessage;
+type ServerResponse = import("node:http").ServerResponse;
 
 /** Poll interval for Supadata async jobs (ms) */
 const SUPADATA_POLL_INTERVAL = 2000;
@@ -23,13 +30,20 @@ export interface SelfHostWebSearchResult {
   citations: string[];
 }
 
-/** Host-owned web-search surface exposed to Agent Chat scripts. */
+/** Address and bearer token for one plugin-owned Agent Chat search channel. */
+export interface SelfHostWebSearchAgentChannel {
+  url: string;
+  token: string;
+}
+
+/** Owns the provider-credential-free local channel used by Agent Chat search scripts. */
 export interface SelfHostWebSearchAgentBridge {
-  search(query: string): Promise<SelfHostWebSearchResult>;
+  getChannel(): Promise<Readonly<SelfHostWebSearchAgentChannel>>;
+  dispose(): void;
 }
 
 /**
- * Keep self-host search credentials and entitlement checks inside the plugin host.
+ * Keep provider credentials and entitlement checks inside a CLI-independent plugin channel.
  *
  * @param isModeValid Resolves the live, verified self-host entitlement state.
  * @param hasSearchKey Resolves whether the selected provider has a credential.
@@ -40,20 +54,142 @@ export function createSelfHostWebSearchAgentBridge(
   hasSearchKey: () => boolean = hasSelfHostSearchKey,
   search: (query: string) => Promise<SelfHostWebSearchResult> = selfHostWebSearch
 ): Readonly<SelfHostWebSearchAgentBridge> {
+  let server: HttpServer | null = null;
+  let channelPromise: Promise<Readonly<SelfHostWebSearchAgentChannel>> | null = null;
+  let rejectChannelStart: ((error: Error) => void) | null = null;
+  let disposed = false;
+
+  const runSearch = async (query: string): Promise<SelfHostWebSearchResult> => {
+    // Agent processes must fail closed instead of falling back to a native
+    // web tool when the signed self-host entitlement is unavailable.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/165
+    if (!isModeValid()) {
+      throw new Error("Self-host web search is not available for this session.");
+    }
+    if (!hasSearchKey()) {
+      throw new Error("Add an API key for the selected self-host search provider.");
+    }
+    return search(query);
+  };
+
+  const startChannel = (): Promise<Readonly<SelfHostWebSearchAgentChannel>> => {
+    const http = requireNodeModule<typeof import("node:http")>("http");
+    const crypto = requireNodeModule<typeof import("node:crypto")>("crypto");
+    const token = crypto.randomBytes(32).toString("hex");
+
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      const rejectStart = (error: Error): void => {
+        if (settled) return;
+        settled = true;
+        rejectChannelStart = null;
+        reject(error);
+      };
+      const resolveStart = (channel: Readonly<SelfHostWebSearchAgentChannel>): void => {
+        if (settled) return;
+        settled = true;
+        rejectChannelStart = null;
+        resolve(channel);
+      };
+      rejectChannelStart = rejectStart;
+      const nextServer = http.createServer((request, response) => {
+        void handleAgentSearchRequest(request, response, token, runSearch);
+      });
+      server = nextServer;
+      nextServer.once("error", rejectStart);
+      nextServer.listen(0, "127.0.0.1", () => {
+        if (disposed) {
+          nextServer.close();
+          rejectStart(new Error("Self-host web search channel is closed."));
+          return;
+        }
+        const address = nextServer.address() as import("node:net").AddressInfo;
+        nextServer.on("error", (error) => {
+          logError("[AgentMode] Self-host web search channel failed", error);
+        });
+        nextServer.unref();
+        resolveStart(
+          Object.freeze({
+            url: `http://127.0.0.1:${address.port}/search`,
+            token,
+          })
+        );
+      });
+    });
+  };
+
   return Object.freeze({
-    async search(query: string): Promise<SelfHostWebSearchResult> {
-      // Agent processes must fail closed instead of falling back to a native
-      // web tool when the signed self-host entitlement is unavailable.
+    getChannel(): Promise<Readonly<SelfHostWebSearchAgentChannel>> {
+      if (disposed) {
+        return Promise.reject(new Error("Self-host web search channel is closed."));
+      }
+      channelPromise ??= startChannel();
+      return channelPromise;
+    },
+    dispose(): void {
+      disposed = true;
+      // Closing before Node emits `listening` skips the listen callback, so
+      // explicitly settle a spawn already awaiting this channel.
       // https://github.com/Brevilabs/obsidian-copilot-private/issues/165
-      if (!isModeValid()) {
-        throw new Error("Self-host web search is not available for this session.");
-      }
-      if (!hasSearchKey()) {
-        throw new Error("Add an API key for the selected self-host search provider.");
-      }
-      return search(query);
+      rejectChannelStart?.(new Error("Self-host web search channel is closed."));
+      server?.close();
+      server = null;
+      channelPromise = null;
     },
   });
+}
+
+async function handleAgentSearchRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  token: string,
+  search: (query: string) => Promise<SelfHostWebSearchResult>
+): Promise<void> {
+  // Bind to loopback, require a per-lifecycle token, and accept only one route
+  // so another vault or local webpage cannot select this plugin instance.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/165
+  if (request.method !== "POST" || request.url !== "/search") {
+    writeAgentSearchResponse(response, 404, { error: "Not found." });
+    return;
+  }
+  if (request.headers.authorization !== `Bearer ${token}`) {
+    writeAgentSearchResponse(response, 401, { error: "Unauthorized." });
+    return;
+  }
+
+  try {
+    const query = await readAgentSearchRequestBody(request);
+    if (!query.trim()) {
+      writeAgentSearchResponse(response, 400, { error: "A non-empty query is required." });
+      return;
+    }
+    writeAgentSearchResponse(response, 200, await search(query));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const status = message === "Request body is too large." ? 413 : 500;
+    writeAgentSearchResponse(response, status, { error: message });
+  }
+}
+
+async function readAgentSearchRequestBody(request: IncomingMessage): Promise<string> {
+  request.setEncoding("utf8");
+  let body = "";
+  for await (const chunk of request) {
+    body += chunk;
+    if (body.length > AGENT_SEARCH_REQUEST_MAX_LENGTH) {
+      throw new Error("Request body is too large.");
+    }
+  }
+  return body;
+}
+
+function writeAgentSearchResponse(
+  response: ServerResponse,
+  status: number,
+  body: SelfHostWebSearchResult | { error: string }
+): void {
+  response.writeHead(status, { "Content-Type": "application/json; charset=utf-8" });
+  response.end(JSON.stringify(body));
 }
 
 interface FirecrawlSearchResult {

--- a/src/LLMProviders/selfHostServices.ts
+++ b/src/LLMProviders/selfHostServices.ts
@@ -1,5 +1,6 @@
 import { type Youtube4llmResponse } from "@/LLMProviders/brevilabsClient";
 import { logError, logInfo } from "@/logger";
+import { isSelfHostModeValid } from "@/plusUtils";
 import { getSettings } from "@/settings/model";
 import { safeFetchNoThrow } from "@/utils";
 
@@ -20,6 +21,39 @@ const SUPADATA_POLL_TIMEOUT = 60000;
 export interface SelfHostWebSearchResult {
   content: string;
   citations: string[];
+}
+
+/** Host-owned web-search surface exposed to Agent Chat scripts. */
+export interface SelfHostWebSearchAgentBridge {
+  search(query: string): Promise<SelfHostWebSearchResult>;
+}
+
+/**
+ * Keep self-host search credentials and entitlement checks inside the plugin host.
+ *
+ * @param isModeValid Resolves the live, verified self-host entitlement state.
+ * @param hasSearchKey Resolves whether the selected provider has a credential.
+ * @param search Runs the configured provider search inside Obsidian.
+ */
+export function createSelfHostWebSearchAgentBridge(
+  isModeValid: () => boolean = isSelfHostModeValid,
+  hasSearchKey: () => boolean = hasSelfHostSearchKey,
+  search: (query: string) => Promise<SelfHostWebSearchResult> = selfHostWebSearch
+): Readonly<SelfHostWebSearchAgentBridge> {
+  return Object.freeze({
+    async search(query: string): Promise<SelfHostWebSearchResult> {
+      // Agent processes must fail closed instead of falling back to a native
+      // web tool when the signed self-host entitlement is unavailable.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/165
+      if (!isModeValid()) {
+        throw new Error("Self-host web search is not available for this session.");
+      }
+      if (!hasSearchKey()) {
+        throw new Error("Add an API key for the selected self-host search provider.");
+      }
+      return search(query);
+    },
+  });
 }
 
 interface FirecrawlSearchResult {

--- a/src/agentMode/backends/opencode/OpencodeBackend.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.test.ts
@@ -29,8 +29,10 @@ import {
   COPILOT_PROMPT_BASE,
 } from "@/agentMode/backends/shared/agentSystemPrompt";
 import {
+  AGENT_VAULT_NAME_ENV,
   MIYO_SEARCH_FOLDER_ENV,
   MIYO_SEARCH_SCOPE_ENV,
+  SELF_HOST_WEB_SEARCH_ENV,
 } from "@/agentMode/skills/builtin/builtinSkills";
 
 function makeSystemPrompt(title: string, content: string): UserSystemPrompt {
@@ -861,6 +863,16 @@ describe("buildOpencodeConfig — agent/prompt/mode/skills blocks (preserved)", 
     expect(cfg.permission).toBeUndefined();
   });
 
+  it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 denies native web tools for every Self-Host opencode agent", async () => {
+    setSettings({ enableSelfHostMode: true });
+
+    const cfg = (await buildOpencodeConfig(getSettings(), NO_MODELS_DEPS)) as {
+      permission?: Record<string, string>;
+    };
+
+    expect(cfg.permission).toEqual({ websearch: "deny", webfetch: "deny" });
+  });
+
   it("synthesises deny rules for a mix of skills (only cross-discovered + not-enabled wins)", async () => {
     seedSkills([
       makeSkill("a", ["claude"]),
@@ -1022,6 +1034,75 @@ describe("OpencodeBackend.buildSpawnDescriptor", () => {
     expect(desc.args).toEqual(["acp", "--cwd", "/active-vault"]);
     expect(desc.env[MIYO_SEARCH_SCOPE_ENV]).toBe("current");
     expect(desc.env[MIYO_SEARCH_FOLDER_ENV]).toBe("active-vault");
+    expect(desc.env[AGENT_VAULT_NAME_ENV]).toBe("active-vault");
+  });
+
+  it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 seals top-level and per-agent native web permissions in config overrides", async () => {
+    setSettings({ enableSelfHostMode: true });
+    updateSetting("agentMode", {
+      byok: {},
+      activeBackend: "opencode",
+      debugFullFrames: false,
+      welcomeDismissed: false,
+      skills: { folder: "copilot/skills" },
+      backends: {
+        opencode: {
+          binaryPath: "/path/to/opencode",
+          envOverrides: {
+            [SELF_HOST_WEB_SEARCH_ENV]: "",
+            [AGENT_VAULT_NAME_ENV]: "other-vault",
+            OPENCODE_CONFIG_CONTENT: JSON.stringify({
+              permission: "ask",
+              agent: {
+                build: { permission: { bash: "ask", websearch: "allow" } },
+                custom: { permission: "allow" },
+              },
+            }),
+          },
+        },
+      },
+    });
+
+    const desc = await new OpencodeBackend(NO_MODELS_DEPS).buildSpawnDescriptor({
+      vaultBasePath: "/active-vault",
+      vaultName: "active-vault",
+    });
+    const cfg = JSON.parse(desc.env.OPENCODE_CONFIG_CONTENT as string);
+
+    expect(desc.env[SELF_HOST_WEB_SEARCH_ENV]).toBe("1");
+    expect(desc.env[AGENT_VAULT_NAME_ENV]).toBe("active-vault");
+    expect(cfg.permission).toEqual({ "*": "ask", websearch: "deny", webfetch: "deny" });
+    expect(cfg.agent.build.permission).toEqual({
+      bash: "ask",
+      websearch: "deny",
+      webfetch: "deny",
+    });
+    expect(cfg.agent.custom.permission).toEqual({
+      "*": "allow",
+      websearch: "deny",
+      webfetch: "deny",
+    });
+  });
+
+  it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 rejects a non-object config override instead of starting without native web denies", async () => {
+    setSettings({ enableSelfHostMode: true });
+    updateSetting("agentMode", {
+      byok: {},
+      activeBackend: "opencode",
+      debugFullFrames: false,
+      welcomeDismissed: false,
+      skills: { folder: "copilot/skills" },
+      backends: {
+        opencode: {
+          binaryPath: "/path/to/opencode",
+          envOverrides: { OPENCODE_CONFIG_CONTENT: "[]" },
+        },
+      },
+    });
+
+    await expect(
+      new OpencodeBackend(NO_MODELS_DEPS).buildSpawnDescriptor({ vaultBasePath: "/vault" })
+    ).rejects.toThrow("OPENCODE_CONFIG_CONTENT must be a JSON object");
   });
 
   it("threads the injected getCacheRoot into the spawned external_directory allow", async () => {

--- a/src/agentMode/backends/opencode/OpencodeBackend.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.test.ts
@@ -29,10 +29,11 @@ import {
   COPILOT_PROMPT_BASE,
 } from "@/agentMode/backends/shared/agentSystemPrompt";
 import {
-  AGENT_VAULT_NAME_ENV,
   MIYO_SEARCH_FOLDER_ENV,
   MIYO_SEARCH_SCOPE_ENV,
   SELF_HOST_WEB_SEARCH_ENV,
+  SELF_HOST_WEB_SEARCH_TOKEN_ENV,
+  SELF_HOST_WEB_SEARCH_URL_ENV,
 } from "@/agentMode/skills/builtin/builtinSkills";
 
 function makeSystemPrompt(title: string, content: string): UserSystemPrompt {
@@ -166,6 +167,10 @@ function makeDeps(args: {
     providerRegistry: {
       getApiKey: async (providerId: string) => keys[providerId] ?? null,
     } as unknown as ProviderRegistry,
+    getSelfHostWebSearchChannel: async () => ({
+      url: "http://127.0.0.1:1234/search",
+      token: "session-token",
+    }),
   };
 }
 
@@ -1034,7 +1039,6 @@ describe("OpencodeBackend.buildSpawnDescriptor", () => {
     expect(desc.args).toEqual(["acp", "--cwd", "/active-vault"]);
     expect(desc.env[MIYO_SEARCH_SCOPE_ENV]).toBe("current");
     expect(desc.env[MIYO_SEARCH_FOLDER_ENV]).toBe("active-vault");
-    expect(desc.env[AGENT_VAULT_NAME_ENV]).toBe("active-vault");
   });
 
   it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 seals top-level and per-agent native web permissions in config overrides", async () => {
@@ -1050,7 +1054,8 @@ describe("OpencodeBackend.buildSpawnDescriptor", () => {
           binaryPath: "/path/to/opencode",
           envOverrides: {
             [SELF_HOST_WEB_SEARCH_ENV]: "",
-            [AGENT_VAULT_NAME_ENV]: "other-vault",
+            [SELF_HOST_WEB_SEARCH_URL_ENV]: "http://attacker.invalid",
+            [SELF_HOST_WEB_SEARCH_TOKEN_ENV]: "replacement-token",
             OPENCODE_CONFIG_CONTENT: JSON.stringify({
               permission: "ask",
               agent: {
@@ -1070,7 +1075,8 @@ describe("OpencodeBackend.buildSpawnDescriptor", () => {
     const cfg = JSON.parse(desc.env.OPENCODE_CONFIG_CONTENT as string);
 
     expect(desc.env[SELF_HOST_WEB_SEARCH_ENV]).toBe("1");
-    expect(desc.env[AGENT_VAULT_NAME_ENV]).toBe("active-vault");
+    expect(desc.env[SELF_HOST_WEB_SEARCH_URL_ENV]).toBe("http://127.0.0.1:1234/search");
+    expect(desc.env[SELF_HOST_WEB_SEARCH_TOKEN_ENV]).toBe("session-token");
     expect(cfg.permission).toEqual({ "*": "ask", websearch: "deny", webfetch: "deny" });
     expect(cfg.agent.build.permission).toEqual({
       bash: "ask",
@@ -1082,6 +1088,24 @@ describe("OpencodeBackend.buildSpawnDescriptor", () => {
       websearch: "deny",
       webfetch: "deny",
     });
+  });
+
+  it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 refuses to start Self-Host OpenCode before the replacement search channel is available", async () => {
+    setSettings({ enableSelfHostMode: true });
+    updateSetting("agentMode", {
+      byok: {},
+      activeBackend: "opencode",
+      debugFullFrames: false,
+      welcomeDismissed: false,
+      skills: { folder: "copilot/skills" },
+      backends: { opencode: { binaryPath: "/path/to/opencode" } },
+    });
+    const deps = makeDeps({ resolved: [] });
+    delete deps.getSelfHostWebSearchChannel;
+
+    await expect(
+      new OpencodeBackend(deps).buildSpawnDescriptor({ vaultBasePath: "/vault" })
+    ).rejects.toThrow("self-host web search channel is unavailable");
   });
 
   it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 rejects a non-object config override instead of starting without native web denies", async () => {

--- a/src/agentMode/backends/opencode/OpencodeBackend.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.ts
@@ -142,14 +142,41 @@ export class OpencodeBackend implements AcpBackend {
     const envOverrides = sanitizeBuiltinSkillEnvOverrides(
       settings.agentMode?.backends?.opencode?.envOverrides
     );
-    // Accepted degradation: a user `OPENCODE_CONFIG_CONTENT` override (spread
-    // last below) replaces the whole generated config, dropping the allow rule.
+    const configOverride = envOverrides.OPENCODE_CONFIG_CONTENT;
+    delete envOverrides.OPENCODE_CONFIG_CONTENT;
+    let configContent = configOverride ?? JSON.stringify(config);
+    if (settings.enableSelfHostMode === true && configOverride !== undefined) {
+      // An explicit config override must not reopen agent-native web tools while
+      // Self-Host mode promises that queries stay on the configured route.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/165
+      let overriddenConfig: Record<string, unknown>;
+      try {
+        const parsed = JSON.parse(configOverride) as unknown;
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error();
+        overriddenConfig = parsed as Record<string, unknown>;
+      } catch {
+        throw new Error("opencode OPENCODE_CONFIG_CONTENT must be a JSON object.");
+      }
+      overriddenConfig.permission = denyNativeWebTools(overriddenConfig.permission);
+      const overriddenAgents = overriddenConfig.agent;
+      if (
+        overriddenAgents &&
+        typeof overriddenAgents === "object" &&
+        !Array.isArray(overriddenAgents)
+      ) {
+        for (const agent of Object.values(overriddenAgents)) {
+          if (!agent || typeof agent !== "object" || Array.isArray(agent)) continue;
+          const agentConfig = agent as Record<string, unknown>;
+          agentConfig.permission = denyNativeWebTools(agentConfig.permission);
+        }
+      }
+      configContent = JSON.stringify(overriddenConfig);
+    }
+    // Accepted degradation: a user `OPENCODE_CONFIG_CONTENT` override replaces
+    // the whole generated config, dropping the allow rule.
     // opencode then prompts on every snapshot read; the sources still appear in
     // the manifest. Warn so the lost approval-suppression is diagnosable.
-    if (
-      cacheRoot &&
-      Object.prototype.hasOwnProperty.call(envOverrides, "OPENCODE_CONFIG_CONTENT")
-    ) {
+    if (cacheRoot && configOverride !== undefined) {
       logWarn(
         "[AgentMode] opencode envOverrides.OPENCODE_CONFIG_CONTENT replaces the generated config; " +
           "the context-cache external_directory allow rule is dropped — opencode will prompt on every " +
@@ -168,11 +195,11 @@ export class OpencodeBackend implements AcpBackend {
       args: ["acp", "--cwd", ctx.vaultBasePath],
       env: {
         ...process.env,
-        OPENCODE_CONFIG_CONTENT: JSON.stringify(config),
         ...builtinSkillEnv,
         // User overrides stay last for ordinary values. Copilot-owned Miyo
         // scope keys were removed above so they cannot widen Current vault.
         ...envOverrides,
+        OPENCODE_CONFIG_CONTENT: configContent,
       },
     };
   }
@@ -188,6 +215,22 @@ export class OpencodeBackend implements AcpBackend {
 function normalizeCacheRoot(raw: string | undefined): string | undefined {
   const trimmed = raw?.trim();
   return trimmed ? trimmed : undefined;
+}
+
+/**
+ * Preserve an OpenCode permission policy while making native web access non-overridable.
+ * https://github.com/Brevilabs/obsidian-copilot-private/issues/165
+ *
+ * @param permission Existing shorthand or object permission policy.
+ */
+function denyNativeWebTools(permission: unknown): Record<string, unknown> {
+  const permissionRecord =
+    typeof permission === "string"
+      ? { "*": permission }
+      : permission && typeof permission === "object" && !Array.isArray(permission)
+        ? (permission as Record<string, unknown>)
+        : {};
+  return { ...permissionRecord, websearch: "deny", webfetch: "deny" };
 }
 
 /** Mutable opencode provider config entry built into `OPENCODE_CONFIG_CONTENT`. */
@@ -323,6 +366,14 @@ export async function buildOpencodeConfig(
   }
 
   const config: Record<string, unknown> = { provider };
+
+  // Top-level rules cover primary agents and subagents. Self-Host mode cannot
+  // rely on prompt steering because opencode's native tools contact its own
+  // search/fetch services directly.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/165
+  if (s.enableSelfHostMode === true) {
+    config.permission = denyNativeWebTools(config.permission);
+  }
 
   // Inject a managed `copilot-build` agent so the mode picker can offer the
   // canonical "default" semantic — let the agent edit, but ask first. The

--- a/src/agentMode/backends/opencode/OpencodeBackend.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.ts
@@ -17,6 +17,7 @@ import { OpencodeBackendDescriptor } from "./descriptor";
 import { copilotPlusModelId, mapProviderToOpencodeId } from "./opencodeModelResolve";
 import type { PlanUsageReading } from "@/agentMode/session/planUsage";
 import { CopilotPlusUsageReader } from "@/agentMode/backends/shared/copilotPlusUsage";
+import type { SelfHostWebSearchAgentChannel } from "@/LLMProviders/selfHostServices";
 
 /**
  * Maps Copilot's `ChatModelProviders` to OpenCode's provider id. Used for the
@@ -71,6 +72,8 @@ export interface OpencodeModelDeps {
    * `external_directory` allow rule is simply not injected (feature dormant).
    */
   getCacheRoot?: () => string | undefined;
+  /** Starts or reuses the owning plugin lifecycle's provider-credential-free channel. */
+  getSelfHostWebSearchChannel?: () => Promise<Readonly<SelfHostWebSearchAgentChannel>>;
 }
 
 /**
@@ -183,11 +186,23 @@ export class OpencodeBackend implements AcpBackend {
           "snapshot read. Remove that override to restore silent cache access."
       );
     }
+    // Native web tools are already denied at this point, so a Self-Host spawn
+    // must obtain its replacement channel or fail before the agent starts.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/165
+    const selfHostSearchChannel =
+      settings.enableSelfHostMode === true
+        ? await this.#deps.getSelfHostWebSearchChannel?.()
+        : undefined;
+    if (settings.enableSelfHostMode === true && !selfHostSearchChannel) {
+      throw new Error("Copilot self-host web search channel is unavailable.");
+    }
+
     // Builtin skills consume plugin-managed runtime paths and credentials.
     const builtinSkillEnv = await buildBuiltinSkillEnv(
       this.#deps.clientVersion,
       ctx.vaultBasePath,
-      ctx.vaultName
+      ctx.vaultName,
+      selfHostSearchChannel
     );
 
     return {

--- a/src/agentMode/backends/opencode/descriptor.ts
+++ b/src/agentMode/backends/opencode/descriptor.ts
@@ -284,6 +284,16 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
         // shared conversions cache. vaultId/path derivation lives entirely in
         // conversionsLocation — this backend never duplicates it.
         getCacheRoot: () => cacheRoot(args.plugin.app),
+        getSelfHostWebSearchChannel: () => {
+          // The native deny is safe only when this lifecycle can provide the
+          // replacement route before OpenCode starts.
+          // https://github.com/Brevilabs/obsidian-copilot-private/issues/165
+          const bridge = args.plugin.selfHostWebSearchAgentBridge;
+          if (!bridge) {
+            throw new Error("Copilot self-host web search channel is unavailable.");
+          }
+          return bridge.getChannel();
+        },
       })
     );
   },

--- a/src/agentMode/backends/shared/builtinSkillEnv.test.ts
+++ b/src/agentMode/backends/shared/builtinSkillEnv.test.ts
@@ -7,9 +7,11 @@ import { getSettings } from "@/settings/model";
 import { getMiyoCustomUrl } from "@/miyo/miyoUtils";
 import { BREVILABS_API_BASE_URL } from "@/constants";
 import {
+  AGENT_VAULT_NAME_ENV,
   MIYO_SEARCH_FOLDER_ENV,
   MIYO_SEARCH_SCOPE_ENV,
   PLUS_ENV,
+  SELF_HOST_WEB_SEARCH_ENV,
 } from "@/agentMode/skills/builtin/builtinSkills";
 import { SYMPOSIUM_WORKSPACE_ROOT_ENV } from "@/symposium/constants";
 import {
@@ -87,6 +89,7 @@ describe("builtinSkillEnv", () => {
 
       expect(await buildBuiltinSkillEnv("", "/vault/root", "root")).toEqual({
         [SYMPOSIUM_WORKSPACE_ROOT_ENV]: "/vault/root",
+        [AGENT_VAULT_NAME_ENV]: "root",
         [MIYO_SEARCH_SCOPE_ENV]: "current",
         [MIYO_SEARCH_FOLDER_ENV]: "root",
       });
@@ -97,6 +100,7 @@ describe("builtinSkillEnv", () => {
 
       expect(await buildBuiltinSkillEnv("", "/vault/root", "root")).toEqual({
         [SYMPOSIUM_WORKSPACE_ROOT_ENV]: "/vault/root",
+        [AGENT_VAULT_NAME_ENV]: "root",
         [MIYO_SEARCH_SCOPE_ENV]: "unrestricted",
         [MIYO_SEARCH_FOLDER_ENV]: "root",
       });
@@ -108,6 +112,22 @@ describe("builtinSkillEnv", () => {
 
       expect(await buildBuiltinSkillEnv()).toEqual({
         [COPILOT_OBSIDIAN_CLI_ENV]: "C:/Users/Me/App Data/Obsidian/Obsidian.com",
+      });
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 injects protected Self-Host routing without provider credentials", async () => {
+      mockGetSettings.mockReturnValue({
+        isPaidUser: false,
+        enableSelfHostMode: true,
+        exaApiKey: "host-only-key",
+      });
+
+      expect(await buildBuiltinSkillEnv("", "/vault/root", "root")).toEqual({
+        [SYMPOSIUM_WORKSPACE_ROOT_ENV]: "/vault/root",
+        [AGENT_VAULT_NAME_ENV]: "root",
+        [MIYO_SEARCH_SCOPE_ENV]: "current",
+        [MIYO_SEARCH_FOLDER_ENV]: "root",
+        [SELF_HOST_WEB_SEARCH_ENV]: "1",
       });
     });
 
@@ -147,6 +167,16 @@ describe("builtinSkillEnv", () => {
         ANTHROPIC_MODEL: "claude",
       });
     });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 prevents backend overrides from bypassing Self-Host search routing", () => {
+      expect(
+        sanitizeBuiltinSkillEnvOverrides({
+          [SELF_HOST_WEB_SEARCH_ENV]: "",
+          [AGENT_VAULT_NAME_ENV]: "other-vault",
+          OPENAI_API_KEY: "allowed",
+        })
+      ).toEqual({ OPENAI_API_KEY: "allowed" });
+    });
   });
 
   describe("getBuiltinSkillEnvRestartPolicy()", () => {
@@ -173,6 +203,20 @@ describe("builtinSkillEnv", () => {
       >;
 
       expect(getBuiltinSkillEnvRestartPolicy(prev, next)).toBe("immediate");
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 immediately blocks native web tools when Self-Host mode is enabled", () => {
+      const prev = { enableSelfHostMode: false } as ReturnType<typeof getSettings>;
+      const next = { enableSelfHostMode: true } as ReturnType<typeof getSettings>;
+
+      expect(getBuiltinSkillEnvRestartPolicy(prev, next)).toBe("immediate");
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 defers the routing refresh when Self-Host mode is disabled", () => {
+      const prev = { enableSelfHostMode: true } as ReturnType<typeof getSettings>;
+      const next = { enableSelfHostMode: false } as ReturnType<typeof getSettings>;
+
+      expect(getBuiltinSkillEnvRestartPolicy(prev, next)).toBe("deferred");
     });
 
     it("https://github.com/Brevilabs/obsidian-copilot-private/issues/121 defers an enabled skill refresh when scope widens", () => {

--- a/src/agentMode/backends/shared/builtinSkillEnv.test.ts
+++ b/src/agentMode/backends/shared/builtinSkillEnv.test.ts
@@ -202,7 +202,7 @@ describe("builtinSkillEnv", () => {
         const prev = { [key]: before } as unknown as ReturnType<typeof getSettings>;
         const next = { [key]: after } as unknown as ReturnType<typeof getSettings>;
 
-        expect(getBuiltinSkillEnvRestartPolicy(prev, next)).toBe("deferred");
+        expect(getBuiltinSkillEnvRestartPolicy(prev, next, "opencode")).toBe("deferred");
       }
     );
 
@@ -214,21 +214,40 @@ describe("builtinSkillEnv", () => {
         typeof getSettings
       >;
 
-      expect(getBuiltinSkillEnvRestartPolicy(prev, next)).toBe("immediate");
+      expect(getBuiltinSkillEnvRestartPolicy(prev, next, "opencode")).toBe("immediate");
     });
 
     it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 immediately blocks native web tools when Self-Host mode is enabled", () => {
       const prev = { enableSelfHostMode: false } as ReturnType<typeof getSettings>;
       const next = { enableSelfHostMode: true } as ReturnType<typeof getSettings>;
 
-      expect(getBuiltinSkillEnvRestartPolicy(prev, next)).toBe("immediate");
+      expect(getBuiltinSkillEnvRestartPolicy(prev, next, "opencode")).toBe("immediate");
     });
 
-    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 defers the routing refresh when Self-Host mode is disabled", () => {
+    it.each(["claude", "codex"])(
+      "https://github.com/Brevilabs/obsidian-copilot-private/issues/165 does not restart %s when OpenCode-only Self-Host routing is enabled",
+      (backendId) => {
+        const prev = { enableSelfHostMode: false } as ReturnType<typeof getSettings>;
+        const next = { enableSelfHostMode: true } as ReturnType<typeof getSettings>;
+
+        expect(getBuiltinSkillEnvRestartPolicy(prev, next, backendId)).toBe("none");
+      }
+    );
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 keeps Claude's shared environment refresh deferred when OpenCode-only routing changes too", () => {
+      const prev = { isPaidUser: false, enableSelfHostMode: false } as ReturnType<
+        typeof getSettings
+      >;
+      const next = { isPaidUser: true, enableSelfHostMode: true } as ReturnType<typeof getSettings>;
+
+      expect(getBuiltinSkillEnvRestartPolicy(prev, next, "claude")).toBe("deferred");
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 defers the OpenCode routing refresh when Self-Host mode is disabled", () => {
       const prev = { enableSelfHostMode: true } as ReturnType<typeof getSettings>;
       const next = { enableSelfHostMode: false } as ReturnType<typeof getSettings>;
 
-      expect(getBuiltinSkillEnvRestartPolicy(prev, next)).toBe("deferred");
+      expect(getBuiltinSkillEnvRestartPolicy(prev, next, "opencode")).toBe("deferred");
     });
 
     it("https://github.com/Brevilabs/obsidian-copilot-private/issues/121 defers an enabled skill refresh when scope widens", () => {
@@ -239,7 +258,7 @@ describe("builtinSkillEnv", () => {
         typeof getSettings
       >;
 
-      expect(getBuiltinSkillEnvRestartPolicy(prev, next)).toBe("deferred");
+      expect(getBuiltinSkillEnvRestartPolicy(prev, next, "opencode")).toBe("deferred");
     });
 
     it("https://github.com/Brevilabs/obsidian-copilot-private/issues/121 skips scope refreshes while the skill is disabled", () => {
@@ -250,14 +269,14 @@ describe("builtinSkillEnv", () => {
         typeof getSettings
       >;
 
-      expect(getBuiltinSkillEnvRestartPolicy(prev, next)).toBe("none");
+      expect(getBuiltinSkillEnvRestartPolicy(prev, next, "opencode")).toBe("none");
     });
 
     it("https://github.com/Brevilabs/obsidian-copilot-private/issues/121 keeps spawn-time state for unrelated settings changes", () => {
       const prev = { miyoSearchAll: false, contextTurns: 5 } as ReturnType<typeof getSettings>;
       const next = { miyoSearchAll: false, contextTurns: 9 } as ReturnType<typeof getSettings>;
 
-      expect(getBuiltinSkillEnvRestartPolicy(prev, next)).toBe("none");
+      expect(getBuiltinSkillEnvRestartPolicy(prev, next, "opencode")).toBe("none");
     });
   });
 });

--- a/src/agentMode/backends/shared/builtinSkillEnv.test.ts
+++ b/src/agentMode/backends/shared/builtinSkillEnv.test.ts
@@ -7,11 +7,12 @@ import { getSettings } from "@/settings/model";
 import { getMiyoCustomUrl } from "@/miyo/miyoUtils";
 import { BREVILABS_API_BASE_URL } from "@/constants";
 import {
-  AGENT_VAULT_NAME_ENV,
   MIYO_SEARCH_FOLDER_ENV,
   MIYO_SEARCH_SCOPE_ENV,
   PLUS_ENV,
   SELF_HOST_WEB_SEARCH_ENV,
+  SELF_HOST_WEB_SEARCH_TOKEN_ENV,
+  SELF_HOST_WEB_SEARCH_URL_ENV,
 } from "@/agentMode/skills/builtin/builtinSkills";
 import { SYMPOSIUM_WORKSPACE_ROOT_ENV } from "@/symposium/constants";
 import {
@@ -89,7 +90,6 @@ describe("builtinSkillEnv", () => {
 
       expect(await buildBuiltinSkillEnv("", "/vault/root", "root")).toEqual({
         [SYMPOSIUM_WORKSPACE_ROOT_ENV]: "/vault/root",
-        [AGENT_VAULT_NAME_ENV]: "root",
         [MIYO_SEARCH_SCOPE_ENV]: "current",
         [MIYO_SEARCH_FOLDER_ENV]: "root",
       });
@@ -100,7 +100,6 @@ describe("builtinSkillEnv", () => {
 
       expect(await buildBuiltinSkillEnv("", "/vault/root", "root")).toEqual({
         [SYMPOSIUM_WORKSPACE_ROOT_ENV]: "/vault/root",
-        [AGENT_VAULT_NAME_ENV]: "root",
         [MIYO_SEARCH_SCOPE_ENV]: "unrestricted",
         [MIYO_SEARCH_FOLDER_ENV]: "root",
       });
@@ -122,13 +121,25 @@ describe("builtinSkillEnv", () => {
         exaApiKey: "host-only-key",
       });
 
-      expect(await buildBuiltinSkillEnv("", "/vault/root", "root")).toEqual({
+      expect(
+        await buildBuiltinSkillEnv("", "/vault/root", "root", {
+          url: "http://127.0.0.1:1234/search",
+          token: "session-token",
+        })
+      ).toEqual({
         [SYMPOSIUM_WORKSPACE_ROOT_ENV]: "/vault/root",
-        [AGENT_VAULT_NAME_ENV]: "root",
         [MIYO_SEARCH_SCOPE_ENV]: "current",
         [MIYO_SEARCH_FOLDER_ENV]: "root",
         [SELF_HOST_WEB_SEARCH_ENV]: "1",
+        [SELF_HOST_WEB_SEARCH_URL_ENV]: "http://127.0.0.1:1234/search",
+        [SELF_HOST_WEB_SEARCH_TOKEN_ENV]: "session-token",
       });
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 does not mark Self-Host routing active before its replacement channel exists", async () => {
+      mockGetSettings.mockReturnValue({ isPaidUser: false, enableSelfHostMode: true });
+
+      expect(await buildBuiltinSkillEnv()).toEqual({});
     });
 
     it("merges MIYO_URL with the Plus relay env for a Plus user with a custom Miyo URL", async () => {
@@ -172,7 +183,8 @@ describe("builtinSkillEnv", () => {
       expect(
         sanitizeBuiltinSkillEnvOverrides({
           [SELF_HOST_WEB_SEARCH_ENV]: "",
-          [AGENT_VAULT_NAME_ENV]: "other-vault",
+          [SELF_HOST_WEB_SEARCH_URL_ENV]: "http://attacker.invalid",
+          [SELF_HOST_WEB_SEARCH_TOKEN_ENV]: "replacement-token",
           OPENAI_API_KEY: "allowed",
         })
       ).toEqual({ OPENAI_API_KEY: "allowed" });

--- a/src/agentMode/backends/shared/builtinSkillEnv.ts
+++ b/src/agentMode/backends/shared/builtinSkillEnv.ts
@@ -15,6 +15,7 @@ import {
   resolveObsidianCliPath,
 } from "@/agentMode/backends/shared/obsidianCliPath";
 import { requireNodeModule } from "@/utils/desktopRuntime";
+import type { BackendId } from "@/agentMode/session/types";
 
 /** Env var the bundled `miyo` CLI reads to target a non-default Miyo service. */
 const MIYO_URL_ENV = "MIYO_URL";
@@ -135,16 +136,24 @@ export function sanitizeBuiltinSkillEnvOverrides(
   return sanitized;
 }
 
-/** How a persisted setting change should refresh the environment captured at spawn. */
+/**
+ * Decide how a persisted setting change refreshes one backend's spawn-time environment.
+ *
+ * @param prev Settings before the change.
+ * @param next Settings after the change.
+ * @param backendId Backend whose active process may need replacement.
+ */
 export function getBuiltinSkillEnvRestartPolicy(
   prev: CopilotSettings,
-  next: CopilotSettings
+  next: CopilotSettings,
+  backendId: BackendId
 ): "none" | "deferred" | "immediate" {
   const ordinaryEnvChanged =
     prev.isPaidUser !== next.isPaidUser ||
     prev.plusLicenseKey !== next.plusLicenseKey ||
-    prev.miyoServerUrl !== next.miyoServerUrl ||
-    prev.enableSelfHostMode !== next.enableSelfHostMode;
+    prev.miyoServerUrl !== next.miyoServerUrl;
+  const selfHostRoutingChanged =
+    backendId === "opencode" && prev.enableSelfHostMode !== next.enableSelfHostMode;
   // Scope changes only affect a currently enabled skill. Tightening an active
   // boundary must cancel the current turn; widening can wait until it is idle.
   // https://github.com/Brevilabs/obsidian-copilot-private/issues/121
@@ -153,11 +162,15 @@ export function getBuiltinSkillEnvRestartPolicy(
     next.enableMiyoSearchSkill === true &&
     prev.miyoSearchAll !== next.miyoSearchAll;
 
-  if (!ordinaryEnvChanged && !activeMiyoScopeChanged) return "none";
+  if (!ordinaryEnvChanged && !selfHostRoutingChanged && !activeMiyoScopeChanged) return "none";
   // Enabling Self-Host mode must stop a live native web tool before another
   // query can leave through the agent's provider.
   // https://github.com/Brevilabs/obsidian-copilot-private/issues/165
-  if (prev.enableSelfHostMode !== true && next.enableSelfHostMode === true) {
+  if (
+    selfHostRoutingChanged &&
+    prev.enableSelfHostMode !== true &&
+    next.enableSelfHostMode === true
+  ) {
     return "immediate";
   }
   if (activeMiyoScopeChanged && prev.miyoSearchAll === true && next.miyoSearchAll !== true) {

--- a/src/agentMode/backends/shared/builtinSkillEnv.ts
+++ b/src/agentMode/backends/shared/builtinSkillEnv.ts
@@ -2,11 +2,12 @@ import { BREVILABS_API_BASE_URL } from "@/constants";
 import { type CopilotSettings, getSettings } from "@/settings/model";
 import { getMiyoCustomUrl } from "@/miyo/miyoUtils";
 import {
-  AGENT_VAULT_NAME_ENV,
   MIYO_SEARCH_FOLDER_ENV,
   MIYO_SEARCH_SCOPE_ENV,
   PLUS_ENV,
   SELF_HOST_WEB_SEARCH_ENV,
+  SELF_HOST_WEB_SEARCH_TOKEN_ENV,
+  SELF_HOST_WEB_SEARCH_URL_ENV,
 } from "@/agentMode/skills/builtin/builtinSkills";
 import { SYMPOSIUM_WORKSPACE_ROOT_ENV } from "@/symposium/constants";
 import {
@@ -22,7 +23,8 @@ const PROTECTED_BUILTIN_ENV_KEYS = [
   MIYO_SEARCH_SCOPE_ENV,
   MIYO_SEARCH_FOLDER_ENV,
   SELF_HOST_WEB_SEARCH_ENV,
-  AGENT_VAULT_NAME_ENV,
+  SELF_HOST_WEB_SEARCH_URL_ENV,
+  SELF_HOST_WEB_SEARCH_TOKEN_ENV,
 ] as const;
 
 /** Frozen empty result so unmanaged spawns don't allocate a fresh object each time. */
@@ -44,8 +46,8 @@ const EMPTY_MANAGED_ENV: Readonly<Record<string, string>> = Object.freeze({});
  *   prompt.
  * - **Host review** (`SYMPOSIUM_WORKSPACE_ROOT`): owning workspace used to
  *   stage HTML and derive the wrapper's explicit Obsidian CLI vault target.
- * - **Self-host web search**: a mode marker and exact vault identity route the
- *   managed skill back into Obsidian without exposing provider credentials.
+ * - **Self-host web search**: a mode marker and per-lifecycle loopback channel
+ *   route the managed skill back into Obsidian without exposing provider credentials.
  * - **Miyo** (`MIYO_URL`): the user's custom/remote Miyo server URL when set, so
  *   the bundled `miyo` CLI targets their configured service instead of local
  *   loopback discovery (the only way Miyo works on mobile or against a remote
@@ -54,12 +56,14 @@ const EMPTY_MANAGED_ENV: Readonly<Record<string, string>> = Object.freeze({});
  *   without a license.
  * @param clientVersion Version reported to the Copilot Plus relay.
  * @param workspaceRootAbs Absolute host workspace root used by portable skills.
- * @param vaultName Exact active-vault name used by host-backed skills.
+ * @param vaultName Exact active-vault name used by vault-scoped skills.
+ * @param selfHostSearchChannel Plugin-owned endpoint and token for Self-Host search.
  */
 export async function buildBuiltinSkillEnv(
   clientVersion = "",
   workspaceRootAbs = "",
-  vaultName = ""
+  vaultName = "",
+  selfHostSearchChannel?: Readonly<{ url: string; token: string }>
 ): Promise<Readonly<Record<string, string>>> {
   const os = requireNodeModule<typeof import("node:os")>("os");
   const settings = getSettings();
@@ -74,14 +78,14 @@ export async function buildBuiltinSkillEnv(
   });
   if (obsidianCliPath) env[COPILOT_OBSIDIAN_CLI_ENV] = obsidianCliPath;
 
-  // The CLI bridge must target this lifecycle's vault instead of whichever
-  // Obsidian renderer happens to be focused.
+  // The channel values are protected from backend overrides so Self-Host mode
+  // cannot silently fall back to a hosted or agent-native search path.
   // https://github.com/Brevilabs/obsidian-copilot-private/issues/165
-  if (vaultName) env[AGENT_VAULT_NAME_ENV] = vaultName;
-  // The marker is protected from backend overrides so Self-Host mode cannot
-  // silently fall back to a hosted or agent-native search path.
-  // https://github.com/Brevilabs/obsidian-copilot-private/issues/165
-  if (settings.enableSelfHostMode === true) env[SELF_HOST_WEB_SEARCH_ENV] = "1";
+  if (settings.enableSelfHostMode === true && selfHostSearchChannel) {
+    env[SELF_HOST_WEB_SEARCH_ENV] = "1";
+    env[SELF_HOST_WEB_SEARCH_URL_ENV] = selfHostSearchChannel.url;
+    env[SELF_HOST_WEB_SEARCH_TOKEN_ENV] = selfHostSearchChannel.token;
+  }
 
   // The CLI reads MIYO_URL; bare/local installs leave it empty and fall back to
   // loopback discovery.

--- a/src/agentMode/backends/shared/builtinSkillEnv.ts
+++ b/src/agentMode/backends/shared/builtinSkillEnv.ts
@@ -2,9 +2,11 @@ import { BREVILABS_API_BASE_URL } from "@/constants";
 import { type CopilotSettings, getSettings } from "@/settings/model";
 import { getMiyoCustomUrl } from "@/miyo/miyoUtils";
 import {
+  AGENT_VAULT_NAME_ENV,
   MIYO_SEARCH_FOLDER_ENV,
   MIYO_SEARCH_SCOPE_ENV,
   PLUS_ENV,
+  SELF_HOST_WEB_SEARCH_ENV,
 } from "@/agentMode/skills/builtin/builtinSkills";
 import { SYMPOSIUM_WORKSPACE_ROOT_ENV } from "@/symposium/constants";
 import {
@@ -16,7 +18,12 @@ import { requireNodeModule } from "@/utils/desktopRuntime";
 /** Env var the bundled `miyo` CLI reads to target a non-default Miyo service. */
 const MIYO_URL_ENV = "MIYO_URL";
 
-const PROTECTED_BUILTIN_ENV_KEYS = [MIYO_SEARCH_SCOPE_ENV, MIYO_SEARCH_FOLDER_ENV] as const;
+const PROTECTED_BUILTIN_ENV_KEYS = [
+  MIYO_SEARCH_SCOPE_ENV,
+  MIYO_SEARCH_FOLDER_ENV,
+  SELF_HOST_WEB_SEARCH_ENV,
+  AGENT_VAULT_NAME_ENV,
+] as const;
 
 /** Frozen empty result so unmanaged spawns don't allocate a fresh object each time. */
 const EMPTY_MANAGED_ENV: Readonly<Record<string, string>> = Object.freeze({});
@@ -37,6 +44,8 @@ const EMPTY_MANAGED_ENV: Readonly<Record<string, string>> = Object.freeze({});
  *   prompt.
  * - **Host review** (`SYMPOSIUM_WORKSPACE_ROOT`): owning workspace used to
  *   stage HTML and derive the wrapper's explicit Obsidian CLI vault target.
+ * - **Self-host web search**: a mode marker and exact vault identity route the
+ *   managed skill back into Obsidian without exposing provider credentials.
  * - **Miyo** (`MIYO_URL`): the user's custom/remote Miyo server URL when set, so
  *   the bundled `miyo` CLI targets their configured service instead of local
  *   loopback discovery (the only way Miyo works on mobile or against a remote
@@ -45,12 +54,12 @@ const EMPTY_MANAGED_ENV: Readonly<Record<string, string>> = Object.freeze({});
  *   without a license.
  * @param clientVersion Version reported to the Copilot Plus relay.
  * @param workspaceRootAbs Absolute host workspace root used by portable skills.
- * @param miyoFolderName Exact active-vault name Miyo resolves on its own host.
+ * @param vaultName Exact active-vault name used by host-backed skills.
  */
 export async function buildBuiltinSkillEnv(
   clientVersion = "",
   workspaceRootAbs = "",
-  miyoFolderName = ""
+  vaultName = ""
 ): Promise<Readonly<Record<string, string>>> {
   const os = requireNodeModule<typeof import("node:os")>("os");
   const settings = getSettings();
@@ -65,6 +74,15 @@ export async function buildBuiltinSkillEnv(
   });
   if (obsidianCliPath) env[COPILOT_OBSIDIAN_CLI_ENV] = obsidianCliPath;
 
+  // The CLI bridge must target this lifecycle's vault instead of whichever
+  // Obsidian renderer happens to be focused.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/165
+  if (vaultName) env[AGENT_VAULT_NAME_ENV] = vaultName;
+  // The marker is protected from backend overrides so Self-Host mode cannot
+  // silently fall back to a hosted or agent-native search path.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/165
+  if (settings.enableSelfHostMode === true) env[SELF_HOST_WEB_SEARCH_ENV] = "1";
+
   // The CLI reads MIYO_URL; bare/local installs leave it empty and fall back to
   // loopback discovery.
   const miyoUrl = getMiyoCustomUrl(settings);
@@ -76,7 +94,7 @@ export async function buildBuiltinSkillEnv(
     // session's cwd and remains portable to remote Miyo hosts.
     // https://github.com/Brevilabs/obsidian-copilot-private/issues/121
     env[MIYO_SEARCH_SCOPE_ENV] = settings.miyoSearchAll === true ? "unrestricted" : "current";
-    if (miyoFolderName) env[MIYO_SEARCH_FOLDER_ENV] = miyoFolderName;
+    if (vaultName) env[MIYO_SEARCH_FOLDER_ENV] = vaultName;
   }
 
   // Copilot Plus relay env — gated on an active subscription with a usable key.
@@ -121,7 +139,8 @@ export function getBuiltinSkillEnvRestartPolicy(
   const ordinaryEnvChanged =
     prev.isPaidUser !== next.isPaidUser ||
     prev.plusLicenseKey !== next.plusLicenseKey ||
-    prev.miyoServerUrl !== next.miyoServerUrl;
+    prev.miyoServerUrl !== next.miyoServerUrl ||
+    prev.enableSelfHostMode !== next.enableSelfHostMode;
   // Scope changes only affect a currently enabled skill. Tightening an active
   // boundary must cancel the current turn; widening can wait until it is idle.
   // https://github.com/Brevilabs/obsidian-copilot-private/issues/121
@@ -131,6 +150,12 @@ export function getBuiltinSkillEnvRestartPolicy(
     prev.miyoSearchAll !== next.miyoSearchAll;
 
   if (!ordinaryEnvChanged && !activeMiyoScopeChanged) return "none";
+  // Enabling Self-Host mode must stop a live native web tool before another
+  // query can leave through the agent's provider.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/165
+  if (prev.enableSelfHostMode !== true && next.enableSelfHostMode === true) {
+    return "immediate";
+  }
   if (activeMiyoScopeChanged && prev.miyoSearchAll === true && next.miyoSearchAll !== true) {
     return "immediate";
   }

--- a/src/agentMode/index.ts
+++ b/src/agentMode/index.ts
@@ -345,16 +345,16 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
     // The managed env injected at spawn (see `buildBuiltinSkillEnv`) changes with
     // Copilot Plus sign-in/out or license rotation (the decrypted license the
     // builtin Plus skill scripts read), with the Miyo server URL (the `MIYO_URL`
-    // the bundled miyo CLI reads), or with the Miyo Search scope. These values
-    // are only read on a fresh spawn, so restart every backend — otherwise a
-    // running subprocess keeps stale policy until a reload. (Restarts coalesce,
-    // so this folds with any Miyo-availability re-seed restart below.)
-    const managedEnvRestartPolicy = getBuiltinSkillEnvRestartPolicy(prev, next);
-    if (managedEnvRestartPolicy !== "none") {
-      // Applying a new search boundary cannot wait for a running turn to finish:
-      // cancel it before it can start another search with the prior scope.
-      // https://github.com/Brevilabs/obsidian-copilot-private/issues/121
-      for (const descriptor of listBackendDescriptors()) {
+    // the bundled miyo CLI reads), with the Miyo Search scope, or with
+    // OpenCode's Self-Host routing boundary. These values are only read on a
+    // fresh spawn. The policy selects only affected backends and restarts
+    // coalesce with any Miyo-availability re-seed restart below.
+    for (const descriptor of listBackendDescriptors()) {
+      const managedEnvRestartPolicy = getBuiltinSkillEnvRestartPolicy(prev, next, descriptor.id);
+      if (managedEnvRestartPolicy !== "none") {
+        // Applying a new search boundary cannot wait for a running turn to finish:
+        // cancel it before it can start another search with the prior scope.
+        // https://github.com/Brevilabs/obsidian-copilot-private/issues/121
         void manager
           .restartBackend(descriptor.id, "managed agent env changed", {
             deferWhileBusy: managedEnvRestartPolicy !== "immediate",

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -1,9 +1,11 @@
 import {
+  AGENT_VAULT_NAME_ENV,
   BUILTIN_SKILLS,
   MIYO_PARSE_SKILL,
   MIYO_SEARCH_SKILL,
   planManagedBuiltins,
   PLUS_ENV,
+  SELF_HOST_WEB_SEARCH_ENV,
 } from "./builtinSkills";
 import {
   SYMPOSIUM_AGENT_HANDOFF_DIR,
@@ -85,7 +87,8 @@ describe("builtinSkills", () => {
         expect(sh).toContain("Authorization: Bearer $KEY");
         expect(sh).toContain("X-Client-Version: $CLIENT_VERSION");
         // Guard + soft fallback when the license/relay config is absent.
-        expect(sh).toContain('[ -n "$KEY" ] && [ -n "$BASE" ] || no_license');
+        expect(sh).toContain("require_relay()");
+        expect(sh).toContain("require_relay\n");
         expect(sh).toContain("Copilot Plus");
 
         const ps1 = scriptOf(skill.name, ".ps1");
@@ -94,7 +97,8 @@ describe("builtinSkills", () => {
         expect(ps1).toContain('Authorization = "Bearer $KEY"');
         expect(ps1).toContain("'X-Client-Version' = $CLIENT_VERSION");
         // Same license guard as the shell script.
-        expect(ps1).toContain("if (-not $KEY -or -not $BASE) { NoLicense }");
+        expect(ps1).toContain("function RequireRelay");
+        expect(ps1).toContain("RequireRelay\n");
         expect(ps1).toContain("Copilot Plus");
         // The body is sent as explicit UTF-8 bytes — Windows PowerShell 5.1 would
         // otherwise ASCII-encode a string body and corrupt non-ASCII input.
@@ -149,6 +153,39 @@ describe("builtinSkills", () => {
       expect(scriptOf("copilot-web-fetch", ".ps1")).toContain('Invoke-Relay "/url4llm"');
       expect(scriptOf("copilot-web-fetch", ".ps1")).toContain(
         "@{ url = $ARG; user_id = $USER_ID }"
+      );
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 routes Self-Host web search through the owning Obsidian plugin bridge", () => {
+      const sh = scriptOf("copilot-web-search", ".sh");
+      expect(sh).toContain(SELF_HOST_WEB_SEARCH_ENV);
+      expect(sh).toContain(AGENT_VAULT_NAME_ENV);
+      expect(sh).toContain("selfHostWebSearchAgentBridge");
+      expect(sh).toContain('"vault=$VAULT_NAME" eval');
+      expect(sh.indexOf('if [ "$SELF_HOST" = "1" ]')).toBeLessThan(sh.indexOf("require_relay\n"));
+
+      const ps1 = scriptOf("copilot-web-search", ".ps1");
+      expect(ps1).toContain("selfHostWebSearchAgentBridge");
+      expect(ps1).toContain('& $OBSIDIAN_CLI "vault=$VAULT_NAME"');
+      expect(ps1.indexOf("if ($SELF_HOST -eq '1')")).toBeLessThan(ps1.indexOf("RequireRelay\n"));
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 fails Self-Host page fetch closed without invoking the hosted relay", () => {
+      const skill = BUILTIN_SKILLS.find((item) => item.name === "copilot-web-fetch");
+      expect(skill?.skillMd).toContain("never use an agent-native web");
+
+      const sh = scriptOf("copilot-web-fetch", ".sh");
+      expect(sh).toContain('if [ "$SELF_HOST" = "1" ]');
+      expect(sh).toContain("Do not use a native web-fetch tool");
+      expect(sh.indexOf("Do not use a native web-fetch tool")).toBeLessThan(
+        sh.indexOf("require_relay\n")
+      );
+
+      const ps1 = scriptOf("copilot-web-fetch", ".ps1");
+      expect(ps1).toContain("if ($SELF_HOST -eq '1')");
+      expect(ps1).toContain("Do not use a native web-fetch tool");
+      expect(ps1.indexOf("Do not use a native web-fetch tool")).toBeLessThan(
+        ps1.indexOf("RequireRelay\n")
       );
     });
 

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -1,11 +1,12 @@
 import {
-  AGENT_VAULT_NAME_ENV,
   BUILTIN_SKILLS,
   MIYO_PARSE_SKILL,
   MIYO_SEARCH_SKILL,
   planManagedBuiltins,
   PLUS_ENV,
   SELF_HOST_WEB_SEARCH_ENV,
+  SELF_HOST_WEB_SEARCH_TOKEN_ENV,
+  SELF_HOST_WEB_SEARCH_URL_ENV,
 } from "./builtinSkills";
 import {
   SYMPOSIUM_AGENT_HANDOFF_DIR,
@@ -156,17 +157,24 @@ describe("builtinSkills", () => {
       );
     });
 
-    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 routes Self-Host web search through the owning Obsidian plugin bridge", () => {
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/165 routes Self-Host web search through the plugin-owned channel without the optional Obsidian CLI", () => {
       const sh = scriptOf("copilot-web-search", ".sh");
       expect(sh).toContain(SELF_HOST_WEB_SEARCH_ENV);
-      expect(sh).toContain(AGENT_VAULT_NAME_ENV);
-      expect(sh).toContain("selfHostWebSearchAgentBridge");
-      expect(sh).toContain('"vault=$VAULT_NAME" eval');
+      expect(sh).toContain(SELF_HOST_WEB_SEARCH_URL_ENV);
+      expect(sh).toContain(SELF_HOST_WEB_SEARCH_TOKEN_ENV);
+      expect(sh).toContain("curl --noproxy '*' -sS -X POST \"$SELF_HOST_URL\"");
+      expect(sh).toContain("--data-binary @-");
+      expect(sh).toContain("-w '\\n%{http_code}'");
+      expect(sh).toContain("printf '%s\\n' \"$RESPONSE_BODY\" >&2");
+      expect(sh).not.toContain("COPILOT_OBSIDIAN_CLI");
+      expect(sh).not.toContain("vault=$VAULT_NAME");
       expect(sh.indexOf('if [ "$SELF_HOST" = "1" ]')).toBeLessThan(sh.indexOf("require_relay\n"));
 
       const ps1 = scriptOf("copilot-web-search", ".ps1");
-      expect(ps1).toContain("selfHostWebSearchAgentBridge");
-      expect(ps1).toContain('& $OBSIDIAN_CLI "vault=$VAULT_NAME"');
+      expect(ps1).toContain("Invoke-WebRequest");
+      expect(ps1).toContain("Bearer $SELF_HOST_TOKEN");
+      expect(ps1).toContain("[Console]::Out.WriteLine($response.Content)");
+      expect(ps1).not.toContain("COPILOT_OBSIDIAN_CLI");
       expect(ps1.indexOf("if ($SELF_HOST -eq '1')")).toBeLessThan(ps1.indexOf("RequireRelay\n"));
     });
 

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -57,6 +57,10 @@ export const PLUS_ENV = {
 /** Plugin-owned scope inputs consumed by the managed Miyo search wrappers. */
 export const MIYO_SEARCH_SCOPE_ENV = "COPILOT_MIYO_SEARCH_SCOPE";
 export const MIYO_SEARCH_FOLDER_ENV = "COPILOT_MIYO_SEARCH_FOLDER";
+/** Routes managed web skills through the plugin host instead of a hosted relay. */
+export const SELF_HOST_WEB_SEARCH_ENV = "COPILOT_SELF_HOST_WEB_SEARCH";
+/** Exact vault identity used to target the owning Obsidian CLI renderer. */
+export const AGENT_VAULT_NAME_ENV = "COPILOT_AGENT_VAULT_NAME";
 
 /**
  * No Copilot Plus license is configured — the free-user case (a non-Plus user
@@ -121,6 +125,9 @@ BASE="\${${PLUS_ENV.baseUrl}:-}"
 KEY="\${${PLUS_ENV.licenseKey}:-}"
 USER_ID="\${${PLUS_ENV.userId}:-}"
 CLIENT_VERSION="\${${PLUS_ENV.clientVersion}:-}"
+SELF_HOST="\${${SELF_HOST_WEB_SEARCH_ENV}:-}"
+OBSIDIAN_CLI="\${COPILOT_OBSIDIAN_CLI:-}"
+VAULT_NAME="\${${AGENT_VAULT_NAME_ENV}:-}"
 NO_LICENSE=${shSingleQuote(NO_LICENSE_MESSAGE)}
 NO_LICENSE_UPSELL=${shSingleQuote(NO_LICENSE_UPSELL)}
 LICENSE_INVALID=${shSingleQuote(LICENSE_INVALID_MESSAGE)}
@@ -140,7 +147,9 @@ no_license() {
   die "$msg"
 }
 
-[ -n "$KEY" ] && [ -n "$BASE" ] || no_license
+require_relay() {
+  [ -n "$KEY" ] && [ -n "$BASE" ] || no_license
+}
 
 # JSON-escape a single-line string: backslash first, then double quote.
 json_escape() {
@@ -200,6 +209,9 @@ $BASE = [Environment]::GetEnvironmentVariable('${PLUS_ENV.baseUrl}')
 $KEY = [Environment]::GetEnvironmentVariable('${PLUS_ENV.licenseKey}')
 $USER_ID = [Environment]::GetEnvironmentVariable('${PLUS_ENV.userId}')
 $CLIENT_VERSION = [Environment]::GetEnvironmentVariable('${PLUS_ENV.clientVersion}')
+$SELF_HOST = [Environment]::GetEnvironmentVariable('${SELF_HOST_WEB_SEARCH_ENV}')
+$OBSIDIAN_CLI = [Environment]::GetEnvironmentVariable('COPILOT_OBSIDIAN_CLI')
+$VAULT_NAME = [Environment]::GetEnvironmentVariable('${AGENT_VAULT_NAME_ENV}')
 if ($null -eq $USER_ID) { $USER_ID = '' }
 if ($null -eq $CLIENT_VERSION) { $CLIENT_VERSION = '' }
 $NO_LICENSE = ${psSingleQuote(NO_LICENSE_MESSAGE)}
@@ -221,7 +233,9 @@ function NoLicense {
   Die $msg
 }
 
-if (-not $KEY -or -not $BASE) { NoLicense }
+function RequireRelay {
+  if (-not $KEY -or -not $BASE) { NoLicense }
+}
 
 # Invoke-Relay endpoint body -> prints the response body, mapping HTTP status.
 function Invoke-Relay($endpoint, $body) {
@@ -340,11 +354,60 @@ function relaySkill(opts: {
   /** Relay body key + usage-doc placeholder, e.g. `["query", "<your search query>"]`. */
   arg: [key: string, placeholder: string];
   scriptFile: string;
+  license?: string;
+  selfHostMode?: "search" | "deny";
+  extraInstructions?: string;
 }): BuiltinSkill {
   const [argKey, argPlaceholder] = opts.arg;
   const cmdFile = opts.scriptFile.replace(/\.sh$/, ".cmd");
   const ps1File = opts.scriptFile.replace(/\.sh$/, ".ps1");
-  const version = 5;
+  const version = 6;
+  // Self-host search crosses back into the owning Obsidian renderer so API
+  // keys never enter the agent process; fetch fails closed because there is no
+  // provider-neutral page-fetch contract.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/165
+  const selfHostSh =
+    opts.selfHostMode === "search"
+      ? `if [ "$SELF_HOST" = "1" ]; then
+  [ -n "$OBSIDIAN_CLI" ] || die "A compatible Obsidian CLI is unavailable for self-host web search." 1
+  [ -n "$VAULT_NAME" ] || die "The owning Obsidian vault is unavailable for self-host web search." 1
+  ARG_B64=$(printf '%s' "$ARG" | base64 | tr -d '\\r\\n')
+  CODE="(()=>{const decode=(value)=>new TextDecoder().decode(Uint8Array.from(atob(value),(char)=>char.charCodeAt(0)));const bridge=app.plugins.plugins.copilot?.selfHostWebSearchAgentBridge;if(!bridge)throw new Error('Copilot self-host web search is unavailable.');return bridge.search(decode('$ARG_B64')).then(JSON.stringify);})()"
+  CLI_OUTPUT=$("$OBSIDIAN_CLI" "vault=$VAULT_NAME" eval "code=$CODE") || exit $?
+  CLI_RESULT=$(printf '%s\\n' "$CLI_OUTPUT" | sed -n '/^=> {/p' | sed -n '$p')
+  case "$CLI_RESULT" in
+    "=> {"*) printf '%s\\n' "\${CLI_RESULT#'=> '}"; exit 0 ;;
+    *) die "Copilot could not complete self-host web search." 1 ;;
+  esac
+fi
+`
+      : opts.selfHostMode === "deny"
+        ? `if [ "$SELF_HOST" = "1" ]; then
+  die "Self-Host mode does not support fetching a specific page. Do not use a native web-fetch tool; use copilot-web-search when search results are sufficient, otherwise tell the user page fetching is unavailable." 1
+fi
+`
+        : "";
+  const selfHostPs1 =
+    opts.selfHostMode === "search"
+      ? `if ($SELF_HOST -eq '1') {
+  if (-not $OBSIDIAN_CLI) { Die 'A compatible Obsidian CLI is unavailable for self-host web search.' 1 }
+  if (-not $VAULT_NAME) { Die 'The owning Obsidian vault is unavailable for self-host web search.' 1 }
+  $ARG_B64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($ARG))
+  $CODE = "(()=>{const decode=(value)=>new TextDecoder().decode(Uint8Array.from(atob(value),(char)=>char.charCodeAt(0)));const bridge=app.plugins.plugins.copilot?.selfHostWebSearchAgentBridge;if(!bridge)throw new Error('Copilot self-host web search is unavailable.');return bridge.search(decode('$ARG_B64')).then(JSON.stringify);})()"
+  $CLI_OUTPUT = & $OBSIDIAN_CLI "vault=$VAULT_NAME" 'eval' "code=$CODE"
+  if ($LASTEXITCODE -ne 0) { Die 'Copilot could not complete self-host web search.' 1 }
+  $CLI_RESULT = [string](@($CLI_OUTPUT | Where-Object { ([string]$_).StartsWith('=> {') })[-1])
+  if (-not $CLI_RESULT.StartsWith('=> {')) { Die 'Copilot could not complete self-host web search.' 1 }
+  [Console]::Out.WriteLine($CLI_RESULT.Substring(3))
+  exit 0
+}
+`
+      : opts.selfHostMode === "deny"
+        ? `if ($SELF_HOST -eq '1') {
+  Die 'Self-Host mode does not support fetching a specific page. Do not use a native web-fetch tool; use copilot-web-search when search results are sufficient, otherwise tell the user page fetching is unavailable.' 1
+}
+`
+        : "";
   return {
     name: opts.name,
     version,
@@ -352,7 +415,7 @@ function relaySkill(opts: {
     skillMd: `---
 name: ${opts.name}
 description: ${opts.description}
-license: Copilot Plus
+license: ${opts.license ?? "Copilot Plus"}
 metadata:
   copilot-enabled-agents: claude, codex, opencode
   copilot-builtin-version: "${version}"
@@ -365,6 +428,7 @@ ${opts.intro}
 ${howToRunSection({ shFile: opts.scriptFile, cmdFile, argPlaceholder })}
 
 ${LICENSE_PROBLEM_SECTION}
+${opts.extraInstructions ? `\n${opts.extraInstructions}\n` : ""}
 `,
     files: [
       {
@@ -372,6 +436,7 @@ ${LICENSE_PROBLEM_SECTION}
         content: `${scriptPreamble()}
 ARG="$*"
 [ -n "$ARG" ] || die "Usage: sh ${opts.scriptFile} <${argKey}>" 1
+${selfHostSh}require_relay
 relay "${opts.endpoint}" "{\\"${argKey}\\":\\"$(json_escape "$ARG")\\",\\"user_id\\":\\"$(json_escape "$USER_ID")\\"}"
 `,
       },
@@ -384,6 +449,7 @@ relay "${opts.endpoint}" "{\\"${argKey}\\":\\"$(json_escape "$ARG")\\",\\"user_i
         content: `${powershellPreamble()}
 $ARG = ($args -join ' ')
 if (-not $ARG) { Die "Usage: ${ps1File} <${argKey}>" 1 }
+${selfHostPs1}RequireRelay
 Invoke-Relay "${opts.endpoint}" @{ ${argKey} = $ARG; user_id = $USER_ID }
 `,
       },
@@ -394,12 +460,14 @@ Invoke-Relay "${opts.endpoint}" @{ ${argKey} = $ARG; user_id = $USER_ID }
 const WEB_SEARCH = relaySkill({
   name: "copilot-web-search",
   description:
-    "Search the web for current information using Copilot Plus. Use when the user asks to search online, look something up on the internet, or needs up-to-date facts beyond the vault. Prefer reading the vault for anything about the user's own notes. Requires an active Copilot Plus license.",
+    "Search the web for current information using Copilot Plus or the configured Self-Host search provider. Use when the user asks to search online, look something up on the internet, or needs up-to-date facts beyond the vault. Prefer reading the vault for anything about the user's own notes.",
   heading: "Copilot web search",
-  intro: "Search the web through Copilot Plus and return results for the user's query.",
+  intro: "Search the web through Copilot and return results for the user's query.",
   endpoint: "/websearch",
   arg: ["query", "<your search query>"],
   scriptFile: "web-search.sh",
+  license: "Copilot Plus or Self-Host",
+  selfHostMode: "search",
 });
 
 const WEB_FETCH = relaySkill({
@@ -411,6 +479,13 @@ const WEB_FETCH = relaySkill({
   endpoint: "/url4llm",
   arg: ["url", "<url-to-fetch>"],
   scriptFile: "web-fetch.sh",
+  selfHostMode: "deny",
+  extraInstructions: `## Self-Host mode
+
+Self-Host search providers do not provide a common full-page fetch contract. If
+the script reports that Self-Host mode is active, never use an agent-native web
+fetch tool. Use \`copilot-web-search\` when search results can answer the request;
+otherwise tell the user that fetching the page is unavailable.`,
 });
 
 const READ_PDF_VERSION = 6;
@@ -445,6 +520,7 @@ ${LICENSE_PROBLEM_SECTION}
     {
       path: "read-pdf.sh",
       content: `${scriptPreamble()}
+require_relay
 FILE=\${1:-}
 [ -n "$FILE" ] || die "Usage: sh read-pdf.sh <path-to-file.pdf>" 1
 [ -f "$FILE" ] && [ -r "$FILE" ] || die "Could not read file: $FILE" 1
@@ -461,6 +537,7 @@ relay "/pdf4llm" "{\\"pdf\\":\\"$PDF\\",\\"user_id\\":\\"$(json_escape "$USER_ID
     {
       path: "read-pdf.ps1",
       content: `${powershellPreamble()}
+RequireRelay
 $FILE = if ($args.Count -ge 1) { $args[0] } else { '' }
 if (-not $FILE) { Die "Usage: read-pdf.ps1 <path-to-file.pdf>" 1 }
 if (-not (Test-Path -LiteralPath $FILE -PathType Leaf)) { Die "Could not read file: $FILE" 1 }

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -59,8 +59,10 @@ export const MIYO_SEARCH_SCOPE_ENV = "COPILOT_MIYO_SEARCH_SCOPE";
 export const MIYO_SEARCH_FOLDER_ENV = "COPILOT_MIYO_SEARCH_FOLDER";
 /** Routes managed web skills through the plugin host instead of a hosted relay. */
 export const SELF_HOST_WEB_SEARCH_ENV = "COPILOT_SELF_HOST_WEB_SEARCH";
-/** Exact vault identity used to target the owning Obsidian CLI renderer. */
-export const AGENT_VAULT_NAME_ENV = "COPILOT_AGENT_VAULT_NAME";
+/** Per-lifecycle loopback endpoint for the plugin-owned search channel. */
+export const SELF_HOST_WEB_SEARCH_URL_ENV = "COPILOT_SELF_HOST_WEB_SEARCH_URL";
+/** Random bearer token authenticating the owning Agent Chat process. */
+export const SELF_HOST_WEB_SEARCH_TOKEN_ENV = "COPILOT_SELF_HOST_WEB_SEARCH_TOKEN";
 
 /**
  * No Copilot Plus license is configured — the free-user case (a non-Plus user
@@ -126,8 +128,8 @@ KEY="\${${PLUS_ENV.licenseKey}:-}"
 USER_ID="\${${PLUS_ENV.userId}:-}"
 CLIENT_VERSION="\${${PLUS_ENV.clientVersion}:-}"
 SELF_HOST="\${${SELF_HOST_WEB_SEARCH_ENV}:-}"
-OBSIDIAN_CLI="\${COPILOT_OBSIDIAN_CLI:-}"
-VAULT_NAME="\${${AGENT_VAULT_NAME_ENV}:-}"
+SELF_HOST_URL="\${${SELF_HOST_WEB_SEARCH_URL_ENV}:-}"
+SELF_HOST_TOKEN="\${${SELF_HOST_WEB_SEARCH_TOKEN_ENV}:-}"
 NO_LICENSE=${shSingleQuote(NO_LICENSE_MESSAGE)}
 NO_LICENSE_UPSELL=${shSingleQuote(NO_LICENSE_UPSELL)}
 LICENSE_INVALID=${shSingleQuote(LICENSE_INVALID_MESSAGE)}
@@ -210,8 +212,8 @@ $KEY = [Environment]::GetEnvironmentVariable('${PLUS_ENV.licenseKey}')
 $USER_ID = [Environment]::GetEnvironmentVariable('${PLUS_ENV.userId}')
 $CLIENT_VERSION = [Environment]::GetEnvironmentVariable('${PLUS_ENV.clientVersion}')
 $SELF_HOST = [Environment]::GetEnvironmentVariable('${SELF_HOST_WEB_SEARCH_ENV}')
-$OBSIDIAN_CLI = [Environment]::GetEnvironmentVariable('COPILOT_OBSIDIAN_CLI')
-$VAULT_NAME = [Environment]::GetEnvironmentVariable('${AGENT_VAULT_NAME_ENV}')
+$SELF_HOST_URL = [Environment]::GetEnvironmentVariable('${SELF_HOST_WEB_SEARCH_URL_ENV}')
+$SELF_HOST_TOKEN = [Environment]::GetEnvironmentVariable('${SELF_HOST_WEB_SEARCH_TOKEN_ENV}')
 if ($null -eq $USER_ID) { $USER_ID = '' }
 if ($null -eq $CLIENT_VERSION) { $CLIENT_VERSION = '' }
 $NO_LICENSE = ${psSingleQuote(NO_LICENSE_MESSAGE)}
@@ -369,15 +371,16 @@ function relaySkill(opts: {
   const selfHostSh =
     opts.selfHostMode === "search"
       ? `if [ "$SELF_HOST" = "1" ]; then
-  [ -n "$OBSIDIAN_CLI" ] || die "A compatible Obsidian CLI is unavailable for self-host web search." 1
-  [ -n "$VAULT_NAME" ] || die "The owning Obsidian vault is unavailable for self-host web search." 1
-  ARG_B64=$(printf '%s' "$ARG" | base64 | tr -d '\\r\\n')
-  CODE="(()=>{const decode=(value)=>new TextDecoder().decode(Uint8Array.from(atob(value),(char)=>char.charCodeAt(0)));const bridge=app.plugins.plugins.copilot?.selfHostWebSearchAgentBridge;if(!bridge)throw new Error('Copilot self-host web search is unavailable.');return bridge.search(decode('$ARG_B64')).then(JSON.stringify);})()"
-  CLI_OUTPUT=$("$OBSIDIAN_CLI" "vault=$VAULT_NAME" eval "code=$CODE") || exit $?
-  CLI_RESULT=$(printf '%s\\n' "$CLI_OUTPUT" | sed -n '/^=> {/p' | sed -n '$p')
-  case "$CLI_RESULT" in
-    "=> {"*) printf '%s\\n' "\${CLI_RESULT#'=> '}"; exit 0 ;;
-    *) die "Copilot could not complete self-host web search." 1 ;;
+  [ -n "$SELF_HOST_URL" ] && [ -n "$SELF_HOST_TOKEN" ] || die "Copilot self-host web search is unavailable for this session." 1
+  HTTP_RESPONSE=$(printf '%s' "$ARG" | curl --noproxy '*' -sS -X POST "$SELF_HOST_URL" \\
+    -H "Authorization: Bearer $SELF_HOST_TOKEN" \\
+    -H "Content-Type: text/plain; charset=utf-8" \\
+    --data-binary @- -w '\\n%{http_code}') || die "Copilot could not complete self-host web search." 1
+  HTTP_STATUS=$(printf '%s\\n' "$HTTP_RESPONSE" | tail -n 1)
+  RESPONSE_BODY=$(printf '%s\\n' "$HTTP_RESPONSE" | sed '$d')
+  case "$HTTP_STATUS" in
+    2??) printf '%s\\n' "$RESPONSE_BODY"; exit 0 ;;
+    *) [ -n "$RESPONSE_BODY" ] && printf '%s\\n' "$RESPONSE_BODY" >&2; exit 1 ;;
   esac
 fi
 `
@@ -390,15 +393,14 @@ fi
   const selfHostPs1 =
     opts.selfHostMode === "search"
       ? `if ($SELF_HOST -eq '1') {
-  if (-not $OBSIDIAN_CLI) { Die 'A compatible Obsidian CLI is unavailable for self-host web search.' 1 }
-  if (-not $VAULT_NAME) { Die 'The owning Obsidian vault is unavailable for self-host web search.' 1 }
-  $ARG_B64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($ARG))
-  $CODE = "(()=>{const decode=(value)=>new TextDecoder().decode(Uint8Array.from(atob(value),(char)=>char.charCodeAt(0)));const bridge=app.plugins.plugins.copilot?.selfHostWebSearchAgentBridge;if(!bridge)throw new Error('Copilot self-host web search is unavailable.');return bridge.search(decode('$ARG_B64')).then(JSON.stringify);})()"
-  $CLI_OUTPUT = & $OBSIDIAN_CLI "vault=$VAULT_NAME" 'eval' "code=$CODE"
-  if ($LASTEXITCODE -ne 0) { Die 'Copilot could not complete self-host web search.' 1 }
-  $CLI_RESULT = [string](@($CLI_OUTPUT | Where-Object { ([string]$_).StartsWith('=> {') })[-1])
-  if (-not $CLI_RESULT.StartsWith('=> {')) { Die 'Copilot could not complete self-host web search.' 1 }
-  [Console]::Out.WriteLine($CLI_RESULT.Substring(3))
+  if (-not $SELF_HOST_URL -or -not $SELF_HOST_TOKEN) { Die 'Copilot self-host web search is unavailable for this session.' 1 }
+  try {
+    $response = Invoke-WebRequest -UseBasicParsing -Uri $SELF_HOST_URL -Method POST -Headers @{ Authorization = "Bearer $SELF_HOST_TOKEN" } -ContentType 'text/plain; charset=utf-8' -Body ([Text.Encoding]::UTF8.GetBytes($ARG))
+  } catch {
+    if ($_.ErrorDetails.Message) { [Console]::Error.WriteLine($_.ErrorDetails.Message) }
+    Die 'Copilot could not complete self-host web search.' 1
+  }
+  [Console]::Out.WriteLine($response.Content)
   exit 0
 }
 `

--- a/src/main.ts
+++ b/src/main.ts
@@ -131,6 +131,10 @@ import {
   type SymposiumAgentBridge,
   SymposiumPublisher,
 } from "@/symposium/SymposiumPublisher";
+import {
+  createSelfHostWebSearchAgentBridge,
+  type SelfHostWebSearchAgentBridge,
+} from "@/LLMProviders/selfHostServices";
 
 // Removed unused FileTrackingState interface
 
@@ -154,6 +158,8 @@ export default class CopilotPlugin extends Plugin {
   modelManagement!: ModelManagementApi;
   /** Frozen path-only facade available to Agent Mode's Obsidian CLI bridge. */
   symposiumAgentBridge?: Readonly<SymposiumAgentBridge>;
+  /** Credential-free facade available to the managed Agent Chat search skill. */
+  selfHostWebSearchAgentBridge?: Readonly<SelfHostWebSearchAgentBridge>;
   // Proof of THIS lifecycle for anything that enqueues a Miyo folder mutation.
   // Assigned in `onload` right after the queue reset, and read by the settings
   // UI rather than captured there: settings tabs mount lazily (`TabContent`
@@ -409,6 +415,8 @@ export default class CopilotPlugin extends Plugin {
     const symposiumPublisher = new SymposiumPublisher(this.app);
     const symposiumAgentBridge = createSymposiumAgentBridge(symposiumPublisher);
     this.symposiumAgentBridge = symposiumAgentBridge;
+    const selfHostWebSearchAgentBridge = createSelfHostWebSearchAgentBridge();
+    this.selfHostWebSearchAgentBridge = selfHostWebSearchAgentBridge;
     const publishFile = (file: TFile): void => {
       void symposiumPublisher
         .open(file)
@@ -419,6 +427,7 @@ export default class CopilotPlugin extends Plugin {
       if (this.symposiumAgentBridge === symposiumAgentBridge) {
         this.symposiumAgentBridge = undefined;
       }
+      this.selfHostWebSearchAgentBridge = undefined;
     });
     registerCommands(this, publishFile);
     registerSymposiumFileMenu(this, publishFile);

--- a/src/main.ts
+++ b/src/main.ts
@@ -158,7 +158,7 @@ export default class CopilotPlugin extends Plugin {
   modelManagement!: ModelManagementApi;
   /** Frozen path-only facade available to Agent Mode's Obsidian CLI bridge. */
   symposiumAgentBridge?: Readonly<SymposiumAgentBridge>;
-  /** Credential-free facade available to the managed Agent Chat search skill. */
+  /** Provider-credential-free channel available to the managed Agent Chat search skill. */
   selfHostWebSearchAgentBridge?: Readonly<SelfHostWebSearchAgentBridge>;
   // Proof of THIS lifecycle for anything that enqueues a Miyo folder mutation.
   // Assigned in `onload` right after the queue reset, and read by the settings
@@ -298,6 +298,17 @@ export default class CopilotPlugin extends Plugin {
     // Initialize the owner of the shared Quick Chat chain
     this.chainOwner = ChainOwner.getInstance(this.app, this.modelManagement);
 
+    // Must precede Agent Chat: startup model discovery may spawn OpenCode.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/165
+    const selfHostWebSearchAgentBridge = createSelfHostWebSearchAgentBridge();
+    this.selfHostWebSearchAgentBridge = selfHostWebSearchAgentBridge;
+    this.register(() => {
+      selfHostWebSearchAgentBridge.dispose();
+      if (this.selfHostWebSearchAgentBridge === selfHostWebSearchAgentBridge) {
+        this.selfHostWebSearchAgentBridge = undefined;
+      }
+    });
+
     // Initialize Agent Mode coordinator (desktop only — ACP needs subprocess
     // support). Gate on `isDesktopRuntime()`, not `Platform.isDesktopApp`:
     // under `app.emulateMobile(true)` the latter stays true while Node is stubbed,
@@ -415,8 +426,6 @@ export default class CopilotPlugin extends Plugin {
     const symposiumPublisher = new SymposiumPublisher(this.app);
     const symposiumAgentBridge = createSymposiumAgentBridge(symposiumPublisher);
     this.symposiumAgentBridge = symposiumAgentBridge;
-    const selfHostWebSearchAgentBridge = createSelfHostWebSearchAgentBridge();
-    this.selfHostWebSearchAgentBridge = selfHostWebSearchAgentBridge;
     const publishFile = (file: TFile): void => {
       void symposiumPublisher
         .open(file)
@@ -427,7 +436,6 @@ export default class CopilotPlugin extends Plugin {
       if (this.symposiumAgentBridge === symposiumAgentBridge) {
         this.symposiumAgentBridge = undefined;
       }
-      this.selfHostWebSearchAgentBridge = undefined;
     });
     registerCommands(this, publishFile);
     registerSymposiumFileMenu(this, publishFile);


### PR DESCRIPTION
Fixes Brevilabs/obsidian-copilot-private#165

## Why

Self-Host Mode lets users choose their own web-search provider, but OpenCode Agent Chat did not use that route. Its bundled search Skill still called Copilot Plus, and OpenCode could fall back to its native web-search or web-fetch tools. A search could therefore bypass the provider selected in Copilot settings.

## What

| State | Before | After |
| --- | --- | --- |
| Self-Host web search with OpenCode | The Skill called Copilot Plus or OpenCode could use its native tool | The Skill calls the provider selected in Self-Host settings through a plugin-owned local channel |
| Self-Host page fetch with OpenCode | OpenCode's native fetch remained available | Page fetch fails closed because there is no shared self-host fetch interface |
| Copilot Plus search | Used the hosted search relay | Unchanged |

Provider credentials remain inside Obsidian. The replacement search route does not require Obsidian's optional command line interface or select a vault by display name. OpenCode's native search and fetch permissions stay denied even when an advanced config override tries to allow them.

## Non goal

Adding provider-backed full-page fetching to the Self-Host provider contract, or extending the enforced route to Agent Chat backends other than OpenCode.

## Screenshot

Not applicable. This PR changes headless Agent Chat routing and permissions, with no visual UI change.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Deterministic tests cover the host channel, protected environment, generated Skills, and OpenCode permission results |
| A defect would fail CI or be obvious on first use | ✅ | Routing and failure branches are covered, and a missing channel or key fails on the first search |
| A revert fully restores prior state, including persisted data | ✅ | No settings migration or irreversible write is introduced |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | The change enforces OpenCode permissions and adds a token-authenticated loopback boundary while keeping provider credentials in Obsidian |
| No public API, plugin API, message, or on-disk contract changes | ❌ | The managed Skill and its internal plugin channel gain a Self-Host request path |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Enabling Self-Host Mode now immediately restarts active agent backends to close the prior route |
| No hot-path behavior lacks deterministic coverage | ✅ | Search routing, channel authentication, request bounds, missing entitlement/key, config overrides, and restart policy are covered |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Any routing failure appears on the next Agent Chat web request |

Review: inspect `createSelfHostWebSearchAgentBridge`, `OpencodeBackend.buildSpawnDescriptor`, `buildOpencodeConfig`, `getBuiltinSkillEnvRestartPolicy`, and `relaySkill` line by line, then run Verification steps 1-4, including the missing-key and config-override cases.

## Verification

1. Leave Obsidian's command line interface disabled. Enable Self-Host Mode, select a configured search provider, start an OpenCode Agent Chat, and ask for current web information. Confirm the `copilot-web-search` Skill returns results and citations from the selected provider.
2. Ask Agent Chat to fetch a specific page. Confirm it reports that full-page fetching is unavailable and does not invoke OpenCode's native fetch tool.
3. Remove the selected provider's API key and repeat the search. Confirm it fails with the missing-key message and does not fall back to a hosted or native search.
4. Set an `OPENCODE_CONFIG_CONTENT` override that allows `websearch` and `webfetch` globally and on the `build` agent, restart Agent Chat, and repeat step 1. Confirm the Self-Host Skill still handles the search and OpenCode's native tools remain unavailable.
