### PR TITLE
Stop sending sampling parameters and let provider errors through

### DIFF
--- a/src/LLMProviders/ChatLMStudio.ts
+++ b/src/LLMProviders/ChatLMStudio.ts
@@ -12,10 +12,7 @@ export interface ChatLMStudioInput {
   modelName?: string;
   apiKey?: string;
   configuration?: Record<string, unknown>;
-  temperature?: number;
   maxTokens?: number;
-  topP?: number;
-  frequencyPenalty?: number;
   streaming?: boolean;
   streamUsage?: boolean;
   [key: string]: unknown;

--- a/src/LLMProviders/ChatOpenRouter.ts
+++ b/src/LLMProviders/ChatOpenRouter.ts
@@ -50,10 +50,7 @@ export interface ChatOpenRouterInput extends BaseChatModelParams {
     fetch?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
     [key: string]: unknown;
   };
-  temperature?: number;
   maxTokens?: number;
-  topP?: number;
-  frequencyPenalty?: number;
   streaming?: boolean;
   maxRetries?: number;
   maxConcurrency?: number;

--- a/src/LLMProviders/chatModelManager.bridge.test.ts
+++ b/src/LLMProviders/chatModelManager.bridge.test.ts
@@ -274,15 +274,14 @@ describe("chatModelManager", () => {
       });
     });
 
