### PR TITLE
Require answers for multi-select agent questions

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -80,6 +80,8 @@ opencode supports **Default** and **Auto**. Claude supports **Default**, **Plan*
 
 When an action needs approval, Agent Chat displays a **Permission required** card with the proposed change or tool input. Choose one of the temporary or persistent allow or deny options offered by that agent. Stopping the turn cancels unanswered requests.
 
+When an agent asks a set of questions, answer every question tab before **Submit** becomes available; **Cancel** declines the entire request.
+
 Your vault or project is the agent's working directory, not a security sandbox. Auto or bypass permissions can reach other files and services available to the agent or your account. Use **Default** for unfamiliar work and review persistent permissions carefully.
 
 ## Context and history

--- a/src/agentMode/ui/AskUserQuestionCard.stories.tsx
+++ b/src/agentMode/ui/AskUserQuestionCard.stories.tsx
@@ -1,0 +1,42 @@
+import { AskUserQuestionCard } from "@/agentMode/ui/AskUserQuestionCard";
+import type { AskUserQuestionPrompt, SessionId } from "@/agentMode/session/types";
+import type { Meta, StoryObj } from "@/lib/story";
+import type * as React from "react";
+
+type AskUserQuestionCardProps = React.ComponentProps<typeof AskUserQuestionCard>;
+
+const request = {
+  sessionId: "gallery-session" as SessionId,
+  requestId: "gallery-question",
+  questions: [
+    {
+      header: "Deployment",
+      question: "Choose deployment",
+      options: [{ label: "Production" }, { label: "Staging" }],
+    },
+    {
+      header: "Timing",
+      question: "When should we ship?",
+      options: [{ label: "Today" }, { label: "Next week" }],
+    },
+    {
+      header: "Checks",
+      question: "Which checks are required?",
+      multiSelect: true,
+      options: [{ label: "Unit tests" }, { label: "End-to-end test" }],
+    },
+  ],
+} satisfies AskUserQuestionPrompt;
+
+const meta = {
+  title: "Agent Mode/Ask User Question Card",
+  component: AskUserQuestionCard,
+  args: {
+    request,
+    onResolve: () => undefined,
+  },
+  parameters: { gallery: { host: "leaf", layout: "padded" } },
+} satisfies Meta<AskUserQuestionCardProps>;
+export default meta;
+
+export const MultipleQuestions: StoryObj<AskUserQuestionCardProps> = {};

