### PR TITLE
Guide users through multi-question agent prompts

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -80,7 +80,7 @@ opencode supports **Default** and **Auto**. Claude supports **Default**, **Plan*
 
 When an action needs approval, Agent Chat displays a **Permission required** card with the proposed change or tool input. Choose one of the temporary or persistent allow or deny options offered by that agent. Stopping the turn cancels unanswered requests.
 
-When an agent asks a set of questions, answer every question tab before **Submit** becomes available; **Cancel** declines the entire request.
+When an agent asks a set of questions, answer the current tab and select **Next**. On the final tab, **Submit** becomes available after every question has an answer. You can use the tabs to review or skip ahead; **Cancel** declines the entire request.
 
 Your vault or project is the agent's working directory, not a security sandbox. Auto or bypass permissions can reach other files and services available to the agent or your account. Use **Default** for unfamiliar work and review persistent permissions carefully.
 

--- a/src/agentMode/ui/AskUserQuestionCard.stories.tsx
+++ b/src/agentMode/ui/AskUserQuestionCard.stories.tsx
@@ -39,4 +39,5 @@ const meta = {
 } satisfies Meta<AskUserQuestionCardProps>;
 export default meta;
 
+/** Answer with Next, or select Checks early to inspect the disabled final Submit state. */
 export const MultipleQuestions: StoryObj<AskUserQuestionCardProps> = {};

--- a/src/agentMode/ui/AskUserQuestionCard.test.tsx
+++ b/src/agentMode/ui/AskUserQuestionCard.test.tsx
@@ -5,6 +5,18 @@ import React from "react";
 
 const SESSION_ID = "s1" as SessionId;
 const REQUEST_ID = "req-1";
