### PR TITLE
Collapse very long user messages behind a Show more control

### DIFF
--- a/docs/chat-interface.md
+++ b/docs/chat-interface.md
@@ -32,6 +32,8 @@ Hover over a message to use its actions:
 - Your messages: **Copy**, **Edit**, and **Delete**.
 - Copilot responses: **Insert / Replace at cursor**, **Copy**, **Regenerate**, and **Delete**.
 
+Your messages collapse after 12 lines. Select **Show more** to read the full message or **Show less** to collapse it again. Copy and Edit still use the complete message.
+
 After a response, the token counter in the top bar shows the context used for the latest response when the provider reports token usage.
 
 ## Start or reopen a chat

--- a/src/components/chat-components/ChatSingleMessage.test.tsx
+++ b/src/components/chat-components/ChatSingleMessage.test.tsx
@@ -260,6 +260,25 @@ describe("normalizeFootnoteRendering", () => {
   });
 });
 
+/**
+ * JSDOM lays nothing out, so a message body always measures zero. Forcing the
+ * natural height is what puts a message over or under the collapse threshold.
+ */
+function stubContentHeight(heightPx: number): () => void {
+  const original = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "scrollHeight");
+  Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+    configurable: true,
+    get: () => heightPx,
+  });
+  return () => {
+    if (original) {
+      Object.defineProperty(HTMLElement.prototype, "scrollHeight", original);
+    } else {
+      Reflect.deleteProperty(HTMLElement.prototype, "scrollHeight");
+    }
+  };
+}
+
 describe("ChatSingleMessage", () => {
   const baseMessage: ChatMessage = {
     id: "message-1",
@@ -452,5 +471,71 @@ describe("ChatSingleMessage", () => {
       </TooltipProvider>
     );
     expect(screen.getByText(timestamp)).toBeTruthy();
+  });
+  it("collapses an oversized user message behind a Show more control (https://github.com/Brevilabs/obsidian-copilot-private/issues/151)", () => {
+    const restoreContentHeight = stubContentHeight(2000);
+
+    try {
+      render(
+        <TooltipProvider>
+          <ChatSingleMessage
+            message={{ ...baseMessage, sender: "user", message: "A very long pasted prompt" }}
+            app={createAppStub()}
+            isStreaming={false}
+          />
+        </TooltipProvider>
+      );
+
+      expect(screen.getByTestId("clamped-content").style.maxHeight).not.toBe("");
+      expect(screen.getByRole("button", { name: /show more/i })).toBeTruthy();
+      // The body stays mounted so Copy and text selection still see it all.
+      expect(screen.getByText("A very long pasted prompt")).toBeTruthy();
+    } finally {
+      restoreContentHeight();
+    }
+  });
+
+  it("leaves a short user message uncollapsed", () => {
+    const restoreContentHeight = stubContentHeight(40);
+
+    try {
+      render(
+        <TooltipProvider>
+          <ChatSingleMessage
+            message={{ ...baseMessage, sender: "user", message: "Hi" }}
+            app={createAppStub()}
+            isStreaming={false}
+          />
+        </TooltipProvider>
+      );
+
+      expect(screen.getByTestId("clamped-content").style.maxHeight).toBe("");
+      expect(screen.queryByRole("button", { name: /show more/i })).toBeNull();
+    } finally {
+      restoreContentHeight();
+    }
+  });
+
+  it("never collapses an assistant message, whose trail owns its own folding", async () => {
+    const restoreContentHeight = stubContentHeight(2000);
+
+    try {
+      render(
+        <TooltipProvider>
+          <ChatSingleMessage
+            message={{ ...baseMessage, message: "A very long answer" }}
+            app={createAppStub()}
+            isStreaming={false}
+          />
+        </TooltipProvider>
+      );
+
+      await waitFor(() => expect(renderMarkdownMock).toHaveBeenCalled());
+
+      expect(screen.queryByTestId("clamped-content")).toBeNull();
+      expect(screen.queryByRole("button", { name: /show more/i })).toBeNull();
+    } finally {
+      restoreContentHeight();
+    }
   });
 });

--- a/src/components/chat-components/ChatSingleMessage.test.tsx
+++ b/src/components/chat-components/ChatSingleMessage.test.tsx
@@ -260,21 +260,33 @@ describe("normalizeFootnoteRendering", () => {
   });
 });
 
-/**
- * JSDOM lays nothing out, so a message body always measures zero. Forcing the
- * natural height is what puts a message over or under the collapse threshold.
- */
-function stubContentHeight(heightPx: number): () => void {
-  const original = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "scrollHeight");
+function stubContentDimensions(scrollHeightPx: number, clientHeightPx: number): () => void {
+  const originalScrollHeight = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "scrollHeight"
+  );
+  const originalClientHeight = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "clientHeight"
+  );
   Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
     configurable: true,
