### PR TITLE
feat(skills): add optional screenpipe activity skill

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -120,7 +120,11 @@ Skills are reusable instruction packets built around a `SKILL.md` file. One Skil
 
 Shared Skills live under `<Copilot folder>/skills/`. Copilot links them into the native folders used by each agent: `.opencode/skills/`, `.claude/skills/`, and `.agents/skills/`. Skills already present in those native folders also appear in the settings list.
 
-Custom Skills and built-in Obsidian Skills are free. Active Plus access adds cloud-backed Skills for web research, PDF reading, YouTube transcripts, X posts, and Symposium.
+Custom Skills and built-in Obsidian Skills are free. Copilot also includes an optional **screenpipe activity** Skill for searching screen and audio history through an existing local screenpipe MCP connection. It is disabled until you enable it for an agent.
+
+The screenpipe Skill does not install screenpipe, start recording, or copy activity into your vault. Install and run screenpipe, [connect its MCP server](https://docs.screenpipe.com/mcp-server) to the same opencode, Claude, or Codex agent, restart Agent Chat, then enable **screenpipe-activity** under **Settings → Copilot → Skills**. You can then ask questions such as “What was I working on before this meeting?” or “Find what we said about the launch yesterday.” The selected agent and model receive the relevant search results, so use a local model when those excerpts must remain on your computer.
+
+Active Plus access adds cloud-backed Skills for web research, PDF reading, YouTube transcripts, X posts, and Symposium.
 
 In Self-Host Mode with OpenCode selected, Agent Chat's built-in web-search Skill uses the search provider selected under **Settings → Copilot → Self-Host**. Provider credentials stay inside Obsidian rather than being passed to OpenCode, and the feature does not require Obsidian's command line interface. Copilot disables OpenCode's native web-search and web-fetch tools so they cannot bypass that route. Full-page web fetching is unavailable through OpenCode in Self-Host Mode because the supported search providers do not share a page-fetch interface; Agent Chat can still use the configured provider's search results.
 

--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -118,7 +118,11 @@ Skills are reusable instruction packets built around a `SKILL.md` file. One Skil
 
 Shared Skills live under `<Copilot folder>/skills/`. Copilot links them into the native folders used by each agent: `.opencode/skills/`, `.claude/skills/`, and `.agents/skills/`. Skills already present in those native folders also appear in the settings list.
 
-Custom Skills and built-in Obsidian Skills are free. Active Plus access adds cloud-backed Skills for web research, PDF reading, YouTube transcripts, X posts, and Symposium.
+Custom Skills and built-in Obsidian Skills are free. Copilot also includes an optional **screenpipe activity** Skill for searching screen and audio history through an existing local screenpipe MCP connection. It is disabled until you enable it for an agent.
+
+The screenpipe Skill does not install screenpipe, start recording, or copy activity into your vault. Install and run screenpipe, [connect its MCP server](https://docs.screenpipe.com/mcp-server) to the same opencode, Claude, or Codex agent, restart Agent Chat, then enable **screenpipe-activity** under **Settings → Copilot → Skills**. You can then ask questions such as “What was I working on before this meeting?” or “Find what we said about the launch yesterday.” The selected agent and model receive the relevant search results, so use a local model when those excerpts must remain on your computer.
+
+Active Plus access adds cloud-backed Skills for web research, PDF reading, YouTube transcripts, X posts, and Symposium.
 
 On Windows, creating the folder links may require **Developer Mode** or administrator access. If a sync service replaces a link, toggle that Skill off and on for the affected agent to recreate it.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -70,7 +70,7 @@ From Agent Chat Home, open **Projects** and select **New project**. A project ke
 
 Skills are reusable instruction packets for jobs such as reviewing a change or drafting a release note. Open **Settings → Copilot → Skills** to see skills from Copilot's shared skills folder and the native opencode, Claude, and Codex skill folders. Enable each skill for the agents that should use it; Copilot links shared skills into the right agent folders for you.
 
-Type `/` in Agent Chat to choose an available skill. Copilot also includes skills for Obsidian Markdown, Bases, Canvas, and the Obsidian CLI. Learn more in [Skills across agents](agent-mode-and-tools.md#skills-across-agents).
+Type `/` in Agent Chat to choose an available skill. Copilot also includes skills for Obsidian Markdown, Bases, Canvas, and the Obsidian CLI, plus an optional screenpipe activity-history workflow. Learn more in [Skills across agents](agent-mode-and-tools.md#skills-across-agents).
 
 ### Reuse Copilot Commands
 

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -27,7 +27,7 @@ const RELAY_SKILLS = BUILTIN_SKILLS.filter((skill) => skill.name.startsWith("cop
 
 describe("builtinSkills", () => {
   describe("BUILTIN_SKILLS", () => {
-    it("ships the approved Plus and Obsidian skills to all three agents", () => {
+    it("ships the approved Plus and Obsidian skills plus the opt-in screenpipe skill", () => {
       expect(BUILTIN_SKILLS.map((s) => s.name)).toEqual([
         "copilot-web-search",
         "copilot-web-fetch",
@@ -35,14 +35,18 @@ describe("builtinSkills", () => {
         "copilot-youtube-transcript",
         "copilot-fetch-x",
         "symposium-publish",
+        "screenpipe-activity",
         "obsidian-markdown",
         "obsidian-bases",
         "json-canvas",
         "obsidian-cli",
       ]);
-      for (const skill of BUILTIN_SKILLS) {
+      for (const skill of BUILTIN_SKILLS.filter((item) => item.name !== "screenpipe-activity")) {
         expect(skill.enabledAgents).toEqual(["claude", "codex", "opencode"]);
       }
+      expect(
+        BUILTIN_SKILLS.find((item) => item.name === "screenpipe-activity")?.enabledAgents
+      ).toEqual([]);
     });
 
     it("keeps the SKILL.md frontmatter version in sync with the numeric version", () => {

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -24,7 +24,7 @@ const RELAY_SKILLS = BUILTIN_SKILLS.filter((skill) => skill.name.startsWith("cop
 
 describe("builtinSkills", () => {
   describe("BUILTIN_SKILLS", () => {
-    it("ships the approved Plus and Obsidian skills to all three agents", () => {
+    it("ships the approved Plus and Obsidian skills plus the opt-in screenpipe skill", () => {
       expect(BUILTIN_SKILLS.map((s) => s.name)).toEqual([
         "copilot-web-search",
         "copilot-web-fetch",
@@ -32,14 +32,18 @@ describe("builtinSkills", () => {
         "copilot-youtube-transcript",
         "copilot-fetch-x",
         "symposium-publish",
+        "screenpipe-activity",
         "obsidian-markdown",
         "obsidian-bases",
         "json-canvas",
         "obsidian-cli",
       ]);
-      for (const skill of BUILTIN_SKILLS) {
+      for (const skill of BUILTIN_SKILLS.filter((item) => item.name !== "screenpipe-activity")) {
         expect(skill.enabledAgents).toEqual(["claude", "codex", "opencode"]);
       }
+      expect(
+        BUILTIN_SKILLS.find((item) => item.name === "screenpipe-activity")?.enabledAgents
+      ).toEqual([]);
     });
 
     it("keeps the SKILL.md frontmatter version in sync with the numeric version", () => {

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -5,6 +5,7 @@ import {
   SYMPOSIUM_WORKSPACE_ROOT_ENV,
 } from "@/symposium/constants";
 import { OBSIDIAN_SKILLS } from "./obsidianSkills";
+import { SCREENPIPE_ACTIVITY_SKILL } from "./screenpipeSkill";
 
 /**
  * Plugin-shipped ("builtin") Agent Mode skills. Unlike user-authored skills,
@@ -778,6 +779,7 @@ export const BUILTIN_SKILLS: readonly BuiltinSkill[] = [
   YOUTUBE_TRANSCRIPT,
   FETCH_X,
   SYMPOSIUM_PUBLISH,
+  SCREENPIPE_ACTIVITY_SKILL,
   ...OBSIDIAN_SKILLS,
 ];
 

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -5,6 +5,7 @@ import {
   SYMPOSIUM_WORKSPACE_ROOT_ENV,
 } from "@/symposium/constants";
 import { OBSIDIAN_SKILLS } from "./obsidianSkills";
+import { SCREENPIPE_ACTIVITY_SKILL } from "./screenpipeSkill";
 
 /**
  * Plugin-shipped ("builtin") Agent Mode skills. Unlike user-authored skills,
@@ -699,6 +700,7 @@ export const BUILTIN_SKILLS: readonly BuiltinSkill[] = [
   YOUTUBE_TRANSCRIPT,
   FETCH_X,
   SYMPOSIUM_PUBLISH,
+  SCREENPIPE_ACTIVITY_SKILL,
   ...OBSIDIAN_SKILLS,
 ];
 

--- a/src/agentMode/skills/builtin/screenpipeSkill.test.ts
+++ b/src/agentMode/skills/builtin/screenpipeSkill.test.ts
@@ -1,0 +1,42 @@
+import { parseSkillFile } from "@/agentMode/skills/skillFormat";
+import { SCREENPIPE_ACTIVITY_SKILL } from "./screenpipeSkill";
+
+describe("screenpipeSkill", () => {
+  describe("SCREENPIPE_ACTIVITY_SKILL", () => {
+    it("is a valid opt-in skill visible to every Agent Mode backend", () => {
+      const parsed = parseSkillFile(
+        SCREENPIPE_ACTIVITY_SKILL.skillMd,
+        SCREENPIPE_ACTIVITY_SKILL.name
+      );
+
+      expect(SCREENPIPE_ACTIVITY_SKILL.enabledAgents).toEqual([]);
+      expect(parsed.frontmatter.enabledAgents).toEqual([]);
+      expect(parsed.frontmatter.description).toMatch(/screenpipe screen and audio history/i);
+      expect(parsed.frontmatter.description).toMatch(/Do not use for ordinary vault questions/i);
+      expect(SCREENPIPE_ACTIVITY_SKILL.skillMd).toContain(
+        `copilot-builtin-version: "${SCREENPIPE_ACTIVITY_SKILL.version}"`
+      );
+    });
+
+    it("keeps retrieval bounded and treats missing capture as inconclusive", () => {
+      const md = SCREENPIPE_ACTIVITY_SKILL.skillMd;
+
+      expect(md).toContain("explicit ISO 8601 start and end times");
+      expect(md).toContain("limit no greater than 20");
+      expect(md).toContain("Keep `include_frames` false");
+      expect(md).toContain("An empty result is inconclusive");
+      expect(md).toContain("counts measure capture volume rather than duration");
+    });
+
+    it("does not authorize installation, persistence, exports, or sharing", () => {
+      const md = SCREENPIPE_ACTIVITY_SKILL.skillMd;
+
+      expect(md).toContain("does not install screenpipe");
+      expect(md).toContain("Do not edit an agent configuration");
+      expect(md).toContain("Do not call `export-video`");
+      expect(md).toMatch(/create\s+or update an Obsidian note/);
+      expect(md).toMatch(/share captured data unless the\s+user explicitly requests/);
+      expect(md).toContain("that model may run outside the user's computer");
+    });
+  });
+});

--- a/src/agentMode/skills/builtin/screenpipeSkill.test.ts
+++ b/src/agentMode/skills/builtin/screenpipeSkill.test.ts
@@ -18,7 +18,7 @@ describe("screenpipeSkill", () => {
       );
     });
 
-    it("keeps retrieval bounded and treats missing capture as inconclusive", () => {
+    it("keeps retrieval bounded and treats missing capture as inconclusive per https://github.com/screenpipe/screenpipe/issues/4351", () => {
       const md = SCREENPIPE_ACTIVITY_SKILL.skillMd;
 
       expect(md).toContain("explicit ISO 8601 start and end times");

--- a/src/agentMode/skills/builtin/screenpipeSkill.ts
+++ b/src/agentMode/skills/builtin/screenpipeSkill.ts
@@ -2,6 +2,14 @@ import type { BuiltinSkill } from "./builtinSkills";
 
 const SCREENPIPE_ACTIVITY_VERSION = 1;
 
+// https://github.com/screenpipe/screenpipe/issues/4351 documents agents giving up
+// after an empty search even when a capture-method mismatch hides recorded content.
+// Treating that result as inconclusive avoids falsely telling users they had no activity.
+const EMPTY_CAPTURE_GUIDANCE = `An empty result is inconclusive. Check whether screenpipe is
+running and recording, broaden the range once when appropriate, and otherwise
+say that no matching capture was available. Do not turn an incomplete read
+into a claim that the user had no activity.`;
+
 /** Optional activity-history guidance for agents with a configured local screenpipe MCP server. */
 export const SCREENPIPE_ACTIVITY_SKILL: BuiltinSkill = {
   name: "screenpipe-activity",
@@ -43,10 +51,7 @@ run an installer unless the user explicitly asks.
 5. Narrow the range or page with \`offset\` if the first result set is too broad.
    Do not raise the result limit above 20 or dump raw result sets into the chat.
 
-An empty result is inconclusive. Check whether screenpipe is running and
-recording, broaden the range once when appropriate, and otherwise say that no
-matching capture was available. Do not turn an incomplete read into a claim
-that the user had no activity.
+${EMPTY_CAPTURE_GUIDANCE}
 
 ## Answer with traceable evidence
 

--- a/src/agentMode/skills/builtin/screenpipeSkill.ts
+++ b/src/agentMode/skills/builtin/screenpipeSkill.ts
@@ -1,0 +1,72 @@
+import type { BuiltinSkill } from "./builtinSkills";
+
+const SCREENPIPE_ACTIVITY_VERSION = 1;
+
+/** Optional activity-history guidance for agents with a configured local screenpipe MCP server. */
+export const SCREENPIPE_ACTIVITY_SKILL: BuiltinSkill = {
+  name: "screenpipe-activity",
+  version: SCREENPIPE_ACTIVITY_VERSION,
+  enabledAgents: [],
+  skillMd: `---
+name: screenpipe-activity
+description: Search the user's screenpipe screen and audio history when they ask what they saw, heard, typed, or worked on during a time range. Use only when a screenpipe MCP server is already configured. Do not use for ordinary vault questions or install screenpipe automatically.
+metadata:
+  copilot-enabled-agents: ""
+  copilot-builtin-version: "${SCREENPIPE_ACTIVITY_VERSION}"
+---
+
+# Search activity with screenpipe
+
+Use this skill only when screenpipe MCP tools are already available to the
+current agent. screenpipe records on the user's computer when they install and
+enable it. This skill does not install screenpipe, start recording, change its
+retention settings, or copy activity into the Obsidian vault.
+
+If no screenpipe tools appear in the current tool catalog, stop and explain
+that the user must connect screenpipe to this agent first. Link to
+https://docs.screenpipe.com/mcp-server. Do not edit an agent configuration or
+run an installer unless the user explicitly asks.
+
+## Query the smallest useful range
+
+1. Translate the requested period into explicit ISO 8601 start and end times.
+   If the period is ambiguous, state the interpretation before searching.
+2. Call screenpipe's \`search-content\` tool with a limit no greater than 20.
+   Start with \`content_type=all\` for a broad recap, \`audio\` for spoken
+   conversation, or \`input\` only when the user explicitly asks about text they
+   typed or copied.
+3. Keep \`include_frames\` false unless the request needs visual detail that the
+   captured text cannot answer. A screenshot can contain unrelated private
+   information.
+4. For audio, begin without a keyword when a time range or speaker is enough.
+   Transcription errors can make a keyword-only query miss relevant speech.
+5. Narrow the range or page with \`offset\` if the first result set is too broad.
+   Do not raise the result limit above 20 or dump raw result sets into the chat.
+
+An empty result is inconclusive. Check whether screenpipe is running and
+recording, broaden the range once when appropriate, and otherwise say that no
+matching capture was available. Do not turn an incomplete read into a claim
+that the user had no activity.
+
+## Answer with traceable evidence
+
+- Prefer a concise synthesis over raw captured text.
+- Ground material claims in returned timestamps, app or window names, and
+  speaker labels when present. Separate captured facts from inference.
+- Link to a screenpipe frame or timeline moment only when the result provides
+  the real frame ID or timestamp. Never invent an identifier.
+- Do not convert frame or result counts into time spent. Capture is
+  event-driven, so counts measure capture volume rather than duration.
+- Mention relevant coverage gaps, transcription uncertainty, or recording
+  health when they affect the answer.
+
+## Keep side effects explicit
+
+Searching is read-only. Do not call \`export-video\`, control another app, create
+or update an Obsidian note, save a memory, or share captured data unless the
+user explicitly requests that separate action. Before an export, confirm the
+requested time range and destination. Send only the smallest relevant excerpts
+to the active model because that model may run outside the user's computer.
+`,
+  files: [],
+};


### PR DESCRIPTION
## Summary

- add a built-in `screenpipe-activity` skill that is visible in Copilot's Skills settings and disabled by default
- teach Agent Mode to make bounded, read-only screenpipe MCP searches with traceable timestamps and explicit coverage gaps
- document setup, model data flow, and privacy boundaries for opencode, Claude, and Codex

## Why

Copilot already shares skills across its Agent Mode backends. This gives users an opt-in way to ask about recent screen and audio history without copying their activity into the Obsidian vault.

## Privacy and side effects

- the skill does not install or start screenpipe, change retention, or write activity to the vault
- search result limits and frame retrieval are conservative by default
- exports, app control, note writes, memory writes, and sharing require a separate explicit request
- the docs state that the selected agent and model receive relevant excerpts

## Testing

- `npm test -- --runInBand` (452 suites, 6,223 tests)
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run review:obsidian`
- `npm run build --prefix docs`

The Obsidian review exits successfully; its reported warnings and fixture diagnostics are pre-existing and outside the changed files.