+const NAVIGATION_QUESTIONS: AskUserQuestionPrompt["questions"] = [
+  {
+    header: "Scope",
+    question: "Which scope?",
+    options: [{ label: "Current note" }, { label: "Vault" }],
+  },
+  {
+    header: "Format",
+    question: "Which format?",
+    options: [{ label: "Summary" }, { label: "Outline" }],
+  },
+];
 
 function makeRequest(questions: AskUserQuestionPrompt["questions"]): AskUserQuestionPrompt {
   return { sessionId: SESSION_ID, requestId: REQUEST_ID, questions };
@@ -23,6 +35,7 @@ function getOtherControl(role: "radio" | "checkbox"): HTMLElement {
 }
 
 const submitButton = (): HTMLElement => screen.getByRole("button", { name: /submit/i });
+const nextButton = (): HTMLElement => screen.getByRole("button", { name: /next/i });
 const cancelButton = (): HTMLElement => screen.getByRole("button", { name: /cancel/i });
 const otherTextarea = (): HTMLElement => screen.getByPlaceholderText(/type your response/i);
 
@@ -98,12 +111,12 @@ describe("AskUserQuestionCard", () => {
       fireEvent.click(screen.getByRole("tab", { name: "Timing" }));
       fireEvent.click(getOtherControl("radio"));
       fireEvent.change(otherTextarea(), { target: { value: "  Friday after QA  " } });
+      fireEvent.click(screen.getByRole("tab", { name: "Checks" }));
 
       expect((submitButton() as HTMLButtonElement).disabled).toBe(true);
       fireEvent.click(submitButton());
       expect(onResolve).not.toHaveBeenCalled();
 
-      fireEvent.click(screen.getByRole("tab", { name: "Checks" }));
       fireEvent.click(screen.getByRole("checkbox", { name: "End-to-end test" }));
 
       expect((submitButton() as HTMLButtonElement).disabled).toBe(false);
@@ -121,6 +134,69 @@ describe("AskUserQuestionCard", () => {
         "When should we ship?": "Friday after QA",
         "Which checks are required?": "End-to-end test",
       });
+    });
+
+    it("advances an answered non-final question without resolving the request (https://github.com/Brevilabs/obsidian-copilot-private/issues/117)", () => {
+      const onResolve = jest.fn();
+      const request = makeRequest(NAVIGATION_QUESTIONS);
+      renderCard(request, onResolve);
+
+      expect((nextButton() as HTMLButtonElement).disabled).toBe(true);
+      fireEvent.click(screen.getByRole("radio", { name: "Current note" }));
+      expect((nextButton() as HTMLButtonElement).disabled).toBe(false);
+
+      fireEvent.click(nextButton());
+
+      expect(screen.getByRole("tab", { name: "Format" }).getAttribute("aria-selected")).toBe(
+        "true"
+      );
+      expect(screen.getByText("Which format?")).not.toBeNull();
+      expect((submitButton() as HTMLButtonElement).disabled).toBe(true);
+      expect(onResolve).not.toHaveBeenCalled();
+
+      fireEvent.click(screen.getByRole("radio", { name: "Summary" }));
+      expect((submitButton() as HTMLButtonElement).disabled).toBe(false);
+      fireEvent.click(submitButton());
+
+      expect(onResolve).toHaveBeenCalledWith(REQUEST_ID, {
+        "Which scope?": "Current note",
+        "Which format?": "Summary",
+      });
+    });
+
+    it("keeps final Submit disabled when a middle question was skipped (https://github.com/Brevilabs/obsidian-copilot-private/issues/117)", () => {
+      const onResolve = jest.fn();
+      const request = makeRequest([
+        ...NAVIGATION_QUESTIONS,
+        {
+          header: "Length",
+          question: "How long?",
+          options: [{ label: "Short" }, { label: "Detailed" }],
+        },
+      ]);
+      renderCard(request, onResolve);
+
+      fireEvent.click(screen.getByRole("radio", { name: "Current note" }));
+      fireEvent.click(nextButton());
+      fireEvent.click(screen.getByRole("tab", { name: "Length" }));
+      fireEvent.click(screen.getByRole("radio", { name: "Short" }));
+
+      expect((submitButton() as HTMLButtonElement).disabled).toBe(true);
+      fireEvent.click(submitButton());
+      expect(onResolve).not.toHaveBeenCalled();
+    });
+
+    it("uses Cmd/Ctrl+Enter for the same Next action shown on a non-final question (https://github.com/Brevilabs/obsidian-copilot-private/issues/117)", () => {
+      const onResolve = jest.fn();
+      const request = makeRequest(NAVIGATION_QUESTIONS);
+      renderCard(request, onResolve);
+
+      fireEvent.click(getOtherControl("radio"));
+      fireEvent.change(otherTextarea(), { target: { value: "Open files" } });
+      fireEvent.keyDown(otherTextarea(), { key: "Enter", metaKey: true });
+
+      expect(screen.getByText("Which format?")).not.toBeNull();
+      expect(onResolve).not.toHaveBeenCalled();
     });
 
     it("disables Submit while 'Other' is armed with empty text, enabling it once text is typed", () => {

--- a/src/agentMode/ui/AskUserQuestionCard.tsx
+++ b/src/agentMode/ui/AskUserQuestionCard.tsx
@@ -61,11 +61,22 @@ export const AskUserQuestionCard: React.FC<AskUserQuestionCardProps> = ({ reques
   const [otherActive, setOtherActive] = useState<Record<number, boolean>>({});
   const [customTexts, setCustomTexts] = useState<Record<number, string>>({});
 
+  const showTabs = questions.length > 1;
+  const active = questions[activeTab] ?? questions[0];
+  const activeIdx = questions[activeTab] ? activeTab : 0;
+
   // Gate Submit until every question has a preset selection or a non-empty
   // "Other" response. An armed "Other" must be filled even when presets remain.
   const canSubmit = questions.every((q, idx) =>
     isAnswered(q, selections[idx], otherActive[idx] ?? false, customTexts[idx] ?? "")
   );
+  const canAdvance = isAnswered(
+    active,
+    selections[activeIdx],
+    otherActive[activeIdx] ?? false,
+    customTexts[activeIdx] ?? ""
+  );
+  const isFinalQuestion = activeIdx === questions.length - 1;
 
   const submit = (): void => {
     if (busy || !canSubmit) return;
@@ -88,15 +99,23 @@ export const AskUserQuestionCard: React.FC<AskUserQuestionCardProps> = ({ reques
     onResolve(requestId, answers);
   };
 
+  // Tabs may skip questions, so Next validates only the visible answer while
+  // final Submit keeps the request-wide validation that prevents partial payloads.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/117
+  const runPrimaryAction = (): void => {
+    if (isFinalQuestion) {
+      submit();
+      return;
+    }
+    if (busy || !canAdvance) return;
+    setActiveTab(activeIdx + 1);
+  };
+
   const cancel = (): void => {
     if (busy) return;
     setBusy(true);
     onResolve(requestId, {});
   };
-
-  const showTabs = questions.length > 1;
-  const active = questions[activeTab] ?? questions[0];
-  const activeIdx = questions[activeTab] ? activeTab : 0;
 
   // Choosing a preset. Single-select picks one label and disarms "Other";
   // multi-select toggles the label in its Set and leaves "Other" alone.
@@ -176,7 +195,7 @@ export const AskUserQuestionCard: React.FC<AskUserQuestionCardProps> = ({ reques
           onTogglePreset={togglePreset}
           onToggleOther={toggleOther}
           onCustomTextChange={(text) => setCustomTexts((prev) => ({ ...prev, [activeIdx]: text }))}
-          onSubmitShortcut={submit}
+          onPrimaryActionShortcut={runPrimaryAction}
         />
       </div>
 
@@ -184,8 +203,13 @@ export const AskUserQuestionCard: React.FC<AskUserQuestionCardProps> = ({ reques
         <Button variant="secondary" size="sm" disabled={busy} onClick={cancel}>
           Cancel
         </Button>
-        <Button variant="default" size="sm" disabled={busy || !canSubmit} onClick={submit}>
-          Submit
+        <Button
+          variant="default"
+          size="sm"
+          disabled={busy || (isFinalQuestion ? !canSubmit : !canAdvance)}
+          onClick={runPrimaryAction}
+        >
+          {isFinalQuestion ? "Submit" : "Next"}
         </Button>
       </div>
     </div>
@@ -203,8 +227,8 @@ interface QuestionPanelProps {
   onTogglePreset: (label: string) => void;
   onToggleOther: () => void;
   onCustomTextChange: (text: string) => void;
-  /** Cmd/Ctrl+Enter in the textarea; the parent guards on `canSubmit`. */
-  onSubmitShortcut: () => void;
+  /** Cmd/Ctrl+Enter in the textarea; matches the parent's visible primary action. */
+  onPrimaryActionShortcut: () => void;
 }
 
 /** The active question's prompt text plus its single- or multi-select option list. */
@@ -218,7 +242,7 @@ const QuestionPanel: React.FC<QuestionPanelProps> = ({
   onTogglePreset,
   onToggleOther,
   onCustomTextChange,
-  onSubmitShortcut,
+  onPrimaryActionShortcut,
 }) => {
   const control = question.multiSelect ? "checkbox" : "radio";
   return (
@@ -289,7 +313,7 @@ const QuestionPanel: React.FC<QuestionPanelProps> = ({
           onKeyDown={(e) => {
             if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
               e.preventDefault();
-              onSubmitShortcut();
+              onPrimaryActionShortcut();
             }
           }}
           rows={2}


### PR DESCRIPTION
Fixes Brevilabs/obsidian-copilot-private#117

## Why

Multi-question agent prompts show a disabled **Submit** button from the first question onward. After answering the visible question, users must infer that another tab needs attention, so the card can appear stuck even though the flow still works.

## What

The tabs remain available for review and direct navigation, while the footer now communicates the action for the visible step.

| State | Primary action | Availability |
| --- | --- | --- |
| Before the final question | **Next** | Enabled when the visible question is answered |
| Final question with an earlier answer missing | **Submit** | Disabled |
| Final question with every answer complete | **Submit** | Enabled |

Cmd/Ctrl+Enter from a custom response follows the same visible Next or Submit action.

## Non goal

- Changing question types, answer validation, or the response payload.
- Redesigning the single-question card flow.
- Changing cancellation behavior.

## Screenshot

| Before | After |
| --- | --- |
| Disabled **Submit** on the first question | Disabled **Next** on the first question |
| ![Before: the first question shows a disabled Submit button](https://github.com/user-attachments/assets/a5143c8b-0caa-4466-8e0d-2148436dbe07) | ![After: the first question shows a disabled Next button](https://github.com/user-attachments/assets/48e769b9-b8fc-443e-9350-6842004830ec) |

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Component tests cover Next gating, final Submit gating, complete answer submission, tab skipping, and the keyboard shortcut |
| A defect would fail CI or be obvious on first use | ✅ | The focused component suite exercises every changed branch |
| A revert fully restores prior state, including persisted data | ✅ | The card keeps only transient React state and writes no persisted data |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Existing option and custom-text answer handling is unchanged |
| No public API, plugin API, message, or on-disk contract changes | ✅ | The request and resolved-answer contracts are unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Navigation remains synchronous component-local state |
| No hot-path behavior lacks deterministic coverage | ✅ | Every new primary-action outcome is covered in the component suite |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Any navigation error appears immediately in the inline question card |

Review: run Verification steps 2-4 once and confirm the footer matches the visible question state.

## Verification

1. Run `npm run gallery:vault`, then open **Agent Mode / Ask User Question Card / MultipleQuestions** in the component gallery at 400 px.
2. Confirm **Next** is disabled on the first question, select an answer, then confirm **Next** enables and advances to the second tab without submitting.
3. Select the final tab while the middle question is unanswered, answer the final question, and confirm **Submit** remains disabled.
4. Answer the skipped middle question, return to the final tab, and confirm **Submit** is enabled.