-    describe("getChatModelWithTemperature()", () => {
-      it("retains the active bridged model for temperature overrides", async () => {
+    describe("setChatModelFromBridged()", () => {
+      it("retains the bridged model as the active one", async () => {
         const manager = ChatModelManager.getInstance();
         const model = bridgedModel({ apiKey: "bridge-key" });
 
         await manager.setChatModelFromBridged(model);
 
         expect(manager.getActiveModel()).toBe(model);
-        await expect(manager.getChatModelWithTemperature(0)).resolves.toBeDefined();
       });
     });
   });

--- a/src/LLMProviders/chatModelManager.requestBody.test.ts
+++ b/src/LLMProviders/chatModelManager.requestBody.test.ts
@@ -40,6 +40,14 @@ const ANTHROPIC_RESPONSE = JSON.stringify({
   usage: { input_tokens: 1, output_tokens: 1 },
 });
 
+/**
+ * The sampling knobs Copilot no longer sends. Copilot never exposed a control
+ * for any of them, and providers disagree on which values a model accepts, so
+ * each provider's own default is the better answer than Copilot's guess.
+ * https://github.com/logancyang/obsidian-copilot/issues/2959
+ */
+const RETIRED_SAMPLING_PARAMS = ["temperature", "top_p", "frequency_penalty"];
+
 /** Captures the body of the single request the model under test sends. */
 function captureRequestBody(responseText: string): () => Record<string, unknown> {
   let captured: Record<string, unknown> = {};
@@ -77,6 +85,23 @@ function wireModel(overrides: Partial<CustomModel> = {}): CustomModel {
   };
 }
 
+/**
+ * Answers every request with a provider-style 400 so the error the SDK raises
+ * can be inspected. Mirrors what Moonshot returns for a rejected parameter.
+ */
+function respondWithBadRequest(message: string): void {
+  const body = JSON.stringify({ error: { message, type: "invalid_request_error" } });
+  setRequestUrlImpl(() =>
+    Promise.resolve({
+      status: 400,
+      text: body,
+      json: JSON.parse(body) as Record<string, unknown>,
+      arrayBuffer: new ArrayBuffer(0),
+      headers: { "content-type": "application/json" },
+    })
+  );
+}
+
 async function send(model: CustomModel): Promise<void> {
   const instance = await ChatModelManager.getInstance().createModelInstanceFromBridged(model);
   await instance.invoke("hi");
@@ -92,6 +117,62 @@ describe("chatModelManager", () => {
 
         expect(body()).not.toHaveProperty("max_tokens");
         expect(body()).not.toHaveProperty("max_completion_tokens");
+      });
+
+      it("sends no sampling parameters, so the provider applies its own defaults (https://github.com/logancyang/obsidian-copilot/issues/2959)", async () => {
+        const body = captureRequestBody(OPENAI_RESPONSE);
+
+        await send(wireModel());
+
+        for (const param of RETIRED_SAMPLING_PARAMS) {
+          expect(body()).not.toHaveProperty(param);
+        }
+      });
+
+      it("sends Anthropic no sampling parameters either (https://github.com/logancyang/obsidian-copilot/issues/2959)", async () => {
+        const body = captureRequestBody(ANTHROPIC_RESPONSE);
+
+        await send(
+          wireModel({
+            name: "claude-sonnet-4-5",
+            provider: ChatModelProviders.ANTHROPIC,
+            baseUrl: "https://anthropic.invalid",
+            maxTokens: DEFAULT_MAX_OUTPUT_TOKENS,
+          })
+        );
+
+        for (const param of RETIRED_SAMPLING_PARAMS) {
+          expect(body()).not.toHaveProperty(param);
+        }
+      });
+
+      it("surfaces a rejected request as the provider's own message rather than a connection failure (https://github.com/logancyang/obsidian-copilot/issues/2959)", async () => {
+        respondWithBadRequest("invalid temperature: only 1 is allowed for this model");
+
+        const error = await send(wireModel()).catch((raised: unknown) => raised);
+
+        expect(error).toMatchObject({ status: 400 });
+        expect(String(error)).toContain("invalid temperature: only 1 is allowed for this model");
+        expect(String(error)).not.toContain("Connection error");
+      });
+
+      it("stops retrying a request the provider has rejected (https://github.com/logancyang/obsidian-copilot/issues/2959)", async () => {
+        let attempts = 0;
+        const body = JSON.stringify({ error: { message: "nope", type: "invalid_request_error" } });
+        setRequestUrlImpl(() => {
+          attempts += 1;
+          return Promise.resolve({
+            status: 400,
+            text: body,
+            json: JSON.parse(body) as Record<string, unknown>,
+            arrayBuffer: new ArrayBuffer(0),
+            headers: { "content-type": "application/json" },
+          });
+        });
+
+        await expect(send(wireModel())).rejects.toThrow();
+
+        expect(attempts).toBe(1);
       });
 
       it("sends an explicit per-model output limit when the model carries one", async () => {

--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -8,14 +8,8 @@ import {
   ProviderInfo,
 } from "@/constants";
 import { logError, logInfo, logWarn } from "@/logger";
-import { isPaidEnabled } from "@/plusUtils";
-import {
-  CopilotSettings,
-  getModelKeyFromModel,
-  getSettings,
-  subscribeToSettingsChange,
-} from "@/settings/model";
-import { findCustomModel, getModelInfo, ModelInfo, safeFetch } from "@/utils";
+import { getModelKeyFromModel, getSettings, subscribeToSettingsChange } from "@/settings/model";
+import { getModelInfo, safeFetchNoThrow } from "@/utils";
 import { googleHostBaseUrl, groqHostBaseUrl } from "@/utils/providerBaseUrl";
 import { ChatAnthropic } from "@langchain/anthropic";
 import { BaseChatModel } from "@langchain/core/language_models/chat_models";
@@ -157,31 +151,6 @@ export default class ChatModelManager {
     return ChatModelManager.instance;
   }
 
-  private static readonly REASONING_MODEL_TEMPERATURE = 1;
-
-  /**
-   * Determines the appropriate temperature for a model
-   * @returns temperature value or undefined if temperature should not be set
-   */
-  private getTemperatureForModel(
-    modelInfo: ModelInfo,
-    customModel: CustomModel,
-    settings: CopilotSettings
-  ): number | undefined {
-    // Thinking-enabled models don't accept temperature
-    if (modelInfo.isThinkingEnabled) {
-      return undefined;
-    }
-
-    // O-series and GPT-5 models require temperature = 1
-    if (modelInfo.isOSeries || modelInfo.isGPT5) {
-      return ChatModelManager.REASONING_MODEL_TEMPERATURE;
-    }
-
-    // All other models use configured temperature
-    return customModel.temperature ?? settings.temperature;
-  }
-
   private async getModelConfig(
     customModel: CustomModel,
     allowLegacyCredentialFallback: boolean = true
@@ -191,7 +160,6 @@ export default class ChatModelManager {
     const modelName = customModel.name;
     const modelInfo = getModelInfo(modelName);
     const { isThinkingEnabled, usesAdaptiveThinking } = modelInfo;
-    const resolvedTemperature = this.getTemperatureForModel(modelInfo, customModel, settings);
     // Copilot sets no output limit. This stays undefined unless the model
     // carries one of its own, and an undefined limit is left out of the
     // request, so the provider writes whatever the context window allows.
@@ -199,17 +167,18 @@ export default class ChatModelManager {
     const maxTokens = customModel.maxTokens;
     const openAIFormatIsKeyless = customModel.requiresApiKey === false;
 
-    // Base config - temperature will be handled by provider-specific methods
+    // No temperature is sent. Copilot exposes no way to choose one, and providers
+    // disagree on which values a model accepts: the Moonshot Kimi line rejects
+    // anything but 1, OpenAI's reasoning models reject anything but 1, and
+    // Anthropic's thinking models reject the parameter outright. Omitting it lets
+    // each provider apply its own default instead of Copilot guessing per family.
+    // https://github.com/logancyang/obsidian-copilot/issues/2959
     const baseConfig: Omit<ModelConfig, "maxTokens" | "maxCompletionTokens"> = {
       modelName: modelName,
       streaming: customModel.stream ?? true,
       maxRetries: 3,
       maxConcurrency: 3,
       enableCors: customModel.enableCors,
-      // Add temperature for normal models (will be overridden by special configs if needed)
-      ...(!isThinkingEnabled && resolvedTemperature !== undefined
-        ? { temperature: resolvedTemperature }
-        : {}),
     };
 
     const providerConfig: {
@@ -224,7 +193,7 @@ export default class ChatModelManager {
         ),
         configuration: {
           baseURL: customModel.baseUrl,
-          fetch: customModel.enableCors ? safeFetch : undefined,
+          fetch: customModel.enableCors ? safeFetchNoThrow : undefined,
           organization: customModel.openAIOrgId || settings.openAIOrgId,
         },
         ...this.getOpenAISpecialConfig(modelName, maxTokens, customModel),
@@ -242,7 +211,7 @@ export default class ChatModelManager {
           defaultHeaders: {
             "anthropic-dangerous-direct-browser-access": "true",
           },
-          fetch: customModel.enableCors ? safeFetch : undefined,
+          fetch: customModel.enableCors ? safeFetchNoThrow : undefined,
         },
         ...(isThinkingEnabled && {
           // Opus 4.7+ defaults thinking.display to "omitted" so thinking summaries
@@ -286,7 +255,7 @@ export default class ChatModelManager {
                 allowLegacyCredentialFallback
               ),
             },
-            fetch: customModel.enableCors ? safeFetch : undefined,
+            fetch: customModel.enableCors ? safeFetchNoThrow : undefined,
           },
           ...this.getOpenAISpecialConfig(modelName, maxTokens, customModel),
         };
@@ -300,7 +269,7 @@ export default class ChatModelManager {
         ),
         configuration: {
           baseURL: customModel.baseUrl || ProviderInfo[ChatModelProviders.COHEREAI].host,
-          fetch: customModel.enableCors ? safeFetch : undefined,
+          fetch: customModel.enableCors ? safeFetchNoThrow : undefined,
         },
       },
       [ChatModelProviders.GOOGLE]: {
@@ -333,7 +302,7 @@ export default class ChatModelManager {
         ),
         configuration: {
           baseURL: customModel.baseUrl || "https://openrouter.ai/api/v1",
-          fetch: customModel.enableCors ? safeFetch : undefined,
+          fetch: customModel.enableCors ? safeFetchNoThrow : undefined,
           defaultHeaders: {
             "HTTP-Referer": "https://obsidiancopilot.com",
             "X-Title": "Obsidian Copilot",
@@ -369,9 +338,9 @@ export default class ChatModelManager {
         headers: {
           Authorization: `Bearer ${customModel.apiKey || "default-key"}`,
         },
-        // Route through Obsidian's requestUrl (safeFetch) to bypass CORS / mixed-content
+        // Route through Obsidian's requestUrl (safeFetchNoThrow) to bypass CORS / mixed-content
         // restrictions — required on mobile (WKWebView) when calling http:// Ollama hosts.
-        fetch: customModel.enableCors ? safeFetch : undefined,
+        fetch: customModel.enableCors ? safeFetchNoThrow : undefined,
         // Enable thinking for models with REASONING capability (e.g., qwen3, deepseek-r1)
         // Thinking content goes to additional_kwargs.reasoning_content
         think: customModel.capabilities?.includes(ModelCapability.REASONING) ?? false,
@@ -385,7 +354,7 @@ export default class ChatModelManager {
         streamUsage: customModel.streamUsage ?? false,
         configuration: {
           baseURL: customModel.baseUrl || "http://localhost:1234/v1",
-          fetch: customModel.enableCors ? safeFetch : undefined,
+          fetch: customModel.enableCors ? safeFetchNoThrow : undefined,
         },
         // Enable reasoning extraction for models with REASONING capability
         enableReasoning: customModel.capabilities?.includes(ModelCapability.REASONING) ?? false,
@@ -408,7 +377,7 @@ export default class ChatModelManager {
         streamUsage: customModel.streamUsage ?? false,
         configuration: {
           baseURL: customModel.baseUrl,
-          fetch: customModel.enableCors ? safeFetch : undefined,
+          fetch: customModel.enableCors ? safeFetchNoThrow : undefined,
           // The OpenAI SDK accepts an explicit null to omit its default auth
           // header while still constructing a client for a keyless endpoint.
           // https://github.com/logancyang/obsidian-copilot/issues/2895
@@ -425,7 +394,7 @@ export default class ChatModelManager {
         ),
         configuration: {
           baseURL: customModel.baseUrl || ProviderInfo[ChatModelProviders.SILICONFLOW].host,
-          fetch: customModel.enableCors ? safeFetch : undefined,
+          fetch: customModel.enableCors ? safeFetchNoThrow : undefined,
         },
         ...this.getOpenAISpecialConfig(modelName, maxTokens, customModel),
       },
@@ -438,7 +407,7 @@ export default class ChatModelManager {
         ),
         configuration: {
           baseURL: BREVILABS_MODELS_BASE_URL,
-          fetch: safeFetch,
+          fetch: safeFetchNoThrow,
           defaultHeaders: BrevilabsClient.getInstance().getPluginVersionHeaders(),
         },
         // Reasoning is opt-in: forward the user's per-model effort pick only for
@@ -465,7 +434,7 @@ export default class ChatModelManager {
         ),
         configuration: {
           baseURL: customModel.baseUrl || ProviderInfo[ChatModelProviders.MISTRAL].host,
-          fetch: customModel.enableCors ? safeFetch : undefined,
+          fetch: customModel.enableCors ? safeFetchNoThrow : undefined,
         },
       },
       [ChatModelProviders.DEEPSEEK]: {
@@ -477,7 +446,7 @@ export default class ChatModelManager {
         ),
         configuration: {
           baseURL: customModel.baseUrl || ProviderInfo[ChatModelProviders.DEEPSEEK].host,
-          fetch: customModel.enableCors ? safeFetch : undefined,
+          fetch: customModel.enableCors ? safeFetchNoThrow : undefined,
         },
       },
     };
@@ -485,16 +454,9 @@ export default class ChatModelManager {
     const selectedProviderConfig =
       providerConfig[customModel.provider as keyof typeof providerConfig] || {};
 
-    // Get provider-specific parameters (like topP, frequencyPenalty) that the provider supports
-    const providerSpecificParams = this.getProviderSpecificParams(
-      customModel.provider as ChatModelProviders,
-      customModel
-    );
-
     const finalConfig = {
       ...baseConfig,
       ...selectedProviderConfig,
-      ...providerSpecificParams,
       ...(maxTokens === undefined ? {} : { maxTokens }),
     };
 
@@ -511,7 +473,7 @@ export default class ChatModelManager {
 
   /**
    * Adds special configuration for OpenAI models that support reasoning
-   * LangChain 0.6.6+ handles most of the token/temperature logic internally
+   * LangChain 0.6.6+ handles most of the token logic internally
    *
    * NOTE: GPT-5 models require Responses API for verbosity parameter to work.
    * The useResponsesApi flag is set automatically in createModelInstance() for GPT-5.
@@ -521,16 +483,9 @@ export default class ChatModelManager {
     maxTokens: number | undefined,
     customModel?: CustomModel
   ): Record<string, unknown> {
-    const settings = getSettings();
     const modelInfo = getModelInfo(modelName);
-    const resolvedTemperature = this.getTemperatureForModel(
-      modelInfo,
-      customModel || ({} as CustomModel),
-      settings
-    );
 
     const config: Record<string, unknown> = {
-      temperature: resolvedTemperature,
       ...(maxTokens === undefined ? {} : { maxTokens }),
     };
 
@@ -558,58 +513,6 @@ export default class ChatModelManager {
     }
 
     return config;
-  }
-
-  /**
-   * Returns provider-specific parameters (like topP, frequencyPenalty) based on what the provider supports
-   * This prevents passing undefined values to providers that don't support them
-   */
-  private getProviderSpecificParams(provider: ChatModelProviders, customModel: CustomModel) {
-    const params: Record<string, unknown> = {};
-
-    // Add topP only if defined
-    if (customModel.topP !== undefined) {
-      // These providers support topP
-      if (
-        [
-          ChatModelProviders.OPENAI,
-          ChatModelProviders.AZURE_OPENAI,
-          ChatModelProviders.ANTHROPIC,
-          ChatModelProviders.GOOGLE,
-          ChatModelProviders.OPENROUTERAI,
-          ChatModelProviders.OLLAMA,
-          ChatModelProviders.LM_STUDIO,
-          ChatModelProviders.OPENAI_FORMAT,
-          ChatModelProviders.MISTRAL,
-          ChatModelProviders.DEEPSEEK,
-          ChatModelProviders.SILICONFLOW,
-        ].includes(provider)
-      ) {
-        params.topP = customModel.topP;
-      }
-    }
-
-    // Add frequencyPenalty only if defined
-    if (customModel.frequencyPenalty !== undefined) {
-      // These providers support frequencyPenalty
-      if (
-        [
-          ChatModelProviders.OPENAI,
-          ChatModelProviders.AZURE_OPENAI,
-          ChatModelProviders.OPENROUTERAI,
-          ChatModelProviders.OLLAMA,
-          ChatModelProviders.LM_STUDIO,
-          ChatModelProviders.OPENAI_FORMAT,
-          ChatModelProviders.MISTRAL,
-          ChatModelProviders.DEEPSEEK,
-          ChatModelProviders.SILICONFLOW,
-        ].includes(provider)
-      ) {
-        params.frequencyPenalty = customModel.frequencyPenalty;
-      }
-    }
-
-    return params;
   }
 
   // Build a map of modelKey to model config
@@ -683,86 +586,6 @@ export default class ChatModelManager {
 
   getActiveModel(): CustomModel | null {
     return ChatModelManager.activeModel;
-  }
-
-  /**
-   * Helper to validate a model config has valid credentials and meets entitlement requirements.
-   * Does NOT check believerExclusive - that's validated at usage time, not selection time.
-   */
-  private isModelConfigValid(model: CustomModel, settings: CopilotSettings): boolean {
-    const modelKey = getModelKeyFromModel(model);
-    const modelInfo = ChatModelManager.modelMap[modelKey];
-
-    // Check if model exists in map and has API key
-    if (!modelInfo || !modelInfo.hasApiKey) {
-      return false;
-    }
-
-    // Check Copilot Plus entitlement requirements (bypassed in self-host mode)
-    if (model.plusExclusive && !isPaidEnabled()) {
-      return false;
-    }
-
-    return true;
-  }
-
-  /**
-   * Resolves the active chat model for temperature override operations.
-   * Uses a single source of truth: getModelKey() -> findCustomModel()
-   * Falls back to first valid model in settings.activeModels if current selection is invalid.
-   *
-   * Note: believerExclusive models are trusted if explicitly selected by the user,
-   * but skipped in fallback to avoid selecting them for non-Believer users.
-   */
-  private resolveModelForTemperatureOverride(): CustomModel {
-    const settings = getSettings();
-
-    // Try to get the user's currently selected model
-    try {
-      const currentModelKey = getModelKey();
-      if (currentModelKey) {
-        const model = findCustomModel(currentModelKey, settings.activeModels);
-
-        // Validate it (trust believerExclusive if user selected it)
-        if (this.isModelConfigValid(model, settings)) {
-          return model;
-        }
-      }
-    } catch {
-      // Model not found or invalid, fall through to fallback
-    }
-
-    // Fallback: Find first valid model in settings.activeModels
-    // Skip believerExclusive models in fallback to avoid selecting them for non-Believer users
-    for (const model of settings.activeModels) {
-      if (model.enabled && !model.believerExclusive && this.isModelConfigValid(model, settings)) {
-        return model;
-      }
-    }
-
-    // No valid model found
-    throw new Error(
-      "No valid chat model available for temperature override. " +
-        "Please check your API key settings and ensure at least one model is properly configured."
-    );
-  }
-
-  /**
-   * langchain 1.0 TypeScript doesn't support temperature override in BaseChatModelCallOptions,
-   * so we need to create a new model instance with the specified temperature.
-   */
-  async getChatModelWithTemperature(temperature: number): Promise<BaseChatModel> {
-    const modelConfig = ChatModelManager.activeModel ?? this.resolveModelForTemperatureOverride();
-
-    // Create a temporary model config with overridden temperature
-    const modelWithTempOverride: CustomModel = {
-      ...modelConfig,
-      temperature,
-    };
-
-    return ChatModelManager.activeModelSource === "bridged"
-      ? await this.createModelInstanceFromBridged(modelWithTempOverride)
-      : await this.createModelInstance(modelWithTempOverride);
   }
 
   async setChatModel(model: CustomModel): Promise<void> {

--- a/src/LLMProviders/embeddingManager.ts
+++ b/src/LLMProviders/embeddingManager.ts
@@ -3,7 +3,7 @@ import { BREVILABS_MODELS_BASE_URL, EmbeddingModelProviders, ProviderInfo } from
 import { CustomError } from "@/error";
 import { logInfo, logWarn } from "@/logger";
 import { getModelKeyFromModel, getSettings, subscribeToSettingsChange } from "@/settings/model";
-import { err2String, safeFetch } from "@/utils";
+import { err2String, safeFetchNoThrow } from "@/utils";
 import { Embeddings } from "@langchain/core/embeddings";
 import { GoogleGenerativeAIEmbeddings } from "@langchain/google-genai";
 import { OllamaEmbeddings } from "@langchain/ollama";
@@ -216,7 +216,7 @@ export default class EmbeddingManager {
         batchSize: getSettings().embeddingBatchSize,
         configuration: {
           baseURL: BREVILABS_MODELS_BASE_URL,
-          fetch: customModel.enableCors ? safeFetch : undefined,
+          fetch: customModel.enableCors ? safeFetchNoThrow : undefined,
         },
       },
       [EmbeddingModelProviders.COPILOT_PLUS_JINA]: {
@@ -228,7 +228,7 @@ export default class EmbeddingManager {
         dimensions: customModel.dimensions,
         baseUrl: BREVILABS_MODELS_BASE_URL + "/embeddings",
         configuration: {
-          fetch: customModel.enableCors ? safeFetch : undefined,
+          fetch: customModel.enableCors ? safeFetchNoThrow : undefined,
         },
       },
       [EmbeddingModelProviders.OPENAI]: {
@@ -238,7 +238,7 @@ export default class EmbeddingManager {
         batchSize: getSettings().embeddingBatchSize,
         configuration: {
           baseURL: customModel.baseUrl,
-          fetch: customModel.enableCors ? safeFetch : undefined,
+          fetch: customModel.enableCors ? safeFetchNoThrow : undefined,
         },
       },
       [EmbeddingModelProviders.COHEREAI]: {
@@ -248,7 +248,7 @@ export default class EmbeddingManager {
         batchSize: getSettings().embeddingBatchSize,
         configuration: {
           baseURL: customModel.baseUrl || ProviderInfo[EmbeddingModelProviders.COHEREAI].host,
-          fetch: customModel.enableCors ? safeFetch : undefined,
+          fetch: customModel.enableCors ? safeFetchNoThrow : undefined,
         },
       },
       [EmbeddingModelProviders.GOOGLE]: {
@@ -278,7 +278,7 @@ export default class EmbeddingManager {
         openAIApiKey: customModel.apiKey || "default-key",
         configuration: {
           baseURL: customModel.baseUrl || "http://localhost:1234/v1",
-          fetch: customModel.enableCors ? safeFetch : undefined,
+          fetch: customModel.enableCors ? safeFetchNoThrow : undefined,
         },
       },
       [EmbeddingModelProviders.OPENAI_FORMAT]: {
@@ -287,7 +287,7 @@ export default class EmbeddingManager {
         batchSize: getSettings().embeddingBatchSize,
         configuration: {
           baseURL: customModel.baseUrl,
-          fetch: customModel.enableCors ? safeFetch : undefined,
+          fetch: customModel.enableCors ? safeFetchNoThrow : undefined,
           dangerouslyAllowBrowser: true,
         },
       },
@@ -297,7 +297,7 @@ export default class EmbeddingManager {
         batchSize: getSettings().embeddingBatchSize,
         configuration: {
           baseURL: customModel.baseUrl || ProviderInfo[EmbeddingModelProviders.SILICONFLOW].host,
-          fetch: customModel.enableCors ? safeFetch : undefined,
+          fetch: customModel.enableCors ? safeFetchNoThrow : undefined,
         },
       },
       [EmbeddingModelProviders.OPENROUTERAI]: {
@@ -306,7 +306,7 @@ export default class EmbeddingManager {
         batchSize: getSettings().embeddingBatchSize,
         configuration: {
           baseURL: customModel.baseUrl || "https://openrouter.ai/api/v1",
-          fetch: customModel.enableCors ? safeFetch : undefined,
+          fetch: customModel.enableCors ? safeFetchNoThrow : undefined,
         },
       },
     };

--- a/src/agentMode/backends/shared/builtinSkillEnv.test.ts
+++ b/src/agentMode/backends/shared/builtinSkillEnv.test.ts
@@ -198,8 +198,8 @@ describe("builtinSkillEnv", () => {
     });
 
     it("https://github.com/Brevilabs/obsidian-copilot-private/issues/121 keeps spawn-time state for unrelated settings changes", () => {
-      const prev = { miyoSearchAll: false, temperature: 0 } as ReturnType<typeof getSettings>;
-      const next = { miyoSearchAll: false, temperature: 1 } as ReturnType<typeof getSettings>;
+      const prev = { miyoSearchAll: false, contextTurns: 5 } as ReturnType<typeof getSettings>;
+      const next = { miyoSearchAll: false, contextTurns: 9 } as ReturnType<typeof getSettings>;
 
       expect(getBuiltinSkillEnvRestartPolicy(prev, next)).toBe("none");
     });

--- a/src/aiParams.ts
+++ b/src/aiParams.ts
@@ -163,7 +163,6 @@ export interface ProjectConfig {
 
 export interface ModelConfig {
   modelName: string;
-  temperature?: number;
   streaming: boolean;
   maxRetries: number;
   maxConcurrency: number;
@@ -209,10 +208,7 @@ export interface CustomModel {
   core?: boolean;
   stream?: boolean;
   streamUsage?: boolean;
-  temperature?: number;
   maxTokens?: number;
-  topP?: number;
-  frequencyPenalty?: number;
 
   // Ollama specific fields
   numCtx?: number;

--- a/src/chainUtils.ts
+++ b/src/chainUtils.ts
@@ -29,10 +29,7 @@ export async function getStandaloneQuestion(
 
   // Wrap the model call with token warning suppression
   return await withSuppressedTokenWarnings(async () => {
-    // Use temperature=0 for deterministic question condensation
-    const chatModel = await ChainOwner.instance
-      .getCurrentChainManager()
-      .chatModelManager.getChatModelWithTemperature(0);
+    const chatModel = ChainOwner.instance.getCurrentChainManager().chatModelManager.getChatModel();
 
     // Use stream() instead of invoke() to avoid LangChain's _generate() path,
     // which triggers tiktoken CDN fetch via _getEstimatedTokenCountFromPrompt.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -967,7 +967,6 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   defaultModelKey: ChatModels.OPENROUTER_GEMINI_2_5_FLASH + "|" + ChatModelProviders.OPENROUTERAI,
   embeddingModelKey:
     EmbeddingModels.OPENROUTER_OPENAI_EMBEDDING_SMALL + "|" + EmbeddingModelProviders.OPENROUTERAI,
-  temperature: DEFAULT_MODEL_SETTING.TEMPERATURE,
   contextTurns: 15,
   userSystemPrompt: "",
   openAIProxyBaseUrl: "",

--- a/src/core/ContextCompactor.ts
+++ b/src/core/ContextCompactor.ts
@@ -22,7 +22,6 @@ import { HumanMessage } from "@langchain/core/messages";
  *
  * ### 2. MAP Phase (Parallel Summarization)
  * Large items (>50k chars) are sent to the LLM for summarization in parallel.
- * - Uses low temperature (0.1) for deterministic output
  * - Max 3 concurrent requests to avoid API overload
  * - Failed summarizations keep original content
  * - If >50% fail, compaction aborts entirely (fail-safe)
@@ -69,8 +68,6 @@ export class ContextCompactor {
   private readonly MIN_ITEM_SIZE = 50000;
   /** Max parallel LLM calls */
   private readonly MAX_CONCURRENCY = 3;
-  /** Low temperature for deterministic summaries */
-  private readonly TEMPERATURE = 0.1;
   /** Max chars per item before truncation */
   private readonly MAX_ITEM_SIZE = 500000;
 
@@ -280,7 +277,7 @@ Summary:`;
       .replace("{path}", item.path)
       .replace("{content}", content);
 
-    const model = await this.chatModelManager.getChatModelWithTemperature(this.TEMPERATURE);
+    const model = this.chatModelManager.getChatModel();
     const response = await model.invoke([new HumanMessage(prompt)]);
 
     return typeof response.content === "string" ? response.content.trim() : "";

--- a/src/modelManagement/chatModel/configuredModelToCustomModel.ts
+++ b/src/modelManagement/chatModel/configuredModelToCustomModel.ts
@@ -108,9 +108,8 @@ function extraString(extras: Record<string, unknown>, key: string): string | und
 /**
  * Build the `CustomModel` for a resolved chat-backend selection.
  *
- * Per-model tuning (temperature, maxTokens, reasoning effort) is left unset.
- * Temperature falls back to the global setting, and `getModelInfo` derives
- * reasoning behavior from the wire model id.
+ * Per-model tuning (maxTokens, reasoning effort) is left unset, and
+ * `getModelInfo` derives reasoning behavior from the wire model id.
  *
  * `maxTokens` is set only for Anthropic, the one provider that will not accept
  * a request without one. Everywhere else it stays unset, because sending a

--- a/src/settings/model.test.ts
+++ b/src/settings/model.test.ts
@@ -718,13 +718,13 @@ describe("model", () => {
       const withRetiredCap = {
         ...DEFAULT_SETTINGS,
         maxTokens: 6000,
-        temperature: 0.4,
+        contextTurns: 4,
       } as unknown as CopilotSettings;
 
       const sanitized = sanitizeSettings(withRetiredCap);
 
       expect("maxTokens" in (sanitized as unknown as Record<string, unknown>)).toBe(false);
-      expect(sanitized.temperature).toBe(0.4);
+      expect(sanitized.contextTurns).toBe(4);
     });
 
     function sanitizeClaudeSlice(autoModePermission: unknown): CopilotSettings {
@@ -1043,7 +1043,7 @@ describe("model", () => {
           baseUrl: "https://proxy.example.test/v1",
           openAIOrgId: "org-model",
           enableCors,
-          temperature: 0.9,
+          displayName: "My renamed model",
         };
         settingsStore.set(settingsAtom, {
           ...DEFAULT_SETTINGS,
@@ -1062,7 +1062,7 @@ describe("model", () => {
         expect(restored!.openAIOrgId).toBe("org-model");
         expect(restored!.enableCors).toBe(enableCors);
         expect(restored!.enabled).toBe(BUILTIN_CHAT_MODELS[0].enabled);
-        expect(restored!.temperature).toBe(BUILTIN_CHAT_MODELS[0].temperature);
+        expect(restored!.displayName).toBe(BUILTIN_CHAT_MODELS[0].displayName);
       }
     );
 

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -73,7 +73,6 @@ export interface CopilotSettings {
   defaultChainType: ChainType;
   defaultModelKey: string;
   embeddingModelKey: string;
-  temperature: number;
   contextTurns: number;
   lastDismissedVersion: string | null;
   // DEPRECATED: Do not use this directly, migrated to file-based system prompts
@@ -698,8 +697,8 @@ function carriesConfiguration(field: string, value: unknown): boolean {
  * Reason: a builtin model's identity and parameters belong to the shipped
  * default, but its credential belongs to the user — and a credential is only
  * usable against the service it was issued for. This narrow allowlist resets
- * preferences such as enabled state and temperature while keeping the retained
- * key pointed where the user aimed it.
+ * preferences such as enabled state while keeping the retained key pointed
+ * where the user aimed it.
  *
  * @param defaultModel - The freshly built default row that owns the identity.
  * @param source - The pre-reset row supplying the credential bundle.
@@ -1000,9 +999,6 @@ export function sanitizeSettings(settings: CopilotSettings): CopilotSettings {
   }
 
   // Stuff in settings are string even when the interface has number type!
-  const temperature = Number(settingsToSanitize.temperature);
-  sanitizedSettings.temperature = isNaN(temperature) ? DEFAULT_SETTINGS.temperature : temperature;
-
   const contextTurns = Number(settingsToSanitize.contextTurns);
   sanitizedSettings.contextTurns = isNaN(contextTurns)
     ? DEFAULT_SETTINGS.contextTurns

--- a/src/settings/resetSettings.integration.test.ts
+++ b/src/settings/resetSettings.integration.test.ts
@@ -94,7 +94,7 @@ describe("model", () => {
         apiKey: "sk-builtin-override",
         baseUrl: "https://proxy.example.test/v1",
         enabled: false,
-        temperature: 0.9,
+        displayName: "My renamed model",
       };
       const customRow: CustomModel = {
         name: "custom-gpt",
@@ -179,7 +179,7 @@ describe("model", () => {
       expect(reloadedBuiltin?.apiKey).toBe("sk-builtin-override");
       expect(reloadedBuiltin?.baseUrl).toBe("https://proxy.example.test/v1");
       expect(reloadedBuiltin?.enabled).toBe(true);
-      expect(reloadedBuiltin?.temperature).toBeUndefined();
+      expect(reloadedBuiltin?.displayName).toBeUndefined();
 
       // Custom row survives whole.
       const reloadedCustom = reloaded.activeModels.find((m) => m.name === "custom-gpt");

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -836,6 +836,12 @@ export async function safeFetch(
  * Wrapper around safeFetch that doesn't throw on HTTP errors (fetch-like behavior).
  * Use this when you need to check response.status for retry logic (e.g., 401 token refresh).
  *
+ * This is also the variant to hand a provider SDK as its `fetch`. `fetch` never
+ * throws on a 4xx, so an SDK given a throwing implementation reads a rejected
+ * request as a dead connection: it reports "Connection error" instead of the
+ * provider's own message and burns its whole retry budget on a request that can
+ * never succeed. https://github.com/logancyang/obsidian-copilot/issues/2959
+ *
  * @remarks
  * Inherits all limitations from safeFetch:
  * - AbortSignal is NOT honored (requests cannot be cancelled)

--- a/src/utils/modelParamsHelper.ts
+++ b/src/utils/modelParamsHelper.ts
@@ -1,18 +1,6 @@
 import { DEFAULT_MODEL_SETTING, ReasoningEffort, Verbosity } from "@/constants";
 
 /**
- * Model parameters configuration interface
- */
-export interface ModelParams {
-  temperature?: number;
-  topP?: number;
-  frequencyPenalty?: number;
-  maxTokens?: number;
-  reasoningEffort?: ReasoningEffort;
-  verbosity?: Verbosity;
-}
-
-/**
  * Reasoning effort options configuration
  */
 export const REASONING_EFFORT_OPTIONS = [


### PR DESCRIPTION
Fixes #2959

## Why

Quick Chat cannot reach any Moonshot Kimi model added with a user's own API key. Every message comes back as `Connection error.` while the same models answer normally in Agent mode. The reporter tried toggling the provider's CORS setting, re-entering the key, and removing and re-adding the provider; none of it helped, and nothing in the message said why.

Two faults stack up. Copilot puts `temperature: 0.1` on every chat request, and Moonshot's Kimi K2.5 and newer line accepts only `1`, so the API answers `400 invalid temperature: only 1 is allowed for this model`. Nobody chose that 0.1. Copilot has no temperature control anywhere in settings, and the same is true of `top_p` and `frequency_penalty`: all three were values the plugin asserted on the user's behalf, with per model family exceptions guessed around them (force `1` for OpenAI reasoning models, send nothing for Anthropic thinking models) and per provider allowlists deciding who got `top_p` and `frequency_penalty` at all.

The 400 then never reached the user. `safeFetch` throws on any 4xx, but `fetch` never does, so the SDK given it read the rejection as a dead connection: it raised `APIConnectionError: Connection error.`, left the provider's sentence in `error.cause`, and retried the doomed request three more times before giving up. That masking applies to every provider rejection, not just this one.

## What

Copilot sends no `temperature`, `top_p`, or `frequency_penalty`, and each provider applies its own defaults. The per family guesses go away with them, as do the temperature-override path that forced `0` for question condensation and `0.1` for context compaction (values the same models reject) and the per-provider allowlists that existed only to forward the other two.

A rejected request now fails once, carrying what the provider actually said.

| Scenario | Before | After |
| --- | --- | --- |
| Quick Chat with a BYOK Kimi model | `Connection error.` on every message | The model answers |
| Any provider rejects a request | `Connection error.`, real reason buried in `error.cause` | `400 invalid temperature: only 1 is allowed for this model` |
| A rejected request | Sent 4 times before failing | Sent once |
| Sampling on every model | Copilot's fixed 0.1, plus `top_p` / `frequency_penalty` where a per-provider list allowed them | The provider's own defaults |

## Non goal

- No user-facing control for any sampling parameter. Suggested follow-up: Expose per-model sampling settings.
- No automatic retry that drops a parameter a provider rejected. Suggested follow-up: Retry once without temperature when a provider rejects the value.
- Agent mode is untouched; it reaches these models over a different path and already worked.
- The inert `copilot-project-temperature` frontmatter key still round-trips, so project files written by earlier versions are unchanged.
- Persisted `temperature`, `topP`, and `frequencyPenalty` values in `data.json` are left in place rather than scrubbed, so a revert restores prior state exactly.

## Screenshot

No screenshot. The changed surface is the HTTP request body and the error text a rejection produces, and reaching the error state in the app needs a configured BYOK Moonshot provider plus a live rejection, which cannot be driven headlessly here. The evidence is the wire traffic instead, captured by running this branch against live provider APIs through the real chat path.

Before, request and response:

```
{"model":"kimi-k3","temperature":0.1,"stream":false,"messages":[...]}
400 {"error":{"message":"invalid temperature: only 1 is allowed for this model",...}}
(same request sent 4 times)
APIConnectionError: "Connection error."
```

After, same model and same key:

```
{"model":"kimi-k3","stream":false,"messages":[...]}
200 {"choices":[{"message":{"role":"assistant","content":"ok"}}],...}
```

Sixteen live requests on this branch, every provider path there is a key for, streaming and non-streaming. Each row is `temperature | top_p | frequency_penalty` in the outgoing body:

```
OpenAI  gpt-4.1-mini                    ABSENT | ABSENT | ABSENT   200  answered
OpenAI  gpt-5.5 (Responses API)         ABSENT | ABSENT | ABSENT   200  answered
OpenAI  gpt-5.4-mini (Responses API)    ABSENT | ABSENT | ABSENT   200  answered
Anthropic  claude-haiku-4-5             ABSENT | ABSENT | ABSENT   200  answered
Anthropic  claude-sonnet-4-5 (thinking) ABSENT | ABSENT | ABSENT   200  answered
OpenRouter  google/gemini-2.5-flash     ABSENT | ABSENT | ABSENT   200  answered
OpenRouter  anthropic/claude-haiku-4.5  ABSENT | ABSENT | ABSENT   200  answered
OpenRouter  deepseek/deepseek-chat      ABSENT | ABSENT | ABSENT   200  answered
Copilot Plus relay  copilot-plus-flash  ABSENT | ABSENT | ABSENT   200  answered
Copilot Plus relay  kimi-k2.6           ABSENT | ABSENT | ABSENT   200  answered
Moonshot BYOK  kimi-k3                  ABSENT | ABSENT | ABSENT   200  answered
+ streaming repeats of one model per provider family, all identical
```

And the error text a user now sees when a provider does reject a request, from the same harness with the temperature forced back on:

```
BadRequestError: 400 invalid temperature: only 1 is allowed for this model
```

## Risk

**Medium**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | `chatModelManager.requestBody.test.ts` asserts the real OpenAI and Anthropic request bodies carry none of the three parameters, that a 400 surfaces the provider's sentence and not `Connection error`, and that a rejected request is sent once |
| A defect would fail CI or be obvious on first use | ✅ | A sampling parameter reappearing in the payload fails the body tests; a re-masked error fails the error test; both run in CI |
| A revert fully restores prior state, including persisted data | ✅ | Nothing is written or removed on disk; persisted values are deliberately left untouched so a revert reads them again |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Credential resolution and every API key path are unchanged |
| No public API, plugin API, message, or on-disk contract changes | ✅ | The three fields are dropped from the `CopilotSettings` and `CustomModel` types only; an existing `data.json` still loads, with retired keys ignored rather than rejected |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Two call sites move from an async model builder to the synchronous `getChatModel()`; no ordering or shared state changes |
| No hot-path behavior lacks deterministic coverage | ✅ | The chat request body is the hot path and is asserted on the wire, and was additionally exercised live against five provider paths |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ❌ | Sampling moves to provider defaults for every chat model, and whether answers read differently is a judgment only a person can make, though any regression shows on the first message |

Review: read `getModelConfig` and `getOpenAISpecialConfig` in `src/LLMProviders/chatModelManager.ts` to confirm no sampling parameter can re-enter the payload, and the `safeFetchNoThrow` JSDoc in `src/utils.ts` for why the SDK-facing fetch must not throw. Then run Verification steps 2 and 4, and step 5 for the sampling change the failed criterion names.

## Verification

1. Build this branch into a test vault and open Copilot.
2. Under Settings > Copilot > BYOK, add Moonshot AI with a Moonshot API key, enable `kimi-k3`, and select it in Quick Chat. Send a message. It answers, where before it returned `Connection error.`
3. Repeat with `kimi-k2.6` and `kimi-k2.7-code`. All three answer.
4. Edit the provider's model id to something the provider does not serve, then send a message. The chat shows the provider's own rejection text, and the dev console shows one failed request rather than four.
5. Switch to any OpenAI, Anthropic, or OpenRouter model and send a few messages. They answer as before, now at the provider's default sampling.
