### PR TITLE
Clear the previous license when an invalid key is applied

### DIFF
--- a/src/LLMProviders/brevilabsClient.test.ts
+++ b/src/LLMProviders/brevilabsClient.test.ts
@@ -112,6 +112,25 @@ describe("brevilabsClient", () => {
         expect(mockTurnOffPaid).toHaveBeenCalled();
       });
 
+      it("answers invalid without a request when no license key is stored (https://github.com/logancyang/obsidian-copilot-preview/issues/352)", async () => {
+        // The server refuses an empty key with the same 403 it gives a wrong
+        // one, so the per-turn and per-model gates, which call this without
+        // checkIsPaidUser's no-key sign-out, would revoke a keyless user.
+        mockGetSettings.mockReturnValue({ plusLicenseKey: "" });
+        const makeRequest = jest.fn();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- verifies the private HTTP boundary
+        (BrevilabsClient.getInstance() as any).makeRequest = makeRequest;
+
+        const result = await BrevilabsClient.getInstance().validateLicenseKey(
+          undefined,
+          MANUAL_LICENSE_CHECK
+        );
+
+        expect(result).toEqual({ isValid: false });
+        expect(makeRequest).not.toHaveBeenCalled();
+        expect(mockTurnOffPaid).not.toHaveBeenCalled();
+      });
+
       it("applies the signed entitlement when the license key is unchanged", async () => {
         stubRequest({ data: VALID_LICENSE_RESPONSE, error: null });
 

--- a/src/LLMProviders/brevilabsClient.test.ts
+++ b/src/LLMProviders/brevilabsClient.test.ts
@@ -87,7 +87,7 @@ describe("brevilabsClient", () => {
       // the HTTP layer and this method: the layer discarded the status, leaving
       // the reason text — which names the rejected key's prefix — as the only
       // thing left to classify on.
-      // https://github.com/logancyang/obsidian-copilot-preview/issues/352
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/307
       it("revokes entitlement for the 403 body the license endpoint actually returns", async () => {
         setRequestUrlImpl(
           jest.fn().mockResolvedValue({
@@ -112,7 +112,7 @@ describe("brevilabsClient", () => {
         expect(mockTurnOffPaid).toHaveBeenCalled();
       });
 
-      it("answers invalid without a request when no license key is stored (https://github.com/logancyang/obsidian-copilot-preview/issues/352)", async () => {
+      it("answers invalid without a request when no license key is stored (https://github.com/Brevilabs/obsidian-copilot-private/issues/307)", async () => {
         // The server refuses an empty key with the same 403 it gives a wrong
         // one, so the per-turn and per-model gates, which call this without
         // checkIsPaidUser's no-key sign-out, would revoke a keyless user.
@@ -202,7 +202,7 @@ describe("brevilabsClient", () => {
       // server names the rejected key's prefix in that text, so an exact-string
       // match silently reclassified every refusal as an unreachable server and
       // left the previous key's entitlement in force.
-      // https://github.com/logancyang/obsidian-copilot-preview/issues/352
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/307
       it("revokes entitlement when the server answers 403, whatever the reason text says", async () => {
         stubRequest(licenseRejection("key-A-gar"));
 
@@ -220,7 +220,7 @@ describe("brevilabsClient", () => {
         // A WAF or gateway can answer 403 with an HTML page and no API error
         // body. Reading that as a verdict on the key would revoke every paying
         // user who checked in during the outage.
-        // https://github.com/logancyang/obsidian-copilot-preview/issues/352
+        // https://github.com/Brevilabs/obsidian-copilot-private/issues/307
         ["an unexplained 403 from infrastructure", 403],
       ])("leaves the entitlement alone for %s", async (_label, status) => {
         stubRequest({ data: null, error: new Error(`HTTP error: ${status}`), status });

--- a/src/LLMProviders/brevilabsClient.test.ts
+++ b/src/LLMProviders/brevilabsClient.test.ts
@@ -27,6 +27,7 @@ const { __setRequestUrlImpl: setRequestUrlImpl } = obsidianModule as unknown as 
 interface RequestOutcome {
   data: unknown;
   error: Error | null;
+  status?: number;
 }
 
 /**
@@ -39,8 +40,18 @@ function stubRequest(outcome: RequestOutcome, onRequest?: () => void): void {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- reaching the private transport is the point
   (BrevilabsClient.getInstance() as any).makeRequest = async () => {
     onRequest?.();
-    return outcome;
+    return { status: outcome.error ? 500 : 200, ...outcome };
   };
+}
+
+/**
+ * How `/license` refuses a key: HTTP 403, with a reason that names the key's
+ * prefix so support can tell which key was tried.
+ */
+function licenseRejection(keyPrefix: string): RequestOutcome {
+  const error = new Error(`Invalid license key (prefix: ${keyPrefix}...)`);
+  error.name = "FORBIDDEN";
+  return { data: null, error, status: 403 };
 }
 
 const VALID_LICENSE_RESPONSE = { entitlement: "signed-token", plan: "supporter" };
@@ -62,8 +73,41 @@ describe("brevilabsClient", () => {
     describe("validateLicenseKey()", () => {
       beforeEach(() => {
         jest.clearAllMocks();
+        // `stubRequest` installs an own property over the prototype method;
+        // dropping it puts the real transport back for the tests that need it.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mirrors how stubRequest reaches it
+        delete (BrevilabsClient.getInstance() as any).makeRequest;
         mockApplyEntitlement.mockResolvedValue(true);
-        mockGetSettings.mockReturnValue({ plusLicenseKey: "key-A" });
+        mockGetSettings.mockReturnValue({ plusLicenseKey: "key-A", userId: "user-1" });
+      });
+
+      // Drives the real transport, because the defect lived in the seam between
+      // the HTTP layer and this method: the layer discarded the status, leaving
+      // the reason text — which names the rejected key's prefix — as the only
+      // thing left to classify on.
+      // https://github.com/logancyang/obsidian-copilot-preview/issues/352
+      it("revokes entitlement for the 403 body the license endpoint actually returns", async () => {
+        setRequestUrlImpl(
+          jest.fn().mockResolvedValue({
+            status: 403,
+            json: {
+              detail: {
+                status: 403,
+                error: "FORBIDDEN",
+                message: "NO_PERMISSION",
+                reason: "Invalid license key (prefix: garbage-ke...)",
+              },
+            },
+          })
+        );
+
+        const result = await BrevilabsClient.getInstance().validateLicenseKey(
+          undefined,
+          MANUAL_LICENSE_CHECK
+        );
+
+        expect(result).toEqual({ isValid: false });
+        expect(mockTurnOffPaid).toHaveBeenCalled();
       });
 
       it("applies the signed entitlement when the license key is unchanged", async () => {
@@ -133,8 +177,13 @@ describe("brevilabsClient", () => {
         }
       );
 
-      it("revokes entitlement when the server rejects the key", async () => {
-        stubRequest({ data: null, error: new Error("Invalid license key") });
+      // The rejection is recognised by its 403, not by its reason text: the
+      // server names the rejected key's prefix in that text, so an exact-string
+      // match silently reclassified every refusal as an unreachable server and
+      // left the previous key's entitlement in force.
+      // https://github.com/logancyang/obsidian-copilot-preview/issues/352
+      it("revokes entitlement when the server answers 403, whatever the reason text says", async () => {
+        stubRequest(licenseRejection("key-A-gar"));
 
         const result = await BrevilabsClient.getInstance().validateLicenseKey(
           undefined,
@@ -143,6 +192,18 @@ describe("brevilabsClient", () => {
 
         expect(result).toEqual({ isValid: false });
         expect(mockTurnOffPaid).toHaveBeenCalled();
+      });
+
+      it("leaves the entitlement alone when the server fails for a reason other than refusing the key", async () => {
+        stubRequest({ data: null, error: new Error("HTTP error: 502"), status: 502 });
+
+        const result = await BrevilabsClient.getInstance().validateLicenseKey(
+          undefined,
+          MANUAL_LICENSE_CHECK
+        );
+
+        expect(result).toEqual({ isValid: undefined });
+        expect(mockTurnOffPaid).not.toHaveBeenCalled();
       });
 
       it("discards a success that arrives after the license key changed", async () => {
@@ -164,9 +225,9 @@ describe("brevilabsClient", () => {
       });
 
       it("discards a rejection that arrives after the license key changed", async () => {
-        // The mirror case: a stale "Invalid license key" must not revoke the
-        // entitlement the user's newly entered key just earned.
-        stubRequest({ data: null, error: new Error("Invalid license key") }, () => {
+        // The mirror case: a stale rejection must not revoke the entitlement
+        // the user's newly entered key just earned.
+        stubRequest(licenseRejection("key-A-gar"), () => {
           mockGetSettings.mockReturnValue({ plusLicenseKey: "key-B" });
         });
 

--- a/src/LLMProviders/brevilabsClient.test.ts
+++ b/src/LLMProviders/brevilabsClient.test.ts
@@ -28,6 +28,7 @@ interface RequestOutcome {
   data: unknown;
   error: Error | null;
   status?: number;
+  detail?: { reason?: string; error?: string };
 }
 
 /**
@@ -49,9 +50,10 @@ function stubRequest(outcome: RequestOutcome, onRequest?: () => void): void {
  * prefix so support can tell which key was tried.
  */
 function licenseRejection(keyPrefix: string): RequestOutcome {
-  const error = new Error(`Invalid license key (prefix: ${keyPrefix}...)`);
+  const reason = `Invalid license key (prefix: ${keyPrefix}...)`;
+  const error = new Error(reason);
   error.name = "FORBIDDEN";
-  return { data: null, error, status: 403 };
+  return { data: null, error, status: 403, detail: { reason, error: "FORBIDDEN" } };
 }
 
 const VALID_LICENSE_RESPONSE = { entitlement: "signed-token", plan: "supporter" };
@@ -194,8 +196,15 @@ describe("brevilabsClient", () => {
         expect(mockTurnOffPaid).toHaveBeenCalled();
       });
 
-      it("leaves the entitlement alone when the server fails for a reason other than refusing the key", async () => {
-        stubRequest({ data: null, error: new Error("HTTP error: 502"), status: 502 });
+      it.each([
+        ["a 502 from the gateway", 502],
+        // A WAF or gateway can answer 403 with an HTML page and no API error
+        // body. Reading that as a verdict on the key would revoke every paying
+        // user who checked in during the outage.
+        // https://github.com/logancyang/obsidian-copilot-preview/issues/352
+        ["an unexplained 403 from infrastructure", 403],
+      ])("leaves the entitlement alone for %s", async (_label, status) => {
+        stubRequest({ data: null, error: new Error(`HTTP error: ${status}`), status });
 
         const result = await BrevilabsClient.getInstance().validateLicenseKey(
           undefined,

--- a/src/LLMProviders/brevilabsClient.ts
+++ b/src/LLMProviders/brevilabsClient.ts
@@ -67,6 +67,13 @@ interface BrevilabsApiResult<T> {
   data: T | null;
   error?: Error;
   status: number;
+  /**
+   * The API's own error body, present only when the server explained the
+   * failure itself. An infrastructure error page (a gateway or WAF 403, an HTML
+   * 502) carries none, which is what lets a caller tell "the API refused this
+   * request" from "the server is having a bad day".
+   */
+  detail?: { reason?: string; error?: string };
 }
 
 /**
@@ -90,7 +97,7 @@ function parseBrevilabsResponse<T>(
     if (detail?.reason) {
       const error = new Error(detail.reason);
       if (detail.error) error.name = detail.error;
-      return { data: null, error, status: response.status };
+      return { data: null, error, status: response.status, detail };
     }
     return {
       data: null,
@@ -362,7 +369,7 @@ export class BrevilabsClient {
       Object.assign(requestBody, filteredContext);
     }
 
-    const { data, error, status } = await this.makeRequest<LicenseResponse>(
+    const { data, error, status, detail } = await this.makeRequest<LicenseResponse>(
       "/license",
       requestBody,
       "POST",
@@ -379,14 +386,17 @@ export class BrevilabsClient {
     }
 
     if (error) {
-      // 403 is how `/license` refuses a key it will not honour — unknown,
-      // mistyped, or revoked — and it is the only part of that answer the
-      // client can rely on. The reason text names the key's prefix
-      // ("Invalid license key (prefix: abc...)"), so matching it verbatim let a
-      // rejection read as an unreachable server, and the fallback below handed
-      // the refused key the previous key's still-live entitlement.
+      // Revoke only on the API's own refusal of this key: a 403 the server
+      // explained in its own error body. Its reason text names the key's prefix
+      // ("Invalid license key (prefix: abc...)"), so matching that verbatim let
+      // a refusal read as an unreachable server, and the fallback below then
+      // handed the refused key the previous key's still-live entitlement.
+      //
+      // A 403 carrying no such body is infrastructure rather than a verdict on
+      // the key. A gateway or WAF answering 403 would otherwise revoke every
+      // paying user who happened to check in during the outage.
       // https://github.com/logancyang/obsidian-copilot-preview/issues/352
-      if (status === 403) {
+      if (status === 403 && detail) {
         turnOffPaid(app);
         return { isValid: false };
       }

--- a/src/LLMProviders/brevilabsClient.ts
+++ b/src/LLMProviders/brevilabsClient.ts
@@ -345,6 +345,16 @@ export class BrevilabsClient {
     // the key it was requested for must be discarded rather than applied.
     const requestedLicenseKey = getSettings().plusLicenseKey;
 
+    // Having no key is not a question for the server. It answers an empty key
+    // with the same 403 refusal it gives a wrong one, so asking would let a
+    // keyless check revoke a user who has simply not entered one yet: the
+    // per-turn and per-model gates below call this without the sign-out that
+    // `checkIsPaidUser` performs when it finds no key.
+    // https://github.com/logancyang/obsidian-copilot-preview/issues/352
+    if (!requestedLicenseKey) {
+      return { isValid: false };
+    }
+
     // Build the request body with proper structure
     const requestBody: Record<string, unknown> = {
       license_key: requestedLicenseKey,

--- a/src/LLMProviders/brevilabsClient.ts
+++ b/src/LLMProviders/brevilabsClient.ts
@@ -350,7 +350,7 @@ export class BrevilabsClient {
     // keyless check revoke a user who has simply not entered one yet: the
     // per-turn and per-model gates below call this without the sign-out that
     // `checkIsPaidUser` performs when it finds no key.
-    // https://github.com/logancyang/obsidian-copilot-preview/issues/352
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/307
     if (!requestedLicenseKey) {
       return { isValid: false };
     }
@@ -405,7 +405,7 @@ export class BrevilabsClient {
       // A 403 carrying no such body is infrastructure rather than a verdict on
       // the key. A gateway or WAF answering 403 would otherwise revoke every
       // paying user who happened to check in during the outage.
-      // https://github.com/logancyang/obsidian-copilot-preview/issues/352
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/307
       if (status === 403 && detail) {
         turnOffPaid(app);
         return { isValid: false };

--- a/src/LLMProviders/brevilabsClient.ts
+++ b/src/LLMProviders/brevilabsClient.ts
@@ -56,13 +56,27 @@ async function buildMultipartFromFormData(
 }
 
 /**
- * Normalize a requestUrl response into the {data, error} shape used by Brevilabs API methods.
+ * A Brevilabs API answer, normalized. `status` is the HTTP status the server
+ * replied with, or 0 when the request never produced one (transport failure).
+ * It is carried separately from `error` because a server's error *wording* is
+ * free to change while its status code is the contract — classifying on the
+ * message text leaves a caller silently mis-reading responses the day the
+ * server adds so much as a suffix.
+ */
+interface BrevilabsApiResult<T> {
+  data: T | null;
+  error?: Error;
+  status: number;
+}
+
+/**
+ * Normalize a requestUrl response into the shape used by Brevilabs API methods.
  * Handles the case where `response.json` is a raw string (non-JSON body, e.g. HTML error page).
  */
 function parseBrevilabsResponse<T>(
   response: { status: number; json: unknown },
   endpoint: string
-): { data: T | null; error?: Error } {
+): BrevilabsApiResult<T> {
   let data: unknown = response.json;
   if (typeof data === "string") {
     try {
@@ -76,9 +90,13 @@ function parseBrevilabsResponse<T>(
     if (detail?.reason) {
       const error = new Error(detail.reason);
       if (detail.error) error.name = detail.error;
-      return { data: null, error };
+      return { data: null, error, status: response.status };
     }
-    return { data: null, error: new Error(`HTTP error: ${response.status}`) };
+    return {
+      data: null,
+      error: new Error(`HTTP error: ${response.status}`),
+      status: response.status,
+    };
   }
   // Redact the signed entitlement JWS so it never lands in the shared
   // copilot-log.md when a license response is logged.
@@ -87,7 +105,7 @@ function parseBrevilabsResponse<T>(
       ? { ...(data as Record<string, unknown>), entitlement: "[redacted]" }
       : data;
   logInfo(`[API ${endpoint} request]:`, loggable);
-  return { data: data as T };
+  return { data: data as T, status: response.status };
 }
 
 export interface RerankResponse {
@@ -232,7 +250,7 @@ export class BrevilabsClient {
     method = "POST",
     excludeAuthHeader = false,
     skipLicenseCheck = false
-  ): Promise<{ data: T | null; error?: Error }> {
+  ): Promise<BrevilabsApiResult<T>> {
     if (!skipLicenseCheck) {
       this.checkLicenseKey();
     }
@@ -267,7 +285,7 @@ export class BrevilabsClient {
     endpoint: string,
     formData: FormData,
     skipLicenseCheck = false
-  ): Promise<{ data: T | null; error?: Error }> {
+  ): Promise<BrevilabsApiResult<T>> {
     if (!skipLicenseCheck) {
       this.checkLicenseKey();
     }
@@ -294,7 +312,11 @@ export class BrevilabsClient {
       });
       return parseBrevilabsResponse<T>(response, `${endpoint} form-data`);
     } catch (error) {
-      return { data: null, error: error instanceof Error ? error : new Error(String(error)) };
+      return {
+        data: null,
+        error: error instanceof Error ? error : new Error(String(error)),
+        status: 0,
+      };
     }
   }
 
@@ -340,7 +362,7 @@ export class BrevilabsClient {
       Object.assign(requestBody, filteredContext);
     }
 
-    const { data, error } = await this.makeRequest<LicenseResponse>(
+    const { data, error, status } = await this.makeRequest<LicenseResponse>(
       "/license",
       requestBody,
       "POST",
@@ -357,11 +379,18 @@ export class BrevilabsClient {
     }
 
     if (error) {
-      if (error.message === "Invalid license key") {
+      // 403 is how `/license` refuses a key it will not honour — unknown,
+      // mistyped, or revoked — and it is the only part of that answer the
+      // client can rely on. The reason text names the key's prefix
+      // ("Invalid license key (prefix: abc...)"), so matching it verbatim let a
+      // rejection read as an unreachable server, and the fallback below handed
+      // the refused key the previous key's still-live entitlement.
+      // https://github.com/logancyang/obsidian-copilot-preview/issues/352
+      if (status === 403) {
         turnOffPaid(app);
         return { isValid: false };
       }
-      // Do nothing if the error is not about the invalid license key
+      // Anything else is unknown, not a refusal: leave the entitlement alone.
       return { isValid: undefined };
     }
     if (data?.entitlement) {

--- a/src/plusUtils.test.ts
+++ b/src/plusUtils.test.ts
@@ -642,7 +642,7 @@ describe("plusUtils", () => {
       expect(isSelfHostModeValid()).toBe(false);
     });
 
-    it("does not tag the proof with a key swapped in while verification was in flight (https://github.com/logancyang/obsidian-copilot-preview/issues/352)", async () => {
+    it("does not tag the proof with a key swapped in while verification was in flight (https://github.com/Brevilabs/obsidian-copilot-private/issues/307)", async () => {
       // validateLicenseKey's key-changed guard runs before this call, so only
       // reading the key up front keeps the old key's claims off the new key.
       mockVerifyEntitlement.mockImplementation(async () => {
@@ -799,7 +799,7 @@ describe("plusUtils", () => {
       expect(await checkIsPaidUser(undefined, { trigger: "manual" })).toBe(false);
     });
 
-    it("refuses the previous key's entitlement to a newly entered key the server cannot rule on (https://github.com/logancyang/obsidian-copilot-preview/issues/352)", async () => {
+    it("refuses the previous key's entitlement to a newly entered key the server cannot rule on (https://github.com/Brevilabs/obsidian-copilot-private/issues/307)", async () => {
       // Swapping the key leaves the old key's token persisted and its proof
       // live. Without the proof naming the key that earned it, this fallback
       // answered `true` for a key the server never accepted, keeping the old
@@ -932,7 +932,7 @@ describe("plusUtils", () => {
       expect(result.current).toEqual({ status: "active" });
     });
 
-    it("stops naming the previous key's plan once a different key is stored (https://github.com/logancyang/obsidian-copilot-preview/issues/352)", async () => {
+    it("stops naming the previous key's plan once a different key is stored (https://github.com/Brevilabs/obsidian-copilot-private/issues/307)", async () => {
       // The badge reads the same proof the gates do, so a proof that outlived
       // its key showed a replaced key the plan it never bought.
       await verifySessionClaims({ plan: "believer", tier: "plus" });

--- a/src/plusUtils.test.ts
+++ b/src/plusUtils.test.ts
@@ -84,6 +84,12 @@ import { Notice } from "obsidian";
 
 const FUTURE_EXP_SECONDS = 9_999_999_999;
 const PAST_EXP_SECONDS = 1_000_000_000;
+/**
+ * The license key these fixtures treat as stored. The verify helpers and
+ * {@link tokenBackedSettings} share it so the in-memory proof belongs to the key
+ * settings hold — the pairing {@link hasLiveEntitlement} now requires.
+ */
+const STORED_LICENSE_KEY = "key";
 
 function buildSettings(overrides: Partial<CopilotSettings>): CopilotSettings {
   return { ...DEFAULT_SETTINGS, ...overrides };
@@ -105,19 +111,26 @@ async function verifySessionFeatures(
     iat: 0,
     exp: expSeconds,
   });
-  mockGetSettings.mockReturnValue(buildSettings({ userId: "user-123", entitlementToken: "token" }));
+  mockGetSettings.mockReturnValue(
+    buildSettings({
+      userId: "user-123",
+      entitlementToken: "token",
+      plusLicenseKey: STORED_LICENSE_KEY,
+    })
+  );
   await verifyCachedEntitlement();
 }
 
 /**
- * Settings of a user holding an unexpired, token-derived entitlement. `token`
- * matches what {@link verifySessionFeatures} verified, so the in-memory proof
- * belongs to the token settings currently hold.
+ * Settings of a user holding an unexpired, token-derived entitlement. The token
+ * and license key match what the verify helpers verified, so the in-memory
+ * proof belongs to both the token and the key settings currently hold.
  */
 function tokenBackedSettings(overrides: Partial<CopilotSettings> = {}): CopilotSettings {
   return buildSettings({
     userId: "user-123",
     entitlementToken: "token",
+    plusLicenseKey: STORED_LICENSE_KEY,
     entitlementExpiresAt: Date.now() + 60_000,
     ...overrides,
   });
@@ -139,7 +152,13 @@ async function verifySessionClaims(
     exp: FUTURE_EXP_SECONDS,
     ...claims,
   });
-  mockGetSettings.mockReturnValue(buildSettings({ userId: "user-123", entitlementToken: "token" }));
+  mockGetSettings.mockReturnValue(
+    buildSettings({
+      userId: "user-123",
+      entitlementToken: "token",
+      plusLicenseKey: STORED_LICENSE_KEY,
+    })
+  );
   await verifyCachedEntitlement();
 }
 
@@ -551,7 +570,11 @@ describe("plusUtils", () => {
 
   describe("applyEntitlement()", () => {
     beforeEach(() => {
-      mockGetSettings.mockReturnValue(buildSettings({ userId: "user-123" }));
+      // A key is always stored by the time this runs: it is the /license answer
+      // for that key that carries the token.
+      mockGetSettings.mockReturnValue(
+        buildSettings({ userId: "user-123", plusLicenseKey: STORED_LICENSE_KEY })
+      );
     });
 
     it("grants Plus and self-host for a Supporter token carrying both features", async () => {
@@ -619,6 +642,31 @@ describe("plusUtils", () => {
       expect(isSelfHostModeValid()).toBe(false);
     });
 
+    it("does not tag the proof with a key swapped in while verification was in flight (https://github.com/logancyang/obsidian-copilot-preview/issues/352)", async () => {
+      // validateLicenseKey's key-changed guard runs before this call, so only
+      // reading the key up front keeps the old key's claims off the new key.
+      mockVerifyEntitlement.mockImplementation(async () => {
+        mockGetSettings.mockReturnValue(
+          buildSettings({ userId: "user-123", plusLicenseKey: "a-different-key" })
+        );
+        return {
+          user_id: "user-123",
+          plan: "believer",
+          tier: "plus",
+          features: ["multi_agent", "self_host"],
+          iat: 0,
+          exp: FUTURE_EXP_SECONDS,
+        };
+      });
+
+      expect(await applyEntitlement("token")).toBe(true);
+      mockGetSettings.mockReturnValue(
+        tokenBackedSettings({ plusLicenseKey: "a-different-key", enableSelfHostMode: true })
+      );
+      expect(isSelfHostModeValid()).toBe(false);
+      expect(canUseMultiAgent()).toBe(false);
+    });
+
     it("does NOT change settings when the token cannot be verified", async () => {
       // An unverifiable token (bad signature, expired, unknown kid, or empty key
       // set during rollout) is not an authoritative negative, so flags are left
@@ -653,7 +701,11 @@ describe("plusUtils", () => {
         exp: FUTURE_EXP_SECONDS,
       };
       mockGetSettings.mockReturnValue(
-        buildSettings({ userId: "user-123", entitlementToken: "old-token" })
+        buildSettings({
+          userId: "user-123",
+          entitlementToken: "old-token",
+          plusLicenseKey: STORED_LICENSE_KEY,
+        })
       );
       mockVerifyEntitlement.mockImplementation(async (token: string) => {
         if (token === "old-token") {
@@ -740,20 +792,21 @@ describe("plusUtils", () => {
     it("refuses the offline fallback to an unexpired free-tier token", async () => {
       // The backend downgrades a lapsed paid key to the free policy instead of
       // refusing it a token, so an unexpired proof is not by itself paid access.
-      mockVerifyEntitlement.mockResolvedValue({
-        user_id: "user-123",
-        plan: "none",
-        tier: "free",
-        features: [],
-        iat: 0,
-        exp: FUTURE_EXP_SECONDS,
-      });
-      mockGetSettings.mockReturnValue(
-        buildSettings({ userId: "user-123", entitlementToken: "token" })
-      );
-      await verifyCachedEntitlement();
-      mockGetSettings.mockReturnValue(tokenBackedSettings({ plusLicenseKey: "key" }));
+      await verifySessionClaims({ plan: "none", tier: "free" });
+      mockGetSettings.mockReturnValue(tokenBackedSettings());
       mockValidateLicenseKey.mockRejectedValue(new Error("net::ERR_INTERNET_DISCONNECTED"));
+
+      expect(await checkIsPaidUser(undefined, { trigger: "manual" })).toBe(false);
+    });
+
+    it("refuses the previous key's entitlement to a newly entered key the server cannot rule on (https://github.com/logancyang/obsidian-copilot-preview/issues/352)", async () => {
+      // Swapping the key leaves the old key's token persisted and its proof
+      // live. Without the proof naming the key that earned it, this fallback
+      // answered `true` for a key the server never accepted, keeping the old
+      // plan's badge and every Plus gate open until that token's exp passed.
+      await verifySessionFeatures(["multi_agent", "self_host"]);
+      mockGetSettings.mockReturnValue(tokenBackedSettings({ plusLicenseKey: "a-different-key" }));
+      mockValidateLicenseKey.mockResolvedValue({ isValid: undefined });
 
       expect(await checkIsPaidUser(undefined, { trigger: "manual" })).toBe(false);
     });
@@ -877,6 +930,19 @@ describe("plusUtils", () => {
       const { result } = renderHook(() => useLicenseState());
 
       expect(result.current).toEqual({ status: "active" });
+    });
+
+    it("stops naming the previous key's plan once a different key is stored (https://github.com/logancyang/obsidian-copilot-preview/issues/352)", async () => {
+      // The badge reads the same proof the gates do, so a proof that outlived
+      // its key showed a replaced key the plan it never bought.
+      await verifySessionClaims({ plan: "believer", tier: "plus" });
+      mockGetSettings.mockReturnValue(
+        tokenBackedSettings({ plusLicenseKey: "a-different-key", isPaidUser: false })
+      );
+
+      const { result } = renderHook(() => useLicenseState());
+
+      expect(result.current).toEqual({ status: "inactive" });
     });
 
     it("shows nothing when no license key is stored", () => {

--- a/src/plusUtils.ts
+++ b/src/plusUtils.ts
@@ -136,7 +136,7 @@ interface VerifiedEntitlement {
    * belongs to no key in particular, so swapping in a different key and getting
    * anything short of an authoritative refusal (offline, 5xx, gateway error)
    * would let the new key inherit the old one's plan.
-   * https://github.com/logancyang/obsidian-copilot-preview/issues/352
+   * https://github.com/Brevilabs/obsidian-copilot-private/issues/307
    */
   licenseKey: string;
   features: ReadonlySet<EntitlementFeature>;

--- a/src/plusUtils.ts
+++ b/src/plusUtils.ts
@@ -124,13 +124,21 @@ function isEntitlementExpired(settings: CopilotSettings): boolean {
  * an edited `entitlementExpiresAt` would hold it open past the token's real
  * `exp` for as long as the session lived.
  *
- * `token` is what settings must still hold for the proof to apply. That is how
- * the paths that drop the token (turnOffPaid and markPaidPendingEntitlement)
- * revoke these capabilities without touching this state: no stored token can
- * match `""` while carrying features.
+ * `token` and `licenseKey` are what settings must still hold for the proof to
+ * apply. That is how the paths that drop the token (turnOffPaid and
+ * markPaidPendingEntitlement) revoke these capabilities without touching this
+ * state: no stored token can match `""` while carrying features.
  */
 interface VerifiedEntitlement {
   token: string;
+  /**
+   * The license key this entitlement was issued for. Without it the proof
+   * belongs to no key in particular, so swapping in a different key and getting
+   * anything short of an authoritative refusal (offline, 5xx, gateway error)
+   * would let the new key inherit the old one's plan.
+   * https://github.com/logancyang/obsidian-copilot-preview/issues/352
+   */
+  licenseKey: string;
   features: ReadonlySet<EntitlementFeature>;
   /** The claims' plan name, for display only — never gated on. */
   plan: string;
@@ -147,6 +155,7 @@ interface VerifiedEntitlement {
 /** Frozen "nothing verified" proof — referential stability for the empty state. */
 const NO_VERIFIED_ENTITLEMENT: VerifiedEntitlement = Object.freeze({
   token: "",
+  licenseKey: "",
   features: Object.freeze(new Set<EntitlementFeature>()),
   plan: "",
   expiresAt: 0,
@@ -157,12 +166,17 @@ let verified: VerifiedEntitlement = NO_VERIFIED_ENTITLEMENT;
 
 /**
  * Whether the entitlement verified this session still stands: the proof must
- * belong to the token settings currently hold, and the signed `exp` must not
- * have passed. This is the offline window — signature-backed, so unlike the
- * persisted `isPaidUser` an edited `data.json` cannot widen it.
+ * belong to the token AND the license key settings currently hold, and the
+ * signed `exp` must not have passed. This is the offline window — signature-backed,
+ * so unlike the persisted `isPaidUser` an edited `data.json` cannot widen it.
  */
 function hasLiveEntitlement(): boolean {
-  return verified.token === getSettings().entitlementToken && Date.now() < verified.expiresAt;
+  const settings = getSettings();
+  return (
+    verified.token === settings.entitlementToken &&
+    verified.licenseKey === settings.plusLicenseKey &&
+    Date.now() < verified.expiresAt
+  );
 }
 
 /**
@@ -564,12 +578,17 @@ export function turnOffPaid(app?: App): void {
  * authoritative negative (invalid license / no key) downgrades, via turnOffPaid.
  */
 export async function applyEntitlement(token: string): Promise<boolean> {
-  const claims = await verifyEntitlement(token, { expectedUserId: getSettings().userId });
+  // Read before the await: a key swapped while verification is in flight would
+  // otherwise tag this proof with the new key while it carries the old key's
+  // claims, which is the inheritance this binding exists to prevent.
+  const { userId, plusLicenseKey } = getSettings();
+  const claims = await verifyEntitlement(token, { expectedUserId: userId });
   if (!claims) {
     return false;
   }
   verified = {
     token,
+    licenseKey: plusLicenseKey,
     features: new Set(claims.features),
     plan: claims.plan,
     expiresAt: claims.exp * 1000,
@@ -594,7 +613,7 @@ export async function applyEntitlement(token: string): Promise<boolean> {
  * separately and overrides this with the server's fresh token.
  */
 export async function verifyCachedEntitlement(): Promise<void> {
-  const { entitlementToken, userId } = getSettings();
+  const { entitlementToken, userId, plusLicenseKey } = getSettings();
   const claims = entitlementToken
     ? await verifyEntitlement(entitlementToken, { expectedUserId: userId })
     : null;
@@ -610,6 +629,7 @@ export async function verifyCachedEntitlement(): Promise<void> {
   // rotation, tampering) must drop the capabilities an earlier check granted it.
   verified = {
     token: entitlementToken,
+    licenseKey: plusLicenseKey,
     features: new Set(claims?.features),
     plan: claims?.plan ?? "",
     expiresAt: (claims?.exp ?? 0) * 1000,


### PR DESCRIPTION
Fixes Brevilabs/obsidian-copilot-private#307

## Why

A user with a working Lifetime key opened Settings, Copilot License, replaced
the stored key with a garbage string, and clicked Apply. Nothing happened. The
badge kept reading `Lifetime`, the "Thanks for being a Copilot Plus user"
welcome modal opened as though the new key had been accepted, no error text
appeared under the field, and every paid gate stayed open for roughly two more
weeks.

Two separate things had to go wrong for that. First, `/license` refuses an
unknown key with HTTP 403 and a reason that names the key's prefix, for example
`Invalid license key (prefix: garbage-ke...)`. The client compared that reason
against the bare string `Invalid license key`, so the prefix suffix broke the
match and an authoritative refusal was reclassified as "server unreachable".
Second, that unreachable path falls back to the entitlement verified earlier in
the session, and nothing tied that entitlement to the license key that earned
it. The refused key inherited the previous key's plan.

The second half is the general one. After any key change, any genuinely unknown
outcome, offline, 5xx, or a gateway error, handed the new key the old key's
access.

## What

| Applying a new key over a working Lifetime key | Before | After |
| --- | --- | --- |
| The API refuses it (403 with its error body) | Badge `Lifetime`, welcome modal, paid gates open | Badge `Inactive`, `Invalid license key` under the field, paid gates closed |
| Server unreachable, 5xx, or an unexplained 403 | Badge `Lifetime`, every paid gate open | `Invalid license key` reported; Plus and self-host gates closed; badge falls back to a generic `Active` and broad paid access persists until the server answers |
| The API accepts it | Badge shows the new plan | Unchanged |
| No key change, server unreachable | Existing plan keeps working offline | Unchanged |

Two things that outage row does not do, both deliberate. It does not name the
previous plan any more, so a refused key can no longer read `Lifetime`. And it
does not revoke anything: the persisted paid flag is not bound to the key that
earned it, and the fix for that unregisters the Plus provider on every valid key
rotation, resetting the user's per-model enablement. Trading a stale badge in an
offline edge case for real state loss on the common path is the wrong trade, so
that half is Brevilabs/obsidian-copilot-private#309.

Revocation happens only when the API itself refuses a key, never on an outage. A
gateway or WAF answering 403 with no API error body is treated as unknown, so a
license server having a bad day costs no paying user their access. A keyless
check no longer reaches the server at all: the endpoint refuses an empty key with
the same 403 it gives a wrong one, and the per-turn and per-model gates call
`validateLicenseKey` without the sign-out `checkIsPaidUser` performs when it finds
no key. The offline window for an unchanged key is untouched.

That 403-with-no-body guard is insurance while sign-out stays destructive, and it
comes out once Brevilabs/obsidian-copilot-private#308 lands.

## Non goal

- Binding the persisted `isPaidUser` flag to its license key, and having
  `useIsSelfHostEligible()` read the key-bound proof rather than re-verifying the
  raw token. Both are Brevilabs/obsidian-copilot-private#309, which is itself
  blocked on Brevilabs/obsidian-copilot-private#308: sign-out deletes the
  ConfiguredModel rows that enablement is keyed on, so clearing the paid flag on
  a key change would reset the user's model curation on every valid rotation.
- The chat error path in `src/utils.ts` matches the same reason text the same
  brittle way, so a lapsed key still shows a raw error there instead of the
  friendly upgrade message. That is pre-existing and unchanged here.
- The expired-license modal now opens for a mistyped key, since that branch
  became reachable. Its "Renew Now" framing is not retuned in this PR.
- No new offline grace behavior, and no change to how any license state renders.

## Screenshot

Not applicable. This PR changes which license state the settings section
reaches, not how any state renders. The diff touches four files, all of them
`src/plusUtils.*` and `src/LLMProviders/brevilabsClient.*`, and no UI component,
copy string, or stylesheet. The reachable states and their exact copy are in the
`What` table above; the `Inactive` badge, the generic `Active` badge, and the
`Invalid license key` message all already exist and are unmodified.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Added tests cover the API refusal, an unexplained 403, a 502, an empty stored key, the key-swap fallback, the badge, and the in-flight key swap |
| A defect would fail CI or be obvious on first use | ✅ | Those tests run in CI, and a wrong verdict shows on the next Apply |
| A revert fully restores prior state, including persisted data | ✅ | The key binding is in-memory only, no settings schema change and no migration; a revert needs no data change |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | This is the license entitlement gate: it decides what unlocks paid features |
| No public API, plugin API, message, or on-disk contract changes | ✅ | `BrevilabsApiResult` and `VerifiedEntitlement` are module-private and no exported signature changed |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | `applyEntitlement` now reads the license key before its verification await rather than after |
| No hot-path behavior lacks deterministic coverage | ✅ | Every changed branch has a test that was confirmed to fail against the previous code |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Confined to license validation, and a wrong result appears on the next Apply or startup check |

Review: inspect `validateLicenseKey` and `parseBrevilabsResponse` in
`src/LLMProviders/brevilabsClient.ts`, then `hasLiveEntitlement`,
`applyEntitlement`, and `verifyCachedEntitlement` in `src/plusUtils.ts`, line by
line. The condition worth the most attention is the one deciding when
`turnOffPaid` runs, since that is the only path that takes access away. Then run
Verification steps 2 to 7, especially step 6, which proves an outage on an
unchanged key costs nothing.

## Verification

1. Build the branch and load it in a vault that has a working paid license key
   applied. Open Settings, Copilot License, and note the plan badge.
2. Replace the key with any garbage string and click Apply. The badge should
   turn to `Inactive`, `Invalid license key` should appear under the field, and
   paid models should stop being offered.
3. Reopen the settings tab. It should still read `Inactive` rather than
   returning to the previous plan.
4. Paste the real key back and click Apply. The plan badge should return and
   paid models should work again.
5. With the real key applied, disconnect from the network, replace the key with
   a garbage string, and click Apply. It should report the key as invalid and
   stop offering Plus models, rather than showing the previous plan name.
6. With the real key applied, disconnect from the network and click Apply without
   changing the key. Access should be unaffected, which is what proves an outage
   costs a paying user nothing.
7. Reconnect, paste the real key, and click Apply. Access should come back.
8. Clear the key field entirely, then start a turn that @-mentions two agents.
   It should refuse the fan-out without opening the expired-license modal, since
   having no key is not a refusal to revoke on.

## Note

The endpoint contract was confirmed against the live server before the fix:
`POST /v1/license` with an unknown key returns HTTP 403 with
`detail.error = "FORBIDDEN"` and a `reason` carrying the key prefix. The
existing unit test passed throughout the bug because it stubbed the bare literal
`Invalid license key`, a shape the server no longer sends.

The presence of that `detail` body, not the 403 alone, is what authorizes
revocation. Infrastructure returns 403 with an HTML page and no API error body,
and reading that as a verdict would revoke every paying user who happened to
check in during an outage.

The same probe showed an empty `license_key` returns the identical 403 and body
as a wrong one, while omitting the field returns 400. Since the plugin always
sends the field, a keyless check was indistinguishable from a refusal, which is
why `validateLicenseKey` now answers locally when no key is stored.