-    get: () => heightPx,
+    get: () => scrollHeightPx,
+  });
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+    configurable: true,
+    get: () => clientHeightPx,
   });
   return () => {
-    if (original) {
-      Object.defineProperty(HTMLElement.prototype, "scrollHeight", original);
+    if (originalScrollHeight) {
+      Object.defineProperty(HTMLElement.prototype, "scrollHeight", originalScrollHeight);
     } else {
       Reflect.deleteProperty(HTMLElement.prototype, "scrollHeight");
+    }
+    if (originalClientHeight) {
+      Object.defineProperty(HTMLElement.prototype, "clientHeight", originalClientHeight);
+    } else {
+      Reflect.deleteProperty(HTMLElement.prototype, "clientHeight");
     }
   };
 }
@@ -473,7 +485,7 @@ describe("ChatSingleMessage", () => {
     expect(screen.getByText(timestamp)).toBeTruthy();
   });
   it("collapses an oversized user message behind a Show more control (https://github.com/Brevilabs/obsidian-copilot-private/issues/151)", () => {
-    const restoreContentHeight = stubContentHeight(2000);
+    const restoreContentHeight = stubContentDimensions(2000, 240);
 
     try {
       render(
@@ -486,7 +498,9 @@ describe("ChatSingleMessage", () => {
         </TooltipProvider>
       );
 
-      expect(screen.getByTestId("clamped-content").style.maxHeight).not.toBe("");
+      expect(screen.getByTestId("clamped-content").classList.contains("tw-max-h-[12lh]")).toBe(
+        true
+      );
       expect(screen.getByRole("button", { name: /show more/i })).toBeTruthy();
       // The body stays mounted so Copy and text selection still see it all.
       expect(screen.getByText("A very long pasted prompt")).toBeTruthy();
@@ -495,8 +509,8 @@ describe("ChatSingleMessage", () => {
     }
   });
 
-  it("leaves a short user message uncollapsed", () => {
-    const restoreContentHeight = stubContentHeight(40);
+  it("leaves a short user message without an expand control (https://github.com/Brevilabs/obsidian-copilot-private/issues/151)", () => {
+    const restoreContentHeight = stubContentDimensions(40, 40);
 
     try {
       render(
@@ -509,15 +523,15 @@ describe("ChatSingleMessage", () => {
         </TooltipProvider>
       );
 
-      expect(screen.getByTestId("clamped-content").style.maxHeight).toBe("");
+      expect(screen.getByTestId("clamped-content").getAttribute("style")).toBeNull();
       expect(screen.queryByRole("button", { name: /show more/i })).toBeNull();
     } finally {
       restoreContentHeight();
     }
   });
 
-  it("never collapses an assistant message, whose trail owns its own folding", async () => {
-    const restoreContentHeight = stubContentHeight(2000);
+  it("never collapses an assistant message, whose trail owns its own folding (https://github.com/Brevilabs/obsidian-copilot-private/issues/151)", async () => {
+    const restoreContentHeight = stubContentDimensions(2000, 240);
 
     try {
       render(

--- a/src/components/chat-components/ChatSingleMessage.tsx
+++ b/src/components/chat-components/ChatSingleMessage.tsx
@@ -56,7 +56,7 @@ const FOOTNOTE_SUFFIX_PATTERN = /^\d+-\d+$/;
  * off the chat surface, so a user message taller than this collapses behind a
  * Show more control: https://github.com/Brevilabs/obsidian-copilot-private/issues/151
  */
-const COLLAPSED_USER_MESSAGE_LINES = 12;
+const COLLAPSED_USER_MESSAGE_CLASS_NAME = cn("tw-max-h-[12lh]");
 
 /**
  * Normalizes rendered markdown footnotes to align with inline citation UX.
@@ -1006,7 +1006,7 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
 
           <div className="message-content tw-break-words !tw-leading-[1.6]">
             {message.sender === USER_SENDER ? (
-              <ClampedContent collapsedLines={COLLAPSED_USER_MESSAGE_LINES}>
+              <ClampedContent collapsedClassName={COLLAPSED_USER_MESSAGE_CLASS_NAME}>
                 {renderMessageContent()}
               </ClampedContent>
             ) : (

--- a/src/components/chat-components/ChatSingleMessage.tsx
+++ b/src/components/chat-components/ChatSingleMessage.tsx
@@ -27,6 +27,7 @@ import {
   type ToolCallRootRecord,
 } from "@/components/chat-components/toolCallRootManager";
 import { AgentReasoningBlock } from "@/components/chat-components/AgentReasoningBlock";
+import { ClampedContent } from "@/components/ui/clamped-content";
 import { USER_SENDER } from "@/constants";
 import { cn } from "@/lib/utils";
 import { parseToolCallMarkers } from "@/LLMProviders/chainRunner/utils/toolCallParser";
@@ -49,6 +50,13 @@ import {
 } from "@/components/chat-components/collapsibleStateUtils";
 
 const FOOTNOTE_SUFFIX_PATTERN = /^\d+-\d+$/;
+
+/**
+ * A pasted prompt, log, or transcript pushes the reply and every earlier turn
+ * off the chat surface, so a user message taller than this collapses behind a
+ * Show more control: https://github.com/Brevilabs/obsidian-copilot-private/issues/151
+ */
+const COLLAPSED_USER_MESSAGE_LINES = 12;
 
 /**
  * Normalizes rendered markdown footnotes to align with inline citation UX.
@@ -997,7 +1005,13 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
           )}
 
           <div className="message-content tw-break-words !tw-leading-[1.6]">
-            {renderMessageContent()}
+            {message.sender === USER_SENDER ? (
+              <ClampedContent collapsedLines={COLLAPSED_USER_MESSAGE_LINES}>
+                {renderMessageContent()}
+              </ClampedContent>
+            ) : (
+              renderMessageContent()
+            )}
           </div>
 
           {!isStreaming && (

--- a/src/components/ui/clamped-content.stories.tsx
+++ b/src/components/ui/clamped-content.stories.tsx
@@ -29,7 +29,7 @@ const MessageBubble: React.FC<{ children: React.ReactNode }> = ({ children }) =>
 export const Collapsed: StoryObj<ClampedContentProps> = {
   render: () => (
     <MessageBubble>
-      <ClampedContent collapsedLines={12}>{LONG_PROMPT}</ClampedContent>
+      <ClampedContent collapsedClassName="tw-max-h-[12lh]">{LONG_PROMPT}</ClampedContent>
     </MessageBubble>
   ),
 };
@@ -38,7 +38,7 @@ export const Collapsed: StoryObj<ClampedContentProps> = {
 export const FitsWithoutControl: StoryObj<ClampedContentProps> = {
   render: () => (
     <MessageBubble>
-      <ClampedContent collapsedLines={12}>
+      <ClampedContent collapsedClassName="tw-max-h-[12lh]">
         Summarize the notes I touched this week and group them by project.
       </ClampedContent>
     </MessageBubble>
@@ -49,7 +49,7 @@ export const FitsWithoutControl: StoryObj<ClampedContentProps> = {
 export const ThreeLineClamp: StoryObj<ClampedContentProps> = {
   render: () => (
     <MessageBubble>
-      <ClampedContent collapsedLines={3}>{LONG_PROMPT}</ClampedContent>
+      <ClampedContent collapsedClassName="tw-max-h-[3lh]">{LONG_PROMPT}</ClampedContent>
     </MessageBubble>
   ),
 };

--- a/src/components/ui/clamped-content.stories.tsx
+++ b/src/components/ui/clamped-content.stories.tsx
@@ -1,0 +1,55 @@
+import { ClampedContent, type ClampedContentProps } from "@/components/ui/clamped-content";
+import type { Meta, StoryObj } from "@/lib/story";
+import React from "react";
+
+const meta = {
+  title: "Chat/Clamped Content",
+  component: ClampedContent,
+  parameters: { gallery: { host: "leaf", layout: "padded" } },
+} satisfies Meta<ClampedContentProps>;
+export default meta;
+
+const LONG_PROMPT = `I want to brainstorm an idea with you. Right now I have new data coming in from several places while maintaining the community: new issues on GitHub, new posts in the feedback channel, and the occasional long thread that never gets read twice.
+
+I would like a local routine that studies the codebase, checks the other open issues, collects whatever context it needs, and drafts a reply worth sending.
+
+Because the feedback is public, I do not want the bot to post anything as-is. I want it to hold its draft, explain what it based the draft on, and wait for a human to agree before anything leaves the machine.
+
+The failure mode I am trying to avoid is the one where the agent quietly finishes, raises nothing, and nobody ever learns that a job was stuck. Silence should not be the same signal as success.
+
+So the shape I am after is: gather, draft, surface, wait. The surfacing step is the one every tool I have tried so far gets wrong.`;
+
+const MessageBubble: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div className="tw-rounded-md tw-border tw-border-solid tw-border-border tw-bg-secondary tw-p-2">
+    <div className="tw-whitespace-pre-wrap tw-break-words !tw-leading-[1.6]">{children}</div>
+  </div>
+);
+
+/** A pasted prompt collapses to its first lines until the reader opens it. */
+export const Collapsed: StoryObj<ClampedContentProps> = {
+  render: () => (
+    <MessageBubble>
+      <ClampedContent collapsedLines={12}>{LONG_PROMPT}</ClampedContent>
+    </MessageBubble>
+  ),
+};
+
+/** A short message stays exactly as written, with no control added. */
+export const FitsWithoutControl: StoryObj<ClampedContentProps> = {
+  render: () => (
+    <MessageBubble>
+      <ClampedContent collapsedLines={12}>
+        Summarize the notes I touched this week and group them by project.
+      </ClampedContent>
+    </MessageBubble>
+  ),
+};
+
+/** A tight budget shows how little content the clamp can leave visible. */
+export const ThreeLineClamp: StoryObj<ClampedContentProps> = {
+  render: () => (
+    <MessageBubble>
+      <ClampedContent collapsedLines={3}>{LONG_PROMPT}</ClampedContent>
+    </MessageBubble>
+  ),
+};

--- a/src/components/ui/clamped-content.test.tsx
+++ b/src/components/ui/clamped-content.test.tsx
@@ -2,22 +2,33 @@ import { ClampedContent } from "@/components/ui/clamped-content";
 import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 
-/**
- * JSDOM lays nothing out, so `scrollHeight` is always 0 and computed
- * `line-height` is `normal`. Stubbing the natural content height is what lets a
- * test choose whether the content sits over or under the clamp.
- */
-function stubContentHeight(heightPx: number): () => void {
-  const original = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "scrollHeight");
+function stubContentDimensions(scrollHeightPx: number, clientHeightPx: number): () => void {
+  const originalScrollHeight = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "scrollHeight"
+  );
+  const originalClientHeight = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "clientHeight"
+  );
   Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
     configurable: true,
-    get: () => heightPx,
+    get: () => scrollHeightPx,
+  });
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+    configurable: true,
+    get: () => clientHeightPx,
   });
   return () => {
-    if (original) {
-      Object.defineProperty(HTMLElement.prototype, "scrollHeight", original);
+    if (originalScrollHeight) {
+      Object.defineProperty(HTMLElement.prototype, "scrollHeight", originalScrollHeight);
     } else {
       Reflect.deleteProperty(HTMLElement.prototype, "scrollHeight");
+    }
+    if (originalClientHeight) {
+      Object.defineProperty(HTMLElement.prototype, "clientHeight", originalClientHeight);
+    } else {
+      Reflect.deleteProperty(HTMLElement.prototype, "clientHeight");
     }
   };
 }
@@ -31,24 +42,24 @@ describe("clamped-content", () => {
       restoreContentHeight = undefined;
     });
 
-    it("renders content that fits without any expand control", () => {
-      // 3 lines at the 20px fallback line height stays under a 5-line clamp.
-      restoreContentHeight = stubContentHeight(60);
+    it("renders content that fits without any expand control (https://github.com/Brevilabs/obsidian-copilot-private/issues/151)", () => {
+      restoreContentHeight = stubContentDimensions(60, 60);
 
-      render(<ClampedContent collapsedLines={5}>Short message</ClampedContent>);
+      render(<ClampedContent collapsedClassName="tw-max-h-[5lh]">Short message</ClampedContent>);
 
       expect(screen.queryByText("Short message")).not.toBeNull();
       expect(screen.queryByRole("button")).toBeNull();
-      expect(screen.getByTestId("clamped-content").style.maxHeight).toBe("");
+      expect(screen.getByTestId("clamped-content").getAttribute("style")).toBeNull();
     });
 
-    it("clips content taller than the clamp to the line budget and offers Show more", () => {
-      restoreContentHeight = stubContentHeight(1000);
+    it("clips content taller than the CSS cap and offers Show more (https://github.com/Brevilabs/obsidian-copilot-private/issues/151)", () => {
+      restoreContentHeight = stubContentDimensions(1000, 100);
 
-      render(<ClampedContent collapsedLines={5}>Very long message</ClampedContent>);
+      render(
+        <ClampedContent collapsedClassName="tw-max-h-[5lh]">Very long message</ClampedContent>
+      );
 
-      // 5 lines at the 20px fallback line height.
-      expect(screen.getByTestId("clamped-content").style.maxHeight).toBe("100px");
+      expect(screen.getByTestId("clamped-content").classList.contains("tw-max-h-[5lh]")).toBe(true);
       expect(screen.getByRole("button", { name: /show more/i }).getAttribute("aria-expanded")).toBe(
         "false"
       );
@@ -56,27 +67,33 @@ describe("clamped-content", () => {
       expect(screen.queryByText("Very long message")).not.toBeNull();
     });
 
-    it("removes the height cap when expanded and restores it when collapsed again", () => {
-      restoreContentHeight = stubContentHeight(1000);
+    it("removes the CSS cap when expanded and restores it when collapsed again (https://github.com/Brevilabs/obsidian-copilot-private/issues/151)", () => {
+      restoreContentHeight = stubContentDimensions(1000, 100);
 
-      render(<ClampedContent collapsedLines={5}>Very long message</ClampedContent>);
+      render(
+        <ClampedContent collapsedClassName="tw-max-h-[5lh]">Very long message</ClampedContent>
+      );
 
       fireEvent.click(screen.getByRole("button", { name: /show more/i }));
 
-      expect(screen.getByTestId("clamped-content").style.maxHeight).toBe("");
+      expect(screen.getByTestId("clamped-content").classList.contains("tw-max-h-[5lh]")).toBe(
+        false
+      );
       const collapseButton = screen.getByRole("button", { name: /show less/i });
       expect(collapseButton.getAttribute("aria-expanded")).toBe("true");
 
       fireEvent.click(collapseButton);
 
-      expect(screen.getByTestId("clamped-content").style.maxHeight).toBe("100px");
+      expect(screen.getByTestId("clamped-content").classList.contains("tw-max-h-[5lh]")).toBe(true);
       expect(screen.queryByRole("button", { name: /show more/i })).not.toBeNull();
     });
 
-    it("points the toggle at the region it controls", () => {
-      restoreContentHeight = stubContentHeight(1000);
+    it("points the toggle at the region it controls (https://github.com/Brevilabs/obsidian-copilot-private/issues/151)", () => {
+      restoreContentHeight = stubContentDimensions(1000, 100);
 
-      render(<ClampedContent collapsedLines={5}>Very long message</ClampedContent>);
+      render(
+        <ClampedContent collapsedClassName="tw-max-h-[5lh]">Very long message</ClampedContent>
+      );
 
       const region = screen.getByTestId("clamped-content");
       expect(region.id).not.toBe("");
@@ -85,19 +102,16 @@ describe("clamped-content", () => {
       );
     });
 
-    it("derives the height cap from the measured line height rather than a fixed size", () => {
-      restoreContentHeight = stubContentHeight(1000);
-      const computedStyle = jest
-        .spyOn(window, "getComputedStyle")
-        .mockReturnValue({ lineHeight: "30px" } as CSSStyleDeclaration);
+    it("uses the caller's CSS cap without writing inline styles (https://github.com/Brevilabs/obsidian-copilot-private/issues/151)", () => {
+      restoreContentHeight = stubContentDimensions(1000, 80);
 
-      try {
-        render(<ClampedContent collapsedLines={4}>Very long message</ClampedContent>);
+      render(
+        <ClampedContent collapsedClassName="tw-max-h-[4lh]">Very long message</ClampedContent>
+      );
 
-        expect(screen.getByTestId("clamped-content").style.maxHeight).toBe("120px");
-      } finally {
-        computedStyle.mockRestore();
-      }
+      const content = screen.getByTestId("clamped-content");
+      expect(content.classList.contains("tw-max-h-[4lh]")).toBe(true);
+      expect(content.getAttribute("style")).toBeNull();
     });
   });
 });

--- a/src/components/ui/clamped-content.test.tsx
+++ b/src/components/ui/clamped-content.test.tsx
@@ -1,0 +1,103 @@
+import { ClampedContent } from "@/components/ui/clamped-content";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+/**
+ * JSDOM lays nothing out, so `scrollHeight` is always 0 and computed
+ * `line-height` is `normal`. Stubbing the natural content height is what lets a
+ * test choose whether the content sits over or under the clamp.
+ */
+function stubContentHeight(heightPx: number): () => void {
+  const original = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "scrollHeight");
+  Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+    configurable: true,
+    get: () => heightPx,
+  });
+  return () => {
+    if (original) {
+      Object.defineProperty(HTMLElement.prototype, "scrollHeight", original);
+    } else {
+      Reflect.deleteProperty(HTMLElement.prototype, "scrollHeight");
+    }
+  };
+}
+
+describe("clamped-content", () => {
+  describe("ClampedContent()", () => {
+    let restoreContentHeight: (() => void) | undefined;
+
+    afterEach(() => {
+      restoreContentHeight?.();
+      restoreContentHeight = undefined;
+    });
+
+    it("renders content that fits without any expand control", () => {
+      // 3 lines at the 20px fallback line height stays under a 5-line clamp.
+      restoreContentHeight = stubContentHeight(60);
+
+      render(<ClampedContent collapsedLines={5}>Short message</ClampedContent>);
+
+      expect(screen.queryByText("Short message")).not.toBeNull();
+      expect(screen.queryByRole("button")).toBeNull();
+      expect(screen.getByTestId("clamped-content").style.maxHeight).toBe("");
+    });
+
+    it("clips content taller than the clamp to the line budget and offers Show more", () => {
+      restoreContentHeight = stubContentHeight(1000);
+
+      render(<ClampedContent collapsedLines={5}>Very long message</ClampedContent>);
+
+      // 5 lines at the 20px fallback line height.
+      expect(screen.getByTestId("clamped-content").style.maxHeight).toBe("100px");
+      expect(screen.getByRole("button", { name: /show more/i }).getAttribute("aria-expanded")).toBe(
+        "false"
+      );
+      // Clipping is visual only, so copy and text selection still see it all.
+      expect(screen.queryByText("Very long message")).not.toBeNull();
+    });
+
+    it("removes the height cap when expanded and restores it when collapsed again", () => {
+      restoreContentHeight = stubContentHeight(1000);
+
+      render(<ClampedContent collapsedLines={5}>Very long message</ClampedContent>);
+
+      fireEvent.click(screen.getByRole("button", { name: /show more/i }));
+
+      expect(screen.getByTestId("clamped-content").style.maxHeight).toBe("");
+      const collapseButton = screen.getByRole("button", { name: /show less/i });
+      expect(collapseButton.getAttribute("aria-expanded")).toBe("true");
+
+      fireEvent.click(collapseButton);
+
+      expect(screen.getByTestId("clamped-content").style.maxHeight).toBe("100px");
+      expect(screen.queryByRole("button", { name: /show more/i })).not.toBeNull();
+    });
+
+    it("points the toggle at the region it controls", () => {
+      restoreContentHeight = stubContentHeight(1000);
+
+      render(<ClampedContent collapsedLines={5}>Very long message</ClampedContent>);
+
+      const region = screen.getByTestId("clamped-content");
+      expect(region.id).not.toBe("");
+      expect(screen.getByRole("button", { name: /show more/i }).getAttribute("aria-controls")).toBe(
+        region.id
+      );
+    });
+
+    it("derives the height cap from the measured line height rather than a fixed size", () => {
+      restoreContentHeight = stubContentHeight(1000);
+      const computedStyle = jest
+        .spyOn(window, "getComputedStyle")
+        .mockReturnValue({ lineHeight: "30px" } as CSSStyleDeclaration);
+
+      try {
+        render(<ClampedContent collapsedLines={4}>Very long message</ClampedContent>);
+
+        expect(screen.getByTestId("clamped-content").style.maxHeight).toBe("120px");
+      } finally {
+        computedStyle.mockRestore();
+      }
+    });
+  });
+});

--- a/src/components/ui/clamped-content.tsx
+++ b/src/components/ui/clamped-content.tsx
@@ -1,77 +1,63 @@
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import React, { useId, useLayoutEffect, useRef, useState } from "react";
 
-/**
- * Line height assumed when the computed `line-height` is not a length, which is
- * what `normal` resolves to whenever no ancestor sets one. Without it every
- * comparison against `NaN` is false, so the clamp would silently never engage
- * and oversized content would render at full height.
- */
-const FALLBACK_LINE_HEIGHT_PX = 20;
+const OVERFLOW_TOLERANCE_PX = 1;
 
 export interface ClampedContentProps {
   /**
-   * How many lines stay visible while collapsed. The pixel cap is derived from
-   * the content's own computed `line-height`, so the clamp tracks the reader's
-   * font size rather than freezing at one theme's metrics.
+   * CSS class that caps the content while collapsed. Keep the class literal at
+   * the call site so Tailwind can generate it.
    */
-  collapsedLines: number;
+  collapsedClassName: string;
   children: React.ReactNode;
 }
 
 /**
- * Clips content taller than `collapsedLines` and offers an explicit expand and
- * collapse control, so a single oversized block cannot bury what surrounds it.
- * Content that already fits renders untouched and shows no control.
+ * Clips overflowing content and offers an explicit expand and collapse control.
+ *
+ * @param props - Content and the CSS class that defines its collapsed cap.
+ * @param props.children - Content that may need to be collapsed.
+ * @param props.collapsedClassName - CSS class applied while the content is collapsed.
  */
-export const ClampedContent: React.FC<ClampedContentProps> = ({ collapsedLines, children }) => {
+export const ClampedContent: React.FC<ClampedContentProps> = ({ collapsedClassName, children }) => {
   const contentRef = useRef<HTMLDivElement>(null);
   const [isExpanded, setIsExpanded] = useState(false);
-  // `null` means the content fits, which is also the state that hides the toggle.
-  const [clampHeightPx, setClampHeightPx] = useState<number | null>(null);
+  const [isOverflowing, setIsOverflowing] = useState(false);
   const contentId = useId();
 
   useLayoutEffect(() => {
     const content = contentRef.current;
-    if (!content) return;
+    // Expanded content has no height cap, so measuring it would hide the control
+    // needed to collapse it again: https://github.com/Brevilabs/obsidian-copilot-private/issues/151
+    if (!content || isExpanded) return;
 
     const measure = () => {
-      // Read styles through the element's own realm: chat also renders inside
-      // Obsidian popout windows, where the ambient `window` is a different one.
-      const view = content.ownerDocument.defaultView;
-      const lineHeightPx = view
-        ? Number.parseFloat(view.getComputedStyle(content).lineHeight)
-        : Number.NaN;
-      const limitPx =
-        (Number.isFinite(lineHeightPx) ? lineHeightPx : FALLBACK_LINE_HEIGHT_PX) * collapsedLines;
-      setClampHeightPx(content.scrollHeight > limitPx ? limitPx : null);
+      setIsOverflowing(content.scrollHeight > content.clientHeight + OVERFLOW_TOLERANCE_PX);
     };
 
     measure();
 
-    // Guard for test/JSDOM environments where ResizeObserver may not exist.
-    if (typeof ResizeObserver === "undefined") return;
-    // Reflow from a resized pane, a loaded image, or a font change can move
-    // content across the threshold in either direction after the first paint.
-    const observer = new ResizeObserver(measure);
-    observer.observe(content);
-    return () => observer.disconnect();
-  }, [collapsedLines]);
+    const ResizeObserverConstructor = content.doc.defaultView?.ResizeObserver;
+    const observer = ResizeObserverConstructor ? new ResizeObserverConstructor(measure) : null;
+    observer?.observe(content);
+    return () => observer?.disconnect();
+  }, [collapsedClassName, isExpanded]);
 
-  const isClamped = clampHeightPx !== null && !isExpanded;
+  const isClamped = isOverflowing && !isExpanded;
 
   return (
     <div className="tw-flex tw-flex-col">
       <div
+        ref={contentRef}
         id={contentId}
         data-testid="clamped-content"
-        className="tw-overflow-hidden"
-        style={isClamped ? { maxHeight: `${clampHeightPx}px` } : undefined}
+        className={cn("tw-overflow-hidden", !isExpanded && collapsedClassName)}
       >
-        <div ref={contentRef}>{children}</div>
+        {children}
       </div>
-      {clampHeightPx !== null && (
+      {isOverflowing && (
         <div className="tw-flex tw-flex-col tw-items-start tw-pt-1">
           {isClamped && (
             <div aria-hidden className="tw-select-none tw-text-muted">

--- a/src/components/ui/clamped-content.tsx
+++ b/src/components/ui/clamped-content.tsx
@@ -1,0 +1,100 @@
+import { Button } from "@/components/ui/button";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import React, { useId, useLayoutEffect, useRef, useState } from "react";
+
+/**
+ * Line height assumed when the computed `line-height` is not a length, which is
+ * what `normal` resolves to whenever no ancestor sets one. Without it every
+ * comparison against `NaN` is false, so the clamp would silently never engage
+ * and oversized content would render at full height.
+ */
+const FALLBACK_LINE_HEIGHT_PX = 20;
+
+export interface ClampedContentProps {
+  /**
+   * How many lines stay visible while collapsed. The pixel cap is derived from
+   * the content's own computed `line-height`, so the clamp tracks the reader's
+   * font size rather than freezing at one theme's metrics.
+   */
+  collapsedLines: number;
+  children: React.ReactNode;
+}
+
+/**
+ * Clips content taller than `collapsedLines` and offers an explicit expand and
+ * collapse control, so a single oversized block cannot bury what surrounds it.
+ * Content that already fits renders untouched and shows no control.
+ */
+export const ClampedContent: React.FC<ClampedContentProps> = ({ collapsedLines, children }) => {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [isExpanded, setIsExpanded] = useState(false);
+  // `null` means the content fits, which is also the state that hides the toggle.
+  const [clampHeightPx, setClampHeightPx] = useState<number | null>(null);
+  const contentId = useId();
+
+  useLayoutEffect(() => {
+    const content = contentRef.current;
+    if (!content) return;
+
+    const measure = () => {
+      // Read styles through the element's own realm: chat also renders inside
+      // Obsidian popout windows, where the ambient `window` is a different one.
+      const view = content.ownerDocument.defaultView;
+      const lineHeightPx = view
+        ? Number.parseFloat(view.getComputedStyle(content).lineHeight)
+        : Number.NaN;
+      const limitPx =
+        (Number.isFinite(lineHeightPx) ? lineHeightPx : FALLBACK_LINE_HEIGHT_PX) * collapsedLines;
+      setClampHeightPx(content.scrollHeight > limitPx ? limitPx : null);
+    };
+
+    measure();
+
+    // Guard for test/JSDOM environments where ResizeObserver may not exist.
+    if (typeof ResizeObserver === "undefined") return;
+    // Reflow from a resized pane, a loaded image, or a font change can move
+    // content across the threshold in either direction after the first paint.
+    const observer = new ResizeObserver(measure);
+    observer.observe(content);
+    return () => observer.disconnect();
+  }, [collapsedLines]);
+
+  const isClamped = clampHeightPx !== null && !isExpanded;
+
+  return (
+    <div className="tw-flex tw-flex-col">
+      <div
+        id={contentId}
+        data-testid="clamped-content"
+        className="tw-overflow-hidden"
+        style={isClamped ? { maxHeight: `${clampHeightPx}px` } : undefined}
+      >
+        <div ref={contentRef}>{children}</div>
+      </div>
+      {clampHeightPx !== null && (
+        <div className="tw-flex tw-flex-col tw-items-start tw-pt-1">
+          {isClamped && (
+            <div aria-hidden className="tw-select-none tw-text-muted">
+              ...
+            </div>
+          )}
+          <Button
+            variant="ghost2"
+            size="fit"
+            aria-controls={contentId}
+            aria-expanded={isExpanded}
+            className="tw--ml-1 tw-py-1"
+            onClick={() => setIsExpanded((expanded) => !expanded)}
+          >
+            {isExpanded ? "Show less" : "Show more"}
+            {isExpanded ? (
+              <ChevronUp className="tw-size-icon-xs" />
+            ) : (
+              <ChevronDown className="tw-size-icon-xs" />
+            )}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
Fixes Brevilabs/obsidian-copilot-private#151

## Why

Long pasted prompts, stack traces, and note excerpts render at full height in Quick Chat. One user message can fill the sidebar and push the reply and earlier turns out of view.

## What

User messages taller than 12 lines now show a 12-line preview with **Show more**. Expanding reveals the complete message and changes the control to **Show less**. Short user messages and assistant responses keep their current presentation, and Copy, Edit, selection, and the other message actions continue to use the complete message.

| User-message state | Result |
| --- | --- |
| 12 lines or fewer | Full message with no expand control |
| Taller than 12 lines | 12-line preview with **Show more** |
| Expanded | Full message with **Show less** |

## Non goal

- Quick Ask and Agent Chat use separate message surfaces and are unchanged.
- Assistant messages are unchanged.
- The 12-line preview is not a user setting.

## Screenshot

Captured in Obsidian 1.13.7 with the same saved Quick Chat thread in an isolated vault. The before image uses `origin/master` at `c8f6639f`; the after image uses this PR at `3f2e21c9`. Loading the saved thread did not send a model request.

**Before (`origin/master`)**

![Before: the long Quick Chat user message fills the sidebar](https://github.com/user-attachments/assets/50f87ba5-1d61-43be-abc2-b679cc7812a3)

**After (this PR)**

![After: the same Quick Chat user message is capped with Show more](https://github.com/user-attachments/assets/9ee2f7a5-2242-4edd-be72-429ae46948a1)

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Deterministic component tests cover fitting, overflowing, expanding, collapsing, and the Quick Chat user-message branch |
| A defect would fail CI or be obvious on first use | ✅ | The behavior is covered in CI and a missing preview or control is visible on the first long user message |
| A revert fully restores prior state, including persisted data | ✅ | The change does not write or migrate saved chats or settings |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Message content and actions keep their existing inputs |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Saved-chat data and external contracts are unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | The change only observes rendered size and toggles one local presentation state |
| No hot-path behavior lacks deterministic coverage | ✅ | Tests cover both Quick Chat message branches and every expand-control state |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | The rendered cap is limited to Quick Chat user messages and appears immediately |

Review: compare the before and after screenshots, then run Verification steps 2-5 in Quick Chat.

## Verification

1. Build this branch, load it in a test vault, and open Quick Chat.
2. Send or load a user message longer than 12 lines. Confirm it shows a 12-line preview followed by **Show more**.
3. Select **Show more**. Confirm the full message appears and the control changes to **Show less**; select **Show less** and confirm the preview returns.
4. Copy, select, and edit the collapsed message. Confirm each action still uses the complete text.
5. Send or load a short user message and an assistant response. Confirm neither receives an expand control.

## Note

The commits are unsigned, as agent commits in this repository are. Re-sign before merging.