--- a/src/agentMode/ui/AskUserQuestionCard.test.tsx
+++ b/src/agentMode/ui/AskUserQuestionCard.test.tsx
@@ -107,6 +107,13 @@ describe("AskUserQuestionCard", () => {
       fireEvent.click(screen.getByRole("checkbox", { name: "End-to-end test" }));
 
       expect((submitButton() as HTMLButtonElement).disabled).toBe(false);
+      fireEvent.click(screen.getByRole("checkbox", { name: "End-to-end test" }));
+      expect((submitButton() as HTMLButtonElement).disabled).toBe(true);
+      fireEvent.click(submitButton());
+      expect(onResolve).not.toHaveBeenCalled();
+
+      fireEvent.click(screen.getByRole("checkbox", { name: "End-to-end test" }));
+      expect((submitButton() as HTMLButtonElement).disabled).toBe(false);
       fireEvent.click(submitButton());
       expect(onResolve).toHaveBeenCalledTimes(1);
       expect(onResolve).toHaveBeenCalledWith(REQUEST_ID, {

--- a/src/agentMode/ui/AskUserQuestionCard.test.tsx
+++ b/src/agentMode/ui/AskUserQuestionCard.test.tsx
@@ -26,93 +26,143 @@ const submitButton = (): HTMLElement => screen.getByRole("button", { name: /subm
 const cancelButton = (): HTMLElement => screen.getByRole("button", { name: /cancel/i });
 const otherTextarea = (): HTMLElement => screen.getByPlaceholderText(/type your response/i);
 
-describe("AskUserQuestionCard custom 'Other' response", () => {
-  it("single-select 'Other' → the trimmed typed text is the answer", () => {
-    const onResolve = jest.fn();
-    const request = makeRequest([
-      {
-        question: "When do we ship?",
-        options: [{ label: "A" }, { label: "B" }],
-      },
-    ]);
-    renderCard(request, onResolve);
+describe("AskUserQuestionCard", () => {
+  describe("AskUserQuestionCard()", () => {
+    it("single-select 'Other' → the trimmed typed text is the answer", () => {
+      const onResolve = jest.fn();
+      const request = makeRequest([
+        {
+          question: "When do we ship?",
+          options: [{ label: "A" }, { label: "B" }],
+        },
+      ]);
+      renderCard(request, onResolve);
 
-    fireEvent.click(getOtherControl("radio"));
-    // Surrounding whitespace proves the answer is trimmed on submit.
-    fireEvent.change(otherTextarea(), { target: { value: "  ship it Friday  " } });
-    fireEvent.click(submitButton());
+      fireEvent.click(getOtherControl("radio"));
+      // Surrounding whitespace proves the answer is trimmed on submit.
+      fireEvent.change(otherTextarea(), { target: { value: "  ship it Friday  " } });
+      fireEvent.click(submitButton());
 
-    expect(onResolve).toHaveBeenCalledTimes(1);
-    expect(onResolve).toHaveBeenCalledWith(REQUEST_ID, { "When do we ship?": "ship it Friday" });
-  });
+      expect(onResolve).toHaveBeenCalledTimes(1);
+      expect(onResolve).toHaveBeenCalledWith(REQUEST_ID, {
+        "When do we ship?": "ship it Friday",
+      });
+    });
 
-  it("multi-select presets + 'Other' → checked labels and trimmed text joined with ', '", () => {
-    const onResolve = jest.fn();
-    const request = makeRequest([
-      {
-        question: "Pick tasks",
-        multiSelect: true,
-        options: [{ label: "A" }, { label: "B" }, { label: "C" }],
-      },
-    ]);
-    renderCard(request, onResolve);
+    it("multi-select presets + 'Other' → checked labels and trimmed text joined with ', '", () => {
+      const onResolve = jest.fn();
+      const request = makeRequest([
+        {
+          question: "Pick tasks",
+          multiSelect: true,
+          options: [{ label: "A" }, { label: "B" }, { label: "C" }],
+        },
+      ]);
+      renderCard(request, onResolve);
 
-    fireEvent.click(screen.getByRole("checkbox", { name: /^A$/ }));
-    fireEvent.click(screen.getByRole("checkbox", { name: /^C$/ }));
-    fireEvent.click(getOtherControl("checkbox"));
-    fireEvent.change(otherTextarea(), { target: { value: "  rollback plan  " } });
-    fireEvent.click(submitButton());
+      fireEvent.click(screen.getByRole("checkbox", { name: /^A$/ }));
+      fireEvent.click(screen.getByRole("checkbox", { name: /^C$/ }));
+      fireEvent.click(getOtherControl("checkbox"));
+      fireEvent.change(otherTextarea(), { target: { value: "  rollback plan  " } });
+      fireEvent.click(submitButton());
 
-    expect(onResolve).toHaveBeenCalledTimes(1);
-    expect(onResolve).toHaveBeenCalledWith(REQUEST_ID, { "Pick tasks": "A, C, rollback plan" });
-  });
+      expect(onResolve).toHaveBeenCalledTimes(1);
+      expect(onResolve).toHaveBeenCalledWith(REQUEST_ID, {
+        "Pick tasks": "A, C, rollback plan",
+      });
+    });
 
-  it("disables Submit while 'Other' is armed with empty text, enabling it once text is typed", () => {
-    const onResolve = jest.fn();
-    const request = makeRequest([
-      {
-        question: "When do we ship?",
-        options: [{ label: "A" }, { label: "B" }],
-      },
-    ]);
-    renderCard(request, onResolve);
+    it("requires an explicit answer for every question before submitting (https://github.com/Brevilabs/obsidian-copilot-private/issues/182)", () => {
+      const onResolve = jest.fn();
+      const request = makeRequest([
+        {
+          header: "Deployment",
+          question: "Choose deployment",
+          options: [{ label: "Production" }, { label: "Staging" }],
+        },
+        {
+          header: "Timing",
+          question: "When should we ship?",
+          options: [{ label: "Today" }, { label: "Next week" }],
+        },
+        {
+          header: "Checks",
+          question: "Which checks are required?",
+          multiSelect: true,
+          options: [{ label: "Unit tests" }, { label: "End-to-end test" }],
+        },
+      ]);
+      renderCard(request, onResolve);
 
-    fireEvent.click(getOtherControl("radio"));
-    expect((submitButton() as HTMLButtonElement).disabled).toBe(true);
+      fireEvent.click(screen.getByRole("radio", { name: "Production" }));
+      fireEvent.click(screen.getByRole("tab", { name: "Timing" }));
+      fireEvent.click(getOtherControl("radio"));
+      fireEvent.change(otherTextarea(), { target: { value: "  Friday after QA  " } });
 
-    fireEvent.change(otherTextarea(), { target: { value: "x" } });
-    expect((submitButton() as HTMLButtonElement).disabled).toBe(false);
-  });
+      expect((submitButton() as HTMLButtonElement).disabled).toBe(true);
+      fireEvent.click(submitButton());
+      expect(onResolve).not.toHaveBeenCalled();
 
-  it("Cancel resolves with an empty answer map", () => {
-    const onResolve = jest.fn();
-    const request = makeRequest([
-      {
-        question: "When do we ship?",
-        options: [{ label: "A" }, { label: "B" }],
-      },
-    ]);
-    renderCard(request, onResolve);
+      fireEvent.click(screen.getByRole("tab", { name: "Checks" }));
+      fireEvent.click(screen.getByRole("checkbox", { name: "End-to-end test" }));
 
-    fireEvent.click(cancelButton());
+      expect((submitButton() as HTMLButtonElement).disabled).toBe(false);
+      fireEvent.click(submitButton());
+      expect(onResolve).toHaveBeenCalledTimes(1);
+      expect(onResolve).toHaveBeenCalledWith(REQUEST_ID, {
+        "Choose deployment": "Production",
+        "When should we ship?": "Friday after QA",
+        "Which checks are required?": "End-to-end test",
+      });
+    });
 
-    expect(onResolve).toHaveBeenCalledWith(REQUEST_ID, {});
-  });
+    it("disables Submit while 'Other' is armed with empty text, enabling it once text is typed", () => {
+      const onResolve = jest.fn();
+      const request = makeRequest([
+        {
+          question: "When do we ship?",
+          options: [{ label: "A" }, { label: "B" }],
+        },
+      ]);
+      renderCard(request, onResolve);
 
-  it("regression: single-select preset still resolves with the chosen label", () => {
-    const onResolve = jest.fn();
-    const request = makeRequest([
-      {
-        question: "When do we ship?",
-        options: [{ label: "A" }, { label: "B" }],
-      },
-    ]);
-    renderCard(request, onResolve);
+      fireEvent.click(getOtherControl("radio"));
+      expect((submitButton() as HTMLButtonElement).disabled).toBe(true);
 
-    fireEvent.click(screen.getByRole("radio", { name: /^A$/ }));
-    fireEvent.click(submitButton());
+      fireEvent.change(otherTextarea(), { target: { value: "x" } });
+      expect((submitButton() as HTMLButtonElement).disabled).toBe(false);
+    });
 
-    expect(onResolve).toHaveBeenCalledTimes(1);
-    expect(onResolve).toHaveBeenCalledWith(REQUEST_ID, { "When do we ship?": "A" });
+    it("Cancel resolves with an empty answer map", () => {
+      const onResolve = jest.fn();
+      const request = makeRequest([
+        {
+          question: "When do we ship?",
+          options: [{ label: "A" }, { label: "B" }],
+        },
+      ]);
+      renderCard(request, onResolve);
+
+      fireEvent.click(cancelButton());
+
+      expect(onResolve).toHaveBeenCalledWith(REQUEST_ID, {});
+    });
+
+    it("regression: single-select preset still resolves with the chosen label", () => {
+      const onResolve = jest.fn();
+      const request = makeRequest([
+        {
+          question: "When do we ship?",
+          options: [{ label: "A" }, { label: "B" }],
+        },
+      ]);
+      renderCard(request, onResolve);
+
+      fireEvent.click(screen.getByRole("radio", { name: /^A$/ }));
+      fireEvent.click(submitButton());
+
+      expect(onResolve).toHaveBeenCalledTimes(1);
+      expect(onResolve).toHaveBeenCalledWith(REQUEST_ID, { "When do we ship?": "A" });
+    });
   });
 });

--- a/src/agentMode/ui/AskUserQuestionCard.tsx
+++ b/src/agentMode/ui/AskUserQuestionCard.tsx
@@ -25,7 +25,11 @@ function isAnswered(
   customText: string
 ): boolean {
   if (otherActive) return customText.trim().length > 0;
-  if (question.multiSelect) return true;
+  if (question.multiSelect) {
+    // An untouched or fully cleared multi-select must not become an empty-string answer.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/182
+    return selection instanceof Set && selection.size > 0;
+  }
   return typeof selection === "string" && selection !== "";
 }
 
@@ -57,9 +61,8 @@ export const AskUserQuestionCard: React.FC<AskUserQuestionCardProps> = ({ reques
   const [otherActive, setOtherActive] = useState<Record<number, boolean>>({});
   const [customTexts, setCustomTexts] = useState<Record<number, string>>({});
 
-  // Gate Submit until every single-select question has a pick (or a non-empty
-  // "Other"). Multi-select questions may be left empty unless "Other" is armed,
-  // in which case its text must be filled.
+  // Gate Submit until every question has a preset selection or a non-empty
+  // "Other" response. An armed "Other" must be filled even when presets remain.
   const canSubmit = questions.every((q, idx) =>
     isAnswered(q, selections[idx], otherActive[idx] ?? false, customTexts[idx] ?? "")
   );


### PR DESCRIPTION
Fixes Brevilabs/obsidian-copilot-private#182

## Why

Agent Chat currently treats an untouched multi-select question as answered. In a three-question card, answering the first two questions, including an Other response on question two, enables Submit and resolves question three as an empty string. The user can therefore send an incomplete answer set without realizing a question was skipped.

## What

> **Before:** An unanswered multi-select question allows the whole question card to submit and becomes an empty-string answer.
>
> **After:** Submit stays disabled until every multi-select question has at least one selected option or a non-empty Other response.

Clearing the last selected option disables Submit again. Cancel continues to decline the entire request, and the rule applies independently of the agent backend.

## Non goal

This PR does not add a per-question Skip action, automatic tab advancement, or next-unanswered navigation cues. Brevilabs/obsidian-copilot-private#117 owns that broader navigation work. It also does not change answer serialization or backend protocols.

## Screenshot

Same three-question state in Obsidian 1.13.7, with the Checklist tab still unanswered.

**Before: Submit is enabled**

![Before: unanswered Checklist still allows Submit](https://github.com/user-attachments/assets/745dd912-718f-40cc-b849-2b4be893488e)

**After: Submit is disabled**

![After: unanswered Checklist keeps Submit disabled](https://github.com/user-attachments/assets/984d3767-ada8-46d3-8e8d-fe2200a14b4a)

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | The three-question regression covers untouched, selected, cleared, and resubmitted multi-select states |
| A defect would fail CI or be obvious on first use | ✅ | The focused component test fails if Submit becomes enabled before every question is answered |
| A revert fully restores prior state, including persisted data | ✅ | The change only affects transient question-card state and writes no persisted data |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Agent-question input validation now rejects empty multi-select answers |
| No public API, plugin API, message, or on-disk contract changes | ✅ | The existing answer map and backend request formats are unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Validation remains a synchronous derivation of local React state |
| No hot-path behavior lacks deterministic coverage | ✅ | Tests cover untouched, selected, cleared, Other, submit, and cancel behavior |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Any regression is visible immediately in the Agent Chat question card's Submit state |

Review: inspect `isAnswered` and the `canSubmit` derivation in `src/agentMode/ui/AskUserQuestionCard.tsx` line by line, then run Verification steps 3-5, including the untouched, cleared, and whitespace-Other variants.

## Verification

1. Run `npm run gallery:vault` and open the Component gallery in the test vault.
2. Open **Agent Mode / Ask User Question Card / MultipleQuestions**.
3. Choose **Production**, open **Timing**, select **Other**, enter `Friday after QA`, and leave **Checks** untouched. Confirm Submit remains disabled.
4. In **Checks**, select **End-to-end test** and confirm Submit enables. Clear that option and confirm Submit disables, then select it again.
5. Return to **Timing**, replace the Other response with whitespace, and confirm Submit disables. Restore non-whitespace text and confirm it enables again.
