### PR TITLE
[Relevant Notes on Miyo] - Step 3: Use Miyo for semantic scoring

### DIFF
--- a/docs/vault-search-and-indexing.md
+++ b/docs/vault-search-and-indexing.md
@@ -39,6 +39,12 @@ Use **Search scope** in the Miyo settings tab:
 
 The scope is a retrieval preference, not a security boundary. Keep Miyo's registered folders intentional, especially when you use an unrestricted scope or connect to a shared remote server.
 
+### Relevant Notes
+
+Relevant Notes always includes direct links and backlinks that pass Copilot's search scope. Miyo is the only source of semantic matches and similarity percentages in this pane; Copilot's legacy local embedding index no longer scores Relevant Notes.
+
+If Miyo is not connected, link and backlink rows stay visible without percentages and the pane offers Miyo download and setup actions. If Miyo is enabled but returns no semantic matches, the same rows remain visible and the pane asks you to check the connection and confirm that this vault is registered and indexed. Use **Open Miyo settings** to return directly to the existing connection flow under **Settings → Copilot → Miyo**, including when you use a remote endpoint or mobile device.
+
 ## Search conversations and process documents
 
 Miyo can also index supported ChatGPT and Claude chat histories. Configure those sources in Miyo, then use the **Search chat** row in Copilot to see their status and open Miyo's management screen. Chat-history search is separate from vault search.

--- a/docs/vault-search-and-indexing.md
+++ b/docs/vault-search-and-indexing.md
@@ -41,9 +41,9 @@ The scope is a retrieval preference, not a security boundary. Keep Miyo's regist
 
 ### Relevant Notes
 
-Relevant Notes always includes direct links and backlinks that pass Copilot's search scope. Miyo is the only source of semantic matches and similarity percentages in this pane; Copilot's legacy local embedding index no longer scores Relevant Notes.
+Miyo is the source of Relevant Notes results and similarity percentages; Copilot's legacy local embedding index no longer scores this pane. When Miyo is available, results can include direct links and backlinks that pass Copilot's search scope.
 
-If Miyo is not connected, link and backlink rows stay visible without percentages and the pane offers Miyo download and setup actions. If Miyo is enabled but returns no semantic matches, the same rows remain visible and the pane asks you to check the connection and confirm that this vault is registered and indexed. Use **Open Miyo settings** to return directly to the existing connection flow under **Settings → Copilot → Miyo**, including when you use a remote endpoint or mobile device.
+If Miyo is not connected or its related-note search is unavailable, the pane does not fall back to link and backlink rows. Instead, it offers Miyo download or setup actions. Use **Open Miyo settings** to return directly to the existing connection flow under **Settings → Copilot → Miyo**, including when you use a remote endpoint or mobile device.
 
 ## Search conversations and process documents
 

--- a/docs/vault-search-and-indexing.md
+++ b/docs/vault-search-and-indexing.md
@@ -41,9 +41,9 @@ The scope is a retrieval preference, not a security boundary. Keep Miyo's regist
 
 ### Relevant Notes
 
-Miyo is the source of Relevant Notes results and similarity percentages; Copilot's legacy local embedding index no longer scores this pane. When Miyo is available, results can include direct links and backlinks that pass Copilot's search scope.
+Miyo is the source of Relevant Notes results and similarity percentages; Copilot's legacy local embedding index no longer scores this pane. Direct-link and backlink indicators can annotate notes returned by Miyo, but links alone do not add notes to the results.
 
-If Miyo is not connected or its related-note search is unavailable, the pane does not fall back to link and backlink rows. Instead, it offers Miyo download or setup actions. Use **Open Miyo settings** to return directly to the existing connection flow under **Settings → Copilot → Miyo**, including when you use a remote endpoint or mobile device.
+If Miyo is not connected, its related-note search is unavailable, or it returns no match for the active note, the pane does not fall back to link and backlink rows. Instead, it offers Miyo download or setup actions. Use **Open Miyo settings** to return directly to the existing connection flow under **Settings → Copilot → Miyo**, including when you use a remote endpoint or mobile device.
 
 ## Search conversations and process documents
 

--- a/src/components/chat-components/RelevantNotes.test.tsx
+++ b/src/components/chat-components/RelevantNotes.test.tsx
@@ -24,6 +24,7 @@ let mockSettings = {
   qaInclusions: "",
   qaExclusions: "",
 };
+let mockMiyoBackend = "unknown";
 
 jest.mock("@/context", () => ({
   useApp: () => mockApp,
@@ -35,6 +36,10 @@ jest.mock("@/hooks/useActiveFile", () => ({
 
 jest.mock("@/hooks/useNoteDrag", () => ({
   useNoteDrag: () => jest.fn(),
+}));
+
+jest.mock("@/miyo/useMiyoStatus", () => ({
+  useMiyoStatus: () => ({ backend: mockMiyoBackend }),
 }));
 
 jest.mock("@/search/findRelevantNotes", () => ({
@@ -73,6 +78,7 @@ describe("RelevantNotes", () => {
       qaInclusions: "",
       qaExclusions: "",
     };
+    mockMiyoBackend = "unknown";
     const sourceFile = makeMarkdownFile("Source.md");
     const targetFile = makeMarkdownFile("Target.md");
     mockUseActiveFile.mockReturnValue(sourceFile);
@@ -120,6 +126,72 @@ describe("RelevantNotes", () => {
       fireEvent.click(await screen.findByRole("button", { name: "Open Miyo settings" }));
       expect(screen.queryByText("Target")).toBeNull();
       expect(openCopilotSettings).toHaveBeenCalledWith(mockApp, window, "miyo");
+    });
+
+    it("keeps setup guidance hidden while the Miyo request is pending (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      mockSettings = { ...mockSettings, enableMiyo: true };
+      mockFindRelevantNotes.mockReturnValue(new Promise(() => undefined));
+
+      render(<RelevantNotes onAddToChat={jest.fn()} />);
+
+      expect(await screen.findByText("Finding relevant notes…")).toBeTruthy();
+      expect(screen.queryByText("Check your Miyo setup")).toBeNull();
+      expect(screen.queryByText("No relevant notes found")).toBeNull();
+    });
+
+    it("keeps setup guidance hidden when no Markdown note is active (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
+      mockSettings = { ...mockSettings, enableMiyo: true };
+      mockUseActiveFile.mockReturnValue(null);
+
+      render(<RelevantNotes onAddToChat={jest.fn()} />);
+
+      expect(screen.queryByText("Check your Miyo setup")).toBeNull();
+      expect(screen.getByText("No relevant notes found")).toBeTruthy();
+      expect(mockFindRelevantNotes).not.toHaveBeenCalled();
+    });
+
+    it("starts a fresh request when the same note reopens after no note was active (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      mockSettings = { ...mockSettings, enableMiyo: true };
+      const sourceFile = makeMarkdownFile("Source.md");
+
+      const { rerender } = render(<RelevantNotes onAddToChat={jest.fn()} />);
+      expect(await screen.findByText("Target")).toBeTruthy();
+
+      mockUseActiveFile.mockReturnValue(null);
+      rerender(<RelevantNotes onAddToChat={jest.fn()} />);
+      expect(screen.getByText("No relevant notes found")).toBeTruthy();
+
+      mockFindRelevantNotes.mockReturnValueOnce(new Promise(() => undefined));
+      mockUseActiveFile.mockReturnValue(sourceFile);
+      rerender(<RelevantNotes onAddToChat={jest.fn()} />);
+
+      expect(await screen.findByText("Finding relevant notes…")).toBeTruthy();
+      expect(screen.queryByText("Target")).toBeNull();
+    });
+
+    it("refetches when the configured Miyo backend becomes available (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      mockSettings = { ...mockSettings, enableMiyo: true };
+      mockMiyoBackend = "unavailable";
+      mockFindRelevantNotes.mockResolvedValueOnce([]).mockResolvedValueOnce([
+        {
+          note: { path: "Target.md", title: "Target" },
+          metadata: {
+            score: 0.9,
+            similarityScore: 0.9,
+            hasOutgoingLinks: false,
+            hasBacklinks: false,
+          },
+        },
+      ]);
+
+      const { rerender } = render(<RelevantNotes onAddToChat={jest.fn()} />);
+      expect(await screen.findByText("Check your Miyo setup")).toBeTruthy();
+
+      mockMiyoBackend = "available";
+      rerender(<RelevantNotes onAddToChat={jest.fn()} />);
+
+      expect(await screen.findByText("Target")).toBeTruthy();
+      expect(mockFindRelevantNotes).toHaveBeenCalledTimes(2);
     });
 
     it("shows graph-only rows without setup guidance after Miyo search succeeds (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {

--- a/src/components/chat-components/RelevantNotes.test.tsx
+++ b/src/components/chat-components/RelevantNotes.test.tsx
@@ -225,27 +225,6 @@ describe("RelevantNotes", () => {
       expect(mockFindRelevantNotes).toHaveBeenCalledTimes(2);
     });
 
-    it("shows graph-only rows without setup guidance after Miyo search succeeds (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
-      mockSettings = { ...mockSettings, enableMiyo: true };
-      mockFindRelevantNotes.mockResolvedValue([
-        {
-          note: { path: "Target.md", title: "Target" },
-          metadata: {
-            score: 0,
-            similarityScore: undefined,
-            hasOutgoingLinks: true,
-            hasBacklinks: false,
-          },
-        },
-      ]);
-
-      render(<RelevantNotes onAddToChat={jest.fn()} />);
-
-      expect(await screen.findByText("Target")).toBeTruthy();
-      expect(screen.queryByText("Check your Miyo setup")).toBeNull();
-      expect(screen.queryByText(/%/)).toBeNull();
-    });
-
     it("refetches Relevant Notes when Miyo settings change (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
       const { rerender } = render(<RelevantNotes onAddToChat={jest.fn()} />);
       await waitFor(() => expect(mockFindRelevantNotes).toHaveBeenCalledTimes(1));

--- a/src/components/chat-components/RelevantNotes.test.tsx
+++ b/src/components/chat-components/RelevantNotes.test.tsx
@@ -25,6 +25,7 @@ let mockSettings = {
   qaExclusions: "",
 };
 let mockMiyoBackend = "unknown";
+let indexChangedListener: (() => void) | null = null;
 
 jest.mock("@/context", () => ({
   useApp: () => mockApp,
@@ -47,7 +48,12 @@ jest.mock("@/search/findRelevantNotes", () => ({
 }));
 
 jest.mock("@/search/indexSignal", () => ({
-  onIndexChanged: () => jest.fn(),
+  onIndexChanged: (listener: () => void) => {
+    indexChangedListener = listener;
+    return () => {
+      if (indexChangedListener === listener) indexChangedListener = null;
+    };
+  },
 }));
 
 jest.mock("@/search/searchUtils", () => ({
@@ -79,6 +85,7 @@ describe("RelevantNotes", () => {
       qaExclusions: "",
     };
     mockMiyoBackend = "unknown";
+    indexChangedListener = null;
     const sourceFile = makeMarkdownFile("Source.md");
     const targetFile = makeMarkdownFile("Target.md");
     mockUseActiveFile.mockReturnValue(sourceFile);
@@ -189,6 +196,30 @@ describe("RelevantNotes", () => {
 
       mockMiyoBackend = "available";
       rerender(<RelevantNotes onAddToChat={jest.fn()} />);
+
+      expect(await screen.findByText("Target")).toBeTruthy();
+      expect(mockFindRelevantNotes).toHaveBeenCalledTimes(2);
+    });
+
+    it("refetches after Miyo registration or resync signals an index change (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      mockSettings = { ...mockSettings, enableMiyo: true };
+      mockMiyoBackend = "available";
+      mockFindRelevantNotes.mockResolvedValueOnce([]).mockResolvedValueOnce([
+        {
+          note: { path: "Target.md", title: "Target" },
+          metadata: {
+            score: 0.9,
+            similarityScore: 0.9,
+            hasOutgoingLinks: false,
+            hasBacklinks: false,
+          },
+        },
+      ]);
+
+      render(<RelevantNotes onAddToChat={jest.fn()} />);
+      expect(await screen.findByText("Check your Miyo setup")).toBeTruthy();
+
+      act(() => indexChangedListener?.());
 
       expect(await screen.findByText("Target")).toBeTruthy();
       expect(mockFindRelevantNotes).toHaveBeenCalledTimes(2);

--- a/src/components/chat-components/RelevantNotes.test.tsx
+++ b/src/components/chat-components/RelevantNotes.test.tsx
@@ -102,27 +102,27 @@ describe("RelevantNotes", () => {
       expect(mockOpenFile).toHaveBeenCalledWith(expect.objectContaining({ path: "Target.md" }));
     });
 
-    it("keeps links-only rows visible without a meter and shows Miyo download guidance (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
-      mockFindRelevantNotes.mockResolvedValue([
-        {
-          note: { path: "Target.md", title: "Target" },
-          metadata: {
-            score: 0,
-            similarityScore: undefined,
-            hasOutgoingLinks: false,
-            hasBacklinks: true,
-          },
-        },
-      ]);
+    it("shows Miyo download guidance without graph-only rows when Miyo is disabled (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      mockFindRelevantNotes.mockResolvedValue([]);
 
       render(<RelevantNotes onAddToChat={jest.fn()} />);
 
-      expect(await screen.findByText("Target")).toBeTruthy();
-      expect(screen.getByText("Add semantic matches with Miyo")).toBeTruthy();
-      expect(screen.queryByText(/%/)).toBeNull();
+      expect(await screen.findByText("Add semantic matches with Miyo")).toBeTruthy();
+      expect(screen.queryByText("Target")).toBeNull();
     });
 
-    it("shows setup guidance for links-only rows when Miyo is enabled and opens the Miyo settings tab (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+    it("shows empty setup guidance when Miyo is unavailable and opens the Miyo settings tab (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      mockSettings = { ...mockSettings, enableMiyo: true };
+      mockFindRelevantNotes.mockResolvedValue([]);
+
+      render(<RelevantNotes onAddToChat={jest.fn()} />);
+
+      fireEvent.click(await screen.findByRole("button", { name: "Open Miyo settings" }));
+      expect(screen.queryByText("Target")).toBeNull();
+      expect(openCopilotSettings).toHaveBeenCalledWith(mockApp, window, "miyo");
+    });
+
+    it("shows graph-only rows without setup guidance after Miyo search succeeds (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
       mockSettings = { ...mockSettings, enableMiyo: true };
       mockFindRelevantNotes.mockResolvedValue([
         {
@@ -138,8 +138,9 @@ describe("RelevantNotes", () => {
 
       render(<RelevantNotes onAddToChat={jest.fn()} />);
 
-      fireEvent.click(await screen.findByRole("button", { name: "Open Miyo settings" }));
-      expect(openCopilotSettings).toHaveBeenCalledWith(mockApp, window, "miyo");
+      expect(await screen.findByText("Target")).toBeTruthy();
+      expect(screen.queryByText("Check your Miyo setup")).toBeNull();
+      expect(screen.queryByText(/%/)).toBeNull();
     });
 
     it("refetches Relevant Notes when Miyo settings change (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {

--- a/src/components/chat-components/RelevantNotes.test.tsx
+++ b/src/components/chat-components/RelevantNotes.test.tsx
@@ -2,7 +2,8 @@
 import { RelevantNotes } from "@/components/chat-components/RelevantNotes";
 import { useActiveFile } from "@/hooks/useActiveFile";
 import { findRelevantNotes } from "@/search/findRelevantNotes";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { openCopilotSettings } from "@/settings/openSettings";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { TFile } from "obsidian";
 import React from "react";
 
@@ -17,14 +18,12 @@ const mockApp = {
     getLeaf: mockGetLeaf,
   },
 };
-
-jest.mock("@/aiParams", () => ({
-  useIndexingProgress: () => [{ isActive: false, indexedCount: 0, totalFiles: 0 }],
-}));
-
-jest.mock("@/components/modals/SemanticSearchToggleModal", () => ({
-  SemanticSearchToggleModal: jest.fn(),
-}));
+let mockSettings = {
+  enableMiyo: false,
+  miyoServerUrl: "",
+  qaInclusions: "",
+  qaExclusions: "",
+};
 
 jest.mock("@/context", () => ({
   useApp: () => mockApp,
@@ -36,11 +35,6 @@ jest.mock("@/hooks/useActiveFile", () => ({
 
 jest.mock("@/hooks/useNoteDrag", () => ({
   useNoteDrag: () => jest.fn(),
-}));
-
-jest.mock("@/miyo/miyoUtils", () => ({
-  getSearchBackend: () => "keyword",
-  shouldUseMiyo: () => false,
 }));
 
 jest.mock("@/search/findRelevantNotes", () => ({
@@ -56,21 +50,11 @@ jest.mock("@/search/searchUtils", () => ({
   shouldIndexFile: () => true,
 }));
 
-jest.mock("@/search/vectorStoreManager", () => ({
-  __esModule: true,
-  default: {
-    getInstance: () => ({
-      hasIndex: jest.fn().mockResolvedValue(true),
-      indexVaultToVectorStore: jest.fn().mockResolvedValue(undefined),
-    }),
-  },
+jest.mock("@/settings/model", () => ({
+  useSettingsValue: () => mockSettings,
 }));
 
-jest.mock("@/settings/model", () => ({
-  getSettings: () => ({ enableSemanticSearchV3: true }),
-  updateSetting: jest.fn(),
-  useSettingsValue: () => ({ qaInclusions: "", qaExclusions: "" }),
-}));
+jest.mock("@/settings/openSettings", () => ({ openCopilotSettings: jest.fn() }));
 
 const mockUseActiveFile = useActiveFile as jest.MockedFunction<typeof useActiveFile>;
 const mockFindRelevantNotes = findRelevantNotes as jest.MockedFunction<typeof findRelevantNotes>;
@@ -83,6 +67,12 @@ function makeMarkdownFile(path: string): TFile {
 describe("RelevantNotes", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSettings = {
+      enableMiyo: false,
+      miyoServerUrl: "",
+      qaInclusions: "",
+      qaExclusions: "",
+    };
     const sourceFile = makeMarkdownFile("Source.md");
     const targetFile = makeMarkdownFile("Target.md");
     mockUseActiveFile.mockReturnValue(sourceFile);
@@ -110,6 +100,135 @@ describe("RelevantNotes", () => {
 
       expect(mockGetLeaf).toHaveBeenCalledWith(true);
       expect(mockOpenFile).toHaveBeenCalledWith(expect.objectContaining({ path: "Target.md" }));
+    });
+
+    it("keeps links-only rows visible without a meter and shows Miyo download guidance (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      mockFindRelevantNotes.mockResolvedValue([
+        {
+          note: { path: "Target.md", title: "Target" },
+          metadata: {
+            score: 0,
+            similarityScore: undefined,
+            hasOutgoingLinks: false,
+            hasBacklinks: true,
+          },
+        },
+      ]);
+
+      render(<RelevantNotes onAddToChat={jest.fn()} />);
+
+      expect(await screen.findByText("Target")).toBeTruthy();
+      expect(screen.getByText("Add semantic matches with Miyo")).toBeTruthy();
+      expect(screen.queryByText(/%/)).toBeNull();
+    });
+
+    it("shows setup guidance for links-only rows when Miyo is enabled and opens the Miyo settings tab (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      mockSettings = { ...mockSettings, enableMiyo: true };
+      mockFindRelevantNotes.mockResolvedValue([
+        {
+          note: { path: "Target.md", title: "Target" },
+          metadata: {
+            score: 0,
+            similarityScore: undefined,
+            hasOutgoingLinks: true,
+            hasBacklinks: false,
+          },
+        },
+      ]);
+
+      render(<RelevantNotes onAddToChat={jest.fn()} />);
+
+      fireEvent.click(await screen.findByRole("button", { name: "Open Miyo settings" }));
+      expect(openCopilotSettings).toHaveBeenCalledWith(mockApp, window, "miyo");
+    });
+
+    it("refetches Relevant Notes when Miyo settings change (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      const { rerender } = render(<RelevantNotes onAddToChat={jest.fn()} />);
+      await waitFor(() => expect(mockFindRelevantNotes).toHaveBeenCalledTimes(1));
+
+      mockSettings = { ...mockSettings, enableMiyo: true };
+      rerender(<RelevantNotes onAddToChat={jest.fn()} />);
+
+      await waitFor(() => expect(mockFindRelevantNotes).toHaveBeenCalledTimes(2));
+    });
+
+    it("keeps a superseded Miyo request from overwriting newer results (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      let resolveFirst:
+        | ((notes: Awaited<ReturnType<typeof findRelevantNotes>>) => void)
+        | undefined;
+      const firstResult = new Promise<Awaited<ReturnType<typeof findRelevantNotes>>>((resolve) => {
+        resolveFirst = resolve;
+      });
+      mockFindRelevantNotes.mockReturnValueOnce(firstResult).mockResolvedValueOnce([
+        {
+          note: { path: "Current.md", title: "Current" },
+          metadata: {
+            score: 0.9,
+            similarityScore: 0.9,
+            hasOutgoingLinks: false,
+            hasBacklinks: false,
+          },
+        },
+      ]);
+
+      const { rerender } = render(<RelevantNotes onAddToChat={jest.fn()} />);
+      await waitFor(() => expect(mockFindRelevantNotes).toHaveBeenCalledTimes(1));
+
+      mockSettings = { ...mockSettings, enableMiyo: true, miyoServerUrl: "https://new-miyo" };
+      rerender(<RelevantNotes onAddToChat={jest.fn()} />);
+      expect(await screen.findByText("Current")).toBeTruthy();
+
+      await act(async () => {
+        resolveFirst?.([
+          {
+            note: { path: "Stale.md", title: "Stale" },
+            metadata: {
+              score: 0.7,
+              similarityScore: 0.7,
+              hasOutgoingLinks: false,
+              hasBacklinks: false,
+            },
+          },
+        ]);
+        await firstResult;
+      });
+
+      expect(screen.queryByText("Stale")).toBeNull();
+      expect(screen.getByText("Current")).toBeTruthy();
+    });
+
+    it("keeps a superseded Miyo failure from clearing newer results (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      let rejectFirst: ((reason: Error) => void) | undefined;
+      const firstResult = new Promise<Awaited<ReturnType<typeof findRelevantNotes>>>(
+        (_, reject) => {
+          rejectFirst = reject;
+        }
+      );
+      mockFindRelevantNotes.mockReturnValueOnce(firstResult).mockResolvedValueOnce([
+        {
+          note: { path: "Current.md", title: "Current" },
+          metadata: {
+            score: 0.9,
+            similarityScore: 0.9,
+            hasOutgoingLinks: false,
+            hasBacklinks: false,
+          },
+        },
+      ]);
+
+      const { rerender } = render(<RelevantNotes onAddToChat={jest.fn()} />);
+      await waitFor(() => expect(mockFindRelevantNotes).toHaveBeenCalledTimes(1));
+
+      mockSettings = { ...mockSettings, enableMiyo: true, miyoServerUrl: "https://new-miyo" };
+      rerender(<RelevantNotes onAddToChat={jest.fn()} />);
+      expect(await screen.findByText("Current")).toBeTruthy();
+
+      await act(async () => {
+        rejectFirst?.(new Error("Old endpoint failed"));
+        await expect(firstResult).rejects.toThrow("Old endpoint failed");
+      });
+
+      expect(screen.getByText("Current")).toBeTruthy();
     });
   });
 });

--- a/src/components/chat-components/RelevantNotes.tsx
+++ b/src/components/chat-components/RelevantNotes.tsx
@@ -368,15 +368,11 @@ export const RelevantNotes = memo(
       onAddToChat(`[[${prompt}]]`);
     };
 
-    // A links-only result set signals the absence of Miyo scores directly. It
-    // must keep its rows visible while still showing download or setup help.
+    // Miyo help is an empty state, not a banner above graph-only fallback rows.
+    // A successful Miyo search can still return direct links and backlinks.
     // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
-    const hasSemanticMatches = relevantNotes.some((note) => note.metadata.similarityScore != null);
-    const guidance: RelevantNotesGuidance = hasSemanticMatches
-      ? null
-      : settings.enableMiyo
-        ? "setup"
-        : "download";
+    const guidance: RelevantNotesGuidance =
+      relevantNotes.length > 0 ? null : settings.enableMiyo ? "setup" : "download";
 
     return (
       <div className={cn("tw-flex tw-min-h-full tw-w-full tw-flex-1 tw-flex-col", className)}>

--- a/src/components/chat-components/RelevantNotes.tsx
+++ b/src/components/chat-components/RelevantNotes.tsx
@@ -202,15 +202,13 @@ function RelevantNoteHoverCard({
           </p>
         )}
 
-        {similarity != null && (
-          <div className="tw-flex tw-items-center tw-gap-2">
-            <span className="tw-shrink-0 tw-text-xs tw-text-faint">Similarity</span>
-            <RelevanceMeter score={similarity} className="tw-h-1 tw-flex-1" />
-            <span className="tw-shrink-0 tw-text-xs tw-font-medium tw-tabular-nums tw-text-normal">
-              {(similarity * 100).toFixed(1)}%
-            </span>
-          </div>
-        )}
+        <div className="tw-flex tw-items-center tw-gap-2">
+          <span className="tw-shrink-0 tw-text-xs tw-text-faint">Similarity</span>
+          <RelevanceMeter score={similarity} className="tw-h-1 tw-flex-1" />
+          <span className="tw-shrink-0 tw-text-xs tw-font-medium tw-tabular-nums tw-text-normal">
+            {(similarity * 100).toFixed(1)}%
+          </span>
+        </div>
 
         {(note.metadata.hasOutgoingLinks || note.metadata.hasBacklinks) && (
           <div className="tw-flex tw-items-center tw-gap-4 tw-text-xs tw-text-faint">
@@ -305,11 +303,9 @@ function RelevantNoteRow({
             {note.metadata.hasBacklinks && (
               <LinkBadge icon={<FileInput className="tw-size-3" />} label="Backlink" />
             )}
-            {similarity != null && (
-              <span className="tw-text-xs tw-font-medium tw-tabular-nums tw-text-muted">
-                {Math.round(similarity * 100)}%
-              </span>
-            )}
+            <span className="tw-text-xs tw-font-medium tw-tabular-nums tw-text-muted">
+              {Math.round(similarity * 100)}%
+            </span>
           </div>
 
           <div className="tw-hidden tw-shrink-0 tw-items-center tw-gap-0.5 group-hover:tw-flex">
@@ -340,7 +336,7 @@ function RelevantNoteRow({
           </div>
         </div>
 
-        {similarity != null && <RelevanceMeter score={similarity} className="tw-mt-1.5" />}
+        <RelevanceMeter score={similarity} className="tw-mt-1.5" />
       </div>
     </RelevantNoteHoverCard>
   );
@@ -405,9 +401,9 @@ export const RelevantNotes = memo(
       onAddToChat(`[[${prompt}]]`);
     };
 
-    // Miyo help is an empty state, not a banner above graph-only fallback rows.
-    // A successful search can include links and backlinks, but without a source
-    // note or a settled request there is no evidence of a setup failure.
+    // Links only annotate Miyo matches, so a settled empty search has no result
+    // rows to show. Without a source note or a settled request, there is no
+    // evidence of a setup or indexing problem.
     // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
     const guidance: RelevantNotesGuidance =
       !activeFile || isPending || relevantNotes.length > 0

--- a/src/components/chat-components/RelevantNotes.tsx
+++ b/src/components/chat-components/RelevantNotes.tsx
@@ -1,33 +1,25 @@
-import { useIndexingProgress } from "@/aiParams";
-import { SemanticSearchToggleModal } from "@/components/modals/SemanticSearchToggleModal";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
-import { Progress } from "@/components/ui/progress";
+import {
+  RelevantNotesPane,
+  type RelevantNotesGuidance,
+} from "@/components/chat-components/ui/RelevantNotesPane";
+import { MIYO_HOMEPAGE_URL } from "@/constants";
 import { useApp } from "@/context";
 import { useActiveFile } from "@/hooks/useActiveFile";
 import { useNoteDrag } from "@/hooks/useNoteDrag";
 import { cn } from "@/lib/utils";
 import { logError, logWarn } from "@/logger";
-import { getSearchBackend } from "@/miyo/miyoUtils";
 import { findRelevantNotes, RelevantNoteEntry } from "@/search/findRelevantNotes";
 import { onIndexChanged } from "@/search/indexSignal";
 import { getMatchingPatterns, shouldIndexFile } from "@/search/searchUtils";
+import { openCopilotSettings } from "@/settings/openSettings";
 import { useSettingsValue } from "@/settings/model";
-import {
-  ArrowRight,
-  EyeOff,
-  FileInput,
-  FileOutput,
-  FileText,
-  GitFork,
-  Loader2,
-  PlusCircle,
-  RefreshCw,
-} from "lucide-react";
+import { ArrowRight, EyeOff, FileInput, FileOutput, FileText, PlusCircle } from "lucide-react";
 import { TFile } from "obsidian";
 import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
 
-function useRelevantNotes(refresher: number) {
+function useRelevantNotes(enableMiyo: boolean, miyoServerUrl: string) {
   const app = useApp();
   const [relevantNotes, setRelevantNotes] = useState<RelevantNoteEntry[]>([]);
   const [signalTick, setSignalTick] = useState(0);
@@ -36,55 +28,31 @@ function useRelevantNotes(refresher: number) {
   useEffect(() => onIndexChanged(() => setSignalTick((t) => t + 1)), []);
 
   useEffect(() => {
+    let cancelled = false;
+
     async function fetchNotes() {
       if (!activeFile?.path) return;
       try {
         const notes = await findRelevantNotes({ app, filePath: activeFile.path });
-        setRelevantNotes(notes);
+        // A settings or active-note change can supersede an in-flight Miyo
+        // request. Its older result must not replace the newer pane state.
+        // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+        if (!cancelled) setRelevantNotes(notes);
       } catch (error) {
-        logWarn("Failed to fetch relevant notes", error);
-        setRelevantNotes([]);
+        if (!cancelled) {
+          logWarn("Failed to fetch relevant notes", error);
+          setRelevantNotes([]);
+        }
       }
     }
 
     void fetchNotes();
-  }, [app, activeFile?.path, refresher, signalTick]);
+    return () => {
+      cancelled = true;
+    };
+  }, [app, activeFile?.path, enableMiyo, miyoServerUrl, signalTick]);
 
   return relevantNotes;
-}
-
-function useHasIndex(notePath: string, refresher: number) {
-  const [hasIndex, setHasIndex] = useState(true);
-  const [signalTick, setSignalTick] = useState(0);
-
-  useEffect(() => onIndexChanged(() => setSignalTick((t) => t + 1)), []);
-
-  useEffect(() => {
-    if (!notePath) return;
-
-    async function fetchHasIndex() {
-      try {
-        const VectorStoreManager = (await import("@/search/vectorStoreManager")).default;
-        const { getSettings } = await import("@/settings/model");
-        const settings = getSettings();
-        const useMiyo = getSearchBackend(settings) === "miyo";
-
-        if (useMiyo) {
-          const isEmpty = await VectorStoreManager.getInstance().isIndexEmpty();
-          setHasIndex(!isEmpty);
-          return;
-        }
-
-        const has = await VectorStoreManager.getInstance().hasIndex(notePath);
-        setHasIndex(has);
-      } catch {
-        setHasIndex(false);
-      }
-    }
-
-    void fetchHasIndex();
-  }, [notePath, refresher, signalTick]);
-  return hasIndex;
 }
 
 /** Map a 0–1 similarity score directly to the meter fill width (70% → 70%). */
@@ -346,15 +314,7 @@ function RelevantNoteRow({
   );
 }
 
-function RelevantNotesToolbar({
-  activeFileName,
-  isBuilding,
-  onBuild,
-}: {
-  activeFileName: string | undefined;
-  isBuilding: boolean;
-  onBuild: () => void;
-}) {
+function RelevantNotesToolbar({ activeFileName }: { activeFileName: string | undefined }) {
   return (
     <div className="tw-flex tw-flex-none tw-items-center tw-gap-2 tw-border-0 tw-border-b tw-border-solid tw-border-border tw-px-3 tw-py-2">
       <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-1.5 tw-text-xs tw-text-faint">
@@ -368,32 +328,6 @@ function RelevantNotesToolbar({
           <span className="tw-text-muted">—</span>
         )}
       </div>
-      <Button
-        variant="secondary"
-        size="sm"
-        disabled={isBuilding}
-        onClick={onBuild}
-        className="tw-ml-auto tw-shrink-0 tw-gap-1.5"
-      >
-        <RefreshCw className={cn("tw-size-3.5", isBuilding && "tw-animate-spin")} />
-        {isBuilding ? "Building…" : "Build index"}
-      </Button>
-    </div>
-  );
-}
-
-function BuildOverlay({ indexedCount, totalFiles }: { indexedCount: number; totalFiles: number }) {
-  const progress = totalFiles > 0 ? Math.round((indexedCount / totalFiles) * 100) : 0;
-  return (
-    <div className="tw-absolute tw-inset-0 tw-flex tw-flex-col tw-items-center tw-justify-center tw-gap-4 tw-px-10 tw-text-center tw-backdrop-blur-sm tw-bg-primary/90">
-      <Loader2 className="tw-size-6 tw-animate-spin tw-text-accent" />
-      <span className="tw-text-sm tw-font-semibold tw-text-normal">Indexing your vault</span>
-      <Progress value={progress} className="tw-h-1 tw-w-48" />
-      {totalFiles > 0 && (
-        <span className="tw-text-xs tw-tabular-nums tw-text-faint">
-          {indexedCount} / {totalFiles} notes embedded
-        </span>
-      )}
     </div>
   );
 }
@@ -407,12 +341,9 @@ interface RelevantNotesProps {
 export const RelevantNotes = memo(
   ({ className, onAddToChat }: RelevantNotesProps): React.ReactElement => {
     const app = useApp();
-    const [refresher, setRefresher] = useState(0);
-    const relevantNotes = useRelevantNotes(refresher);
     const activeFile = useActiveFile();
-    const hasIndex = useHasIndex(activeFile?.path ?? "", refresher);
-    const [indexingState] = useIndexingProgress();
     const settings = useSettingsValue();
+    const relevantNotes = useRelevantNotes(settings.enableMiyo, settings.miyoServerUrl);
 
     // The active note itself is excluded from the index (by the QA
     // inclusion/exclusion settings or an internal exclusion), so no relevant
@@ -437,37 +368,19 @@ export const RelevantNotes = memo(
       onAddToChat(`[[${prompt}]]`);
     };
 
-    const handleBuildIndex = async () => {
-      const { getSettings, updateSetting } = await import("@/settings/model");
-      const settings = getSettings();
-
-      if (!settings.enableSemanticSearchV3) {
-        // Semantic search is off — show confirmation modal (same as settings page)
-        new SemanticSearchToggleModal(
-          app,
-          async () => {
-            updateSetting("enableSemanticSearchV3", true);
-            const VectorStoreManager = (await import("@/search/vectorStoreManager")).default;
-            await VectorStoreManager.getInstance().indexVaultToVectorStore(false, {
-              userInitiated: true,
-            });
-            setRefresher(refresher + 1);
-          },
-          true // enabling
-        ).open();
-      } else {
-        // Semantic search is on but index missing — build it
-        const VectorStoreManager = (await import("@/search/vectorStoreManager")).default;
-        await VectorStoreManager.getInstance().indexVaultToVectorStore(false, {
-          userInitiated: true,
-        });
-        setRefresher(refresher + 1);
-      }
-    };
+    // A links-only result set signals the absence of Miyo scores directly. It
+    // must keep its rows visible while still showing download or setup help.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+    const hasSemanticMatches = relevantNotes.some((note) => note.metadata.similarityScore != null);
+    const guidance: RelevantNotesGuidance = hasSemanticMatches
+      ? null
+      : settings.enableMiyo
+        ? "setup"
+        : "download";
 
     return (
       <div className={cn("tw-flex tw-min-h-full tw-w-full tw-flex-1 tw-flex-col", className)}>
-        {isActiveFileExcluded && (
+        {isActiveFileExcluded ? (
           <div
             data-relevant-notes-empty-state
             className="tw-flex tw-flex-1 tw-flex-col tw-items-center tw-justify-center tw-px-6"
@@ -487,71 +400,28 @@ export const RelevantNotes = memo(
               </div>
             </div>
           </div>
-        )}
-
-        {!isActiveFileExcluded && !hasIndex && (
-          <div
-            data-relevant-notes-empty-state
-            className="tw-flex tw-flex-1 tw-flex-col tw-items-center tw-justify-center tw-px-6"
-          >
-            <div className="tw-flex tw-w-full tw-max-w-xs tw-flex-col tw-items-center tw-gap-6 tw-text-center">
-              <div className="tw-flex tw-size-16 tw-items-center tw-justify-center tw-rounded-xl tw-border tw-border-solid tw-border-border tw-bg-secondary">
-                <GitFork className="tw-size-7 tw-text-accent" />
-              </div>
-              <div className="tw-flex tw-flex-col tw-gap-1.5">
-                <span className="tw-text-lg tw-font-semibold tw-text-normal">
-                  No semantic index yet
-                </span>
-                <span className="tw-text-sm tw-text-muted">
-                  {"Build it once to surface notes related to whatever you're writing."}
-                </span>
-              </div>
-              <div className="tw-flex tw-w-full tw-flex-col tw-items-center tw-gap-3">
-                <Button
-                  variant="default"
-                  onClick={() => void handleBuildIndex()}
-                  className="tw-h-11 tw-w-full tw-gap-2 tw-rounded-lg"
-                >
-                  <GitFork className="tw-size-4" />
-                  Build index
-                </Button>
-              </div>
-            </div>
-          </div>
-        )}
-
-        {!isActiveFileExcluded && hasIndex && (
+        ) : (
           <>
-            <RelevantNotesToolbar
-              activeFileName={activeFile?.basename}
-              isBuilding={indexingState.isActive}
-              onBuild={() => void handleBuildIndex()}
-            />
+            <RelevantNotesToolbar activeFileName={activeFile?.basename} />
             <div className="tw-relative tw-min-h-0 tw-flex-1">
               <div className="tw-absolute tw-inset-0 tw-overflow-y-auto tw-p-2">
-                {relevantNotes.length === 0 ? (
-                  <div className="tw-flex tw-h-full tw-items-center tw-justify-center tw-px-4 tw-text-center">
-                    <span className="tw-text-sm tw-text-muted">No relevant notes found</span>
-                  </div>
-                ) : (
-                  <div className="tw-flex tw-flex-col tw-gap-0.5">
-                    {relevantNotes.map((note) => (
-                      <RelevantNoteRow
-                        key={note.note.path}
-                        note={note}
-                        onAddToChat={() => addToChat(note.note.title)}
-                        onNavigateToNote={() => navigateToNote(note.note.path)}
-                      />
-                    ))}
-                  </div>
-                )}
-              </div>
-              {indexingState.isActive && (
-                <BuildOverlay
-                  indexedCount={indexingState.indexedCount}
-                  totalFiles={indexingState.totalFiles}
+                <RelevantNotesPane
+                  guidance={guidance}
+                  noteCount={relevantNotes.length}
+                  noteRows={relevantNotes.map((note) => (
+                    <RelevantNoteRow
+                      key={note.note.path}
+                      note={note}
+                      onAddToChat={() => addToChat(note.note.title)}
+                      onNavigateToNote={() => navigateToNote(note.note.path)}
+                    />
+                  ))}
+                  miyoDownloadUrl={MIYO_HOMEPAGE_URL}
+                  onOpenMiyoSettings={(event) =>
+                    openCopilotSettings(app, event.currentTarget.win, "miyo")
+                  }
                 />
-              )}
+              </div>
             </div>
           </>
         )}

--- a/src/components/chat-components/RelevantNotes.tsx
+++ b/src/components/chat-components/RelevantNotes.tsx
@@ -10,7 +10,8 @@ import { useActiveFile } from "@/hooks/useActiveFile";
 import { useNoteDrag } from "@/hooks/useNoteDrag";
 import { cn } from "@/lib/utils";
 import { logError, logWarn } from "@/logger";
-import { findRelevantNotes, RelevantNoteEntry } from "@/search/findRelevantNotes";
+import { useMiyoStatus } from "@/miyo/useMiyoStatus";
+import { findRelevantNotes, type RelevantNoteEntry } from "@/search/findRelevantNotes";
 import { onIndexChanged } from "@/search/indexSignal";
 import { getMatchingPatterns, shouldIndexFile } from "@/search/searchUtils";
 import { openCopilotSettings } from "@/settings/openSettings";
@@ -19,11 +20,30 @@ import { ArrowRight, EyeOff, FileInput, FileOutput, FileText, PlusCircle } from 
 import { TFile } from "obsidian";
 import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
 
-function useRelevantNotes(enableMiyo: boolean, miyoServerUrl: string) {
+const EMPTY_RELEVANT_NOTES: readonly RelevantNoteEntry[] = Object.freeze([]);
+
+interface RelevantNotesRequestResult {
+  requestKey: string | null;
+  notes: readonly RelevantNoteEntry[];
+}
+
+const EMPTY_RELEVANT_NOTES_RESULT: RelevantNotesRequestResult = Object.freeze({
+  requestKey: null,
+  notes: EMPTY_RELEVANT_NOTES,
+});
+
+function useRelevantNotes(
+  enableMiyo: boolean,
+  miyoServerUrl: string,
+  miyoBackendAvailable: boolean
+) {
   const app = useApp();
-  const [relevantNotes, setRelevantNotes] = useState<RelevantNoteEntry[]>([]);
+  const [result, setResult] = useState<RelevantNotesRequestResult>(EMPTY_RELEVANT_NOTES_RESULT);
   const [signalTick, setSignalTick] = useState(0);
   const activeFile = useActiveFile();
+  const requestKey = activeFile?.path
+    ? JSON.stringify([activeFile.path, enableMiyo, miyoServerUrl, miyoBackendAvailable, signalTick])
+    : null;
 
   useEffect(() => onIndexChanged(() => setSignalTick((t) => t + 1)), []);
 
@@ -31,17 +51,23 @@ function useRelevantNotes(enableMiyo: boolean, miyoServerUrl: string) {
     let cancelled = false;
 
     async function fetchNotes() {
-      if (!activeFile?.path) return;
+      // Leaving the source-note state must also forget its settled request. If
+      // the same note reopens later, it needs a fresh loading and result cycle.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+      if (!activeFile?.path || requestKey === null) {
+        setResult(EMPTY_RELEVANT_NOTES_RESULT);
+        return;
+      }
       try {
         const notes = await findRelevantNotes({ app, filePath: activeFile.path });
         // A settings or active-note change can supersede an in-flight Miyo
         // request. Its older result must not replace the newer pane state.
         // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
-        if (!cancelled) setRelevantNotes(notes);
+        if (!cancelled) setResult({ requestKey, notes });
       } catch (error) {
         if (!cancelled) {
           logWarn("Failed to fetch relevant notes", error);
-          setRelevantNotes([]);
+          setResult({ requestKey, notes: EMPTY_RELEVANT_NOTES });
         }
       }
     }
@@ -50,9 +76,15 @@ function useRelevantNotes(enableMiyo: boolean, miyoServerUrl: string) {
     return () => {
       cancelled = true;
     };
-  }, [app, activeFile?.path, enableMiyo, miyoServerUrl, signalTick]);
+  }, [app, activeFile?.path, requestKey]);
 
-  return relevantNotes;
+  // Results from a previous source or Miyo state must not describe the current
+  // request. Treat the exact current request as pending until it settles.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+  return {
+    isPending: enableMiyo && requestKey !== null && result.requestKey !== requestKey,
+    relevantNotes: result.requestKey === requestKey ? result.notes : EMPTY_RELEVANT_NOTES,
+  };
 }
 
 /** Map a 0–1 similarity score directly to the meter fill width (70% → 70%). */
@@ -343,7 +375,12 @@ export const RelevantNotes = memo(
     const app = useApp();
     const activeFile = useActiveFile();
     const settings = useSettingsValue();
-    const relevantNotes = useRelevantNotes(settings.enableMiyo, settings.miyoServerUrl);
+    const miyoBackendAvailable = useMiyoStatus().backend === "available";
+    const { isPending, relevantNotes } = useRelevantNotes(
+      settings.enableMiyo,
+      settings.miyoServerUrl,
+      miyoBackendAvailable
+    );
 
     // The active note itself is excluded from the index (by the QA
     // inclusion/exclusion settings or an internal exclusion), so no relevant
@@ -369,10 +406,15 @@ export const RelevantNotes = memo(
     };
 
     // Miyo help is an empty state, not a banner above graph-only fallback rows.
-    // A successful Miyo search can still return direct links and backlinks.
+    // A successful search can include links and backlinks, but without a source
+    // note or a settled request there is no evidence of a setup failure.
     // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
     const guidance: RelevantNotesGuidance =
-      relevantNotes.length > 0 ? null : settings.enableMiyo ? "setup" : "download";
+      !activeFile || isPending || relevantNotes.length > 0
+        ? null
+        : settings.enableMiyo
+          ? "setup"
+          : "download";
 
     return (
       <div className={cn("tw-flex tw-min-h-full tw-w-full tw-flex-1 tw-flex-col", className)}>
@@ -403,6 +445,7 @@ export const RelevantNotes = memo(
               <div className="tw-absolute tw-inset-0 tw-overflow-y-auto tw-p-2">
                 <RelevantNotesPane
                   guidance={guidance}
+                  isPending={isPending}
                   noteCount={relevantNotes.length}
                   noteRows={relevantNotes.map((note) => (
                     <RelevantNoteRow

--- a/src/components/chat-components/ui/RelevantNotesPane.stories.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.stories.tsx
@@ -1,0 +1,65 @@
+import {
+  RelevantNotesPane,
+  type RelevantNotesPaneProps,
+} from "@/components/chat-components/ui/RelevantNotesPane";
+import type { Meta, StoryObj } from "@/lib/story";
+import { FileInput, FileOutput } from "lucide-react";
+import React from "react";
+
+function NoteRows({ scored }: { scored: boolean }) {
+  return (
+    <>
+      {[
+        { title: "Design principles", score: 0.86, outgoing: true, backlink: false },
+        { title: "Product research", score: 0.72, outgoing: false, backlink: true },
+      ].map((note) => (
+        <div
+          key={note.title}
+          className="tw-flex tw-min-h-8 tw-items-center tw-gap-2 tw-rounded-md tw-px-2.5 tw-py-1.5"
+        >
+          <span className="tw-min-w-0 tw-flex-1 tw-truncate tw-text-sm tw-font-medium tw-text-normal">
+            {note.title}
+          </span>
+          {note.outgoing && <FileOutput className="tw-size-3 tw-text-faint" />}
+          {note.backlink && <FileInput className="tw-size-3 tw-text-faint" />}
+          {scored && (
+            <span className="tw-text-xs tw-font-medium tw-tabular-nums tw-text-muted">
+              {Math.round(note.score * 100)}%
+            </span>
+          )}
+        </div>
+      ))}
+    </>
+  );
+}
+
+const baseArgs: RelevantNotesPaneProps = {
+  guidance: null,
+  noteCount: 2,
+  noteRows: <NoteRows scored />,
+  miyoDownloadUrl: "https://www.miyo.md/",
+  onOpenMiyoSettings: () => undefined,
+};
+
+const meta = {
+  title: "Chat/Relevant Notes Pane",
+  component: RelevantNotesPane,
+  args: baseArgs,
+  parameters: { gallery: { host: "leaf", layout: "fullscreen" } },
+} satisfies Meta<RelevantNotesPaneProps>;
+
+export default meta;
+
+export const ConnectedScoredResults: StoryObj<RelevantNotesPaneProps> = {};
+
+export const NoMiyoEmptyGuidance: StoryObj<RelevantNotesPaneProps> = {
+  args: { guidance: "download", noteCount: 0, noteRows: null },
+};
+
+export const LinksOnlyDownloadGuidance: StoryObj<RelevantNotesPaneProps> = {
+  args: { guidance: "download", noteRows: <NoteRows scored={false} /> },
+};
+
+export const LinksOnlySetupGuidance: StoryObj<RelevantNotesPaneProps> = {
+  args: { guidance: "setup", noteRows: <NoteRows scored={false} /> },
+};

--- a/src/components/chat-components/ui/RelevantNotesPane.stories.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.stories.tsx
@@ -35,6 +35,7 @@ function NoteRows({ scored }: { scored: boolean }) {
 
 const baseArgs: RelevantNotesPaneProps = {
   guidance: null,
+  isPending: false,
   noteCount: 2,
   noteRows: <NoteRows scored />,
   miyoDownloadUrl: "https://www.miyo.md/",
@@ -51,6 +52,10 @@ const meta = {
 export default meta;
 
 export const ConnectedScoredResults: StoryObj<RelevantNotesPaneProps> = {};
+
+export const Loading: StoryObj<RelevantNotesPaneProps> = {
+  args: { isPending: true, noteCount: 0, noteRows: null },
+};
 
 export const NoMiyoEmptyGuidance: StoryObj<RelevantNotesPaneProps> = {
   args: { guidance: "download", noteCount: 0, noteRows: null },

--- a/src/components/chat-components/ui/RelevantNotesPane.stories.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.stories.tsx
@@ -56,10 +56,6 @@ export const NoMiyoEmptyGuidance: StoryObj<RelevantNotesPaneProps> = {
   args: { guidance: "download", noteCount: 0, noteRows: null },
 };
 
-export const LinksOnlyDownloadGuidance: StoryObj<RelevantNotesPaneProps> = {
-  args: { guidance: "download", noteRows: <NoteRows scored={false} /> },
-};
-
-export const LinksOnlySetupGuidance: StoryObj<RelevantNotesPaneProps> = {
-  args: { guidance: "setup", noteRows: <NoteRows scored={false} /> },
+export const MiyoSetupEmptyGuidance: StoryObj<RelevantNotesPaneProps> = {
+  args: { guidance: "setup", noteCount: 0, noteRows: null },
 };

--- a/src/components/chat-components/ui/RelevantNotesPane.test.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.test.tsx
@@ -1,0 +1,58 @@
+import { RelevantNotesPane, type RelevantNotesPaneProps } from "./RelevantNotesPane";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+const BASE_PROPS: RelevantNotesPaneProps = {
+  guidance: null,
+  noteCount: 1,
+  noteRows: <div>Related note</div>,
+  miyoDownloadUrl: "https://www.miyo.md/",
+  onOpenMiyoSettings: jest.fn(),
+};
+
+describe("RelevantNotesPane", () => {
+  describe("RelevantNotesPane()", () => {
+    it("renders scored results without setup guidance", () => {
+      render(<RelevantNotesPane {...BASE_PROPS} />);
+
+      expect(screen.getByText("Related note")).toBeTruthy();
+      expect(screen.queryByText(/Miyo/)).toBeNull();
+    });
+
+    it("shows honest download guidance when no Miyo scores exist, including beside link rows (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
+      render(<RelevantNotesPane {...BASE_PROPS} guidance="download" />);
+
+      expect(screen.getByText("Related note")).toBeTruthy();
+      expect(screen.getByText("Add semantic matches with Miyo")).toBeTruthy();
+      expect(screen.getByRole("link", { name: "Download Miyo" }).getAttribute("href")).toBe(
+        "https://www.miyo.md/"
+      );
+    });
+
+    it("shows setup guidance beside link rows and opens Copilot's Miyo tab (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
+      const onOpenMiyoSettings = jest.fn();
+      render(
+        <RelevantNotesPane
+          {...BASE_PROPS}
+          guidance="setup"
+          onOpenMiyoSettings={onOpenMiyoSettings}
+        />
+      );
+
+      expect(screen.getByText("Related note")).toBeTruthy();
+      expect(screen.getByText("Check your Miyo setup")).toBeTruthy();
+      expect(screen.queryByRole("link", { name: "Open Miyo" })).toBeNull();
+      fireEvent.click(screen.getByRole("button", { name: "Open Miyo settings" }));
+      expect(onOpenMiyoSettings).toHaveBeenCalledTimes(1);
+    });
+
+    it("centers download guidance when there are no notes or Miyo scores (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
+      render(
+        <RelevantNotesPane {...BASE_PROPS} guidance="download" noteCount={0} noteRows={null} />
+      );
+
+      expect(screen.getByText("Add semantic matches with Miyo")).toBeTruthy();
+      expect(screen.queryByText("No relevant notes found")).toBeNull();
+    });
+  });
+});

--- a/src/components/chat-components/ui/RelevantNotesPane.test.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.test.tsx
@@ -19,40 +19,35 @@ describe("RelevantNotesPane", () => {
       expect(screen.queryByText(/Miyo/)).toBeNull();
     });
 
-    it("shows honest download guidance when no Miyo scores exist, including beside link rows (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
-      render(<RelevantNotesPane {...BASE_PROPS} guidance="download" />);
+    it("shows download guidance without graph-only rows when Miyo is disabled (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
+      render(
+        <RelevantNotesPane {...BASE_PROPS} guidance="download" noteCount={0} noteRows={null} />
+      );
 
-      expect(screen.getByText("Related note")).toBeTruthy();
+      expect(screen.queryByText("Related note")).toBeNull();
       expect(screen.getByText("Add semantic matches with Miyo")).toBeTruthy();
       expect(screen.getByRole("link", { name: "Download Miyo" }).getAttribute("href")).toBe(
         "https://www.miyo.md/"
       );
     });
 
-    it("shows setup guidance beside link rows and opens Copilot's Miyo tab (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
+    it("shows empty setup guidance and opens Copilot's Miyo tab (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
       const onOpenMiyoSettings = jest.fn();
       render(
         <RelevantNotesPane
           {...BASE_PROPS}
           guidance="setup"
+          noteCount={0}
+          noteRows={null}
           onOpenMiyoSettings={onOpenMiyoSettings}
         />
       );
 
-      expect(screen.getByText("Related note")).toBeTruthy();
+      expect(screen.queryByText("Related note")).toBeNull();
       expect(screen.getByText("Check your Miyo setup")).toBeTruthy();
       expect(screen.queryByRole("link", { name: "Open Miyo" })).toBeNull();
       fireEvent.click(screen.getByRole("button", { name: "Open Miyo settings" }));
       expect(onOpenMiyoSettings).toHaveBeenCalledTimes(1);
-    });
-
-    it("centers download guidance when there are no notes or Miyo scores (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
-      render(
-        <RelevantNotesPane {...BASE_PROPS} guidance="download" noteCount={0} noteRows={null} />
-      );
-
-      expect(screen.getByText("Add semantic matches with Miyo")).toBeTruthy();
-      expect(screen.queryByText("No relevant notes found")).toBeNull();
     });
   });
 });

--- a/src/components/chat-components/ui/RelevantNotesPane.test.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.test.tsx
@@ -4,6 +4,7 @@ import React from "react";
 
 const BASE_PROPS: RelevantNotesPaneProps = {
   guidance: null,
+  isPending: false,
   noteCount: 1,
   noteRows: <div>Related note</div>,
   miyoDownloadUrl: "https://www.miyo.md/",
@@ -12,6 +13,22 @@ const BASE_PROPS: RelevantNotesPaneProps = {
 
 describe("RelevantNotesPane", () => {
   describe("RelevantNotesPane()", () => {
+    it("shows neutral loading feedback while the Miyo request is pending (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
+      render(
+        <RelevantNotesPane
+          {...BASE_PROPS}
+          guidance="setup"
+          isPending
+          noteCount={0}
+          noteRows={null}
+        />
+      );
+
+      expect(screen.getByText("Finding relevant notes…")).toBeTruthy();
+      expect(screen.queryByText("Check your Miyo setup")).toBeNull();
+      expect(screen.queryByText("No relevant notes found")).toBeNull();
+    });
+
     it("renders scored results without setup guidance", () => {
       render(<RelevantNotesPane {...BASE_PROPS} />);
 

--- a/src/components/chat-components/ui/RelevantNotesPane.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.tsx
@@ -1,0 +1,79 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { Download } from "lucide-react";
+import React from "react";
+
+export type RelevantNotesGuidance = "download" | "setup" | null;
+
+export interface RelevantNotesPaneProps {
+  guidance: RelevantNotesGuidance;
+  noteCount: number;
+  noteRows: React.ReactNode;
+  miyoDownloadUrl: string;
+  onOpenMiyoSettings: (event: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+/** Render the result, empty, and Miyo-help states without plugin or Obsidian runtime access. */
+export function RelevantNotesPane({
+  guidance,
+  noteCount,
+  noteRows,
+  miyoDownloadUrl,
+  onOpenMiyoSettings,
+}: RelevantNotesPaneProps): React.ReactElement {
+  const isDownload = guidance === "download";
+  // A links-only result set must keep its rows and show the same actionable
+  // guidance as an empty semantic result. Otherwise backlinks hide Miyo setup.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+  const guidancePanel = guidance ? (
+    <div
+      data-miyo-guidance={guidance}
+      className={cn(
+        "tw-flex tw-w-full tw-flex-col tw-gap-3 tw-rounded-lg tw-border tw-border-solid tw-border-border tw-bg-secondary tw-p-3",
+        noteCount === 0 && "tw-max-w-xs tw-items-center tw-p-5 tw-text-center"
+      )}
+    >
+      <div className="tw-flex tw-flex-col tw-gap-1">
+        <span className="tw-text-sm tw-font-semibold tw-text-normal">
+          {isDownload ? "Add semantic matches with Miyo" : "Check your Miyo setup"}
+        </span>
+        <span className="tw-text-xs tw-leading-normal tw-text-muted">
+          {isDownload
+            ? "Download Miyo, then connect it in Copilot settings. Links and backlinks still work without it."
+            : "Check your connection and make sure this vault is registered and indexed."}
+        </span>
+      </div>
+      <div className="tw-flex tw-flex-wrap tw-justify-center tw-gap-2">
+        {isDownload && (
+          <Button asChild variant="secondary" size="sm">
+            <a href={miyoDownloadUrl} target="_blank" rel="noopener noreferrer">
+              <Download className="tw-size-3.5" />
+              Download Miyo
+            </a>
+          </Button>
+        )}
+        <Button variant="default" size="sm" onClick={onOpenMiyoSettings}>
+          {isDownload ? "Set up in Copilot" : "Open Miyo settings"}
+        </Button>
+      </div>
+    </div>
+  ) : null;
+
+  if (noteCount === 0) {
+    return (
+      <div
+        data-relevant-notes-empty-state
+        className="tw-flex tw-h-full tw-items-center tw-justify-center tw-px-4"
+      >
+        {guidancePanel ?? <span className="tw-text-sm tw-text-muted">No relevant notes found</span>}
+      </div>
+    );
+  }
+
+  return (
+    <div className="tw-flex tw-flex-col tw-gap-2">
+      {guidancePanel}
+      <div className="tw-flex tw-flex-col tw-gap-0.5">{noteRows}</div>
+    </div>
+  );
+}

--- a/src/components/chat-components/ui/RelevantNotesPane.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.tsx
@@ -1,5 +1,4 @@
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
 import { Download } from "lucide-react";
 import React from "react";
 
@@ -22,16 +21,10 @@ export function RelevantNotesPane({
   onOpenMiyoSettings,
 }: RelevantNotesPaneProps): React.ReactElement {
   const isDownload = guidance === "download";
-  // A links-only result set must keep its rows and show the same actionable
-  // guidance as an empty semantic result. Otherwise backlinks hide Miyo setup.
-  // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
   const guidancePanel = guidance ? (
     <div
       data-miyo-guidance={guidance}
-      className={cn(
-        "tw-flex tw-w-full tw-flex-col tw-gap-3 tw-rounded-lg tw-border tw-border-solid tw-border-border tw-bg-secondary tw-p-3",
-        noteCount === 0 && "tw-max-w-xs tw-items-center tw-p-5 tw-text-center"
-      )}
+      className="tw-flex tw-w-full tw-max-w-xs tw-flex-col tw-items-center tw-gap-3 tw-rounded-lg tw-border tw-border-solid tw-border-border tw-bg-secondary tw-p-5 tw-text-center"
     >
       <div className="tw-flex tw-flex-col tw-gap-1">
         <span className="tw-text-sm tw-font-semibold tw-text-normal">
@@ -39,7 +32,7 @@ export function RelevantNotesPane({
         </span>
         <span className="tw-text-xs tw-leading-normal tw-text-muted">
           {isDownload
-            ? "Download Miyo, then connect it in Copilot settings. Links and backlinks still work without it."
+            ? "Download Miyo, then connect it in Copilot settings to find related notes."
             : "Check your connection and make sure this vault is registered and indexed."}
         </span>
       </div>
@@ -70,10 +63,5 @@ export function RelevantNotesPane({
     );
   }
 
-  return (
-    <div className="tw-flex tw-flex-col tw-gap-2">
-      {guidancePanel}
-      <div className="tw-flex tw-flex-col tw-gap-0.5">{noteRows}</div>
-    </div>
-  );
+  return <div className="tw-flex tw-flex-col tw-gap-0.5">{noteRows}</div>;
 }

--- a/src/components/chat-components/ui/RelevantNotesPane.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.tsx
@@ -1,11 +1,12 @@
 import { Button } from "@/components/ui/button";
-import { Download } from "lucide-react";
+import { Download, Loader2 } from "lucide-react";
 import React from "react";
 
 export type RelevantNotesGuidance = "download" | "setup" | null;
 
 export interface RelevantNotesPaneProps {
   guidance: RelevantNotesGuidance;
+  isPending: boolean;
   noteCount: number;
   noteRows: React.ReactNode;
   miyoDownloadUrl: string;
@@ -15,11 +16,24 @@ export interface RelevantNotesPaneProps {
 /** Render the result, empty, and Miyo-help states without plugin or Obsidian runtime access. */
 export function RelevantNotesPane({
   guidance,
+  isPending,
   noteCount,
   noteRows,
   miyoDownloadUrl,
   onOpenMiyoSettings,
 }: RelevantNotesPaneProps): React.ReactElement {
+  // A pending request has not established either an empty result or a setup
+  // failure, so keep its status neutral until the request settles.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+  if (isPending) {
+    return (
+      <div className="tw-flex tw-h-full tw-items-center tw-justify-center tw-gap-2 tw-text-sm tw-text-normal">
+        <Loader2 className="tw-size-4 tw-animate-spin" />
+        Finding relevant notes…
+      </div>
+    );
+  }
+
   const isDownload = guidance === "download";
   const guidancePanel = guidance ? (
     <div

--- a/src/miyo/miyoResync.test.ts
+++ b/src/miyo/miyoResync.test.ts
@@ -9,6 +9,11 @@ jest.mock("@/miyo/miyoStatusStore", () => ({
 }));
 jest.mock("@/utils/deviceId", () => ({ getDeviceId: jest.fn(() => "device-A") }));
 
+const notifyIndexChanged = jest.fn<void, []>();
+jest.mock("@/search/indexSignal", () => ({
+  notifyIndexChanged: () => notifyIndexChanged(),
+}));
+
 // Controllable Miyo client; the class type is erased (type-only imports).
 const resolveBaseUrl = jest.fn<Promise<string>, unknown[]>();
 const getFolder = jest.fn<Promise<unknown>, unknown[]>();
@@ -177,6 +182,23 @@ describe("miyoResync", () => {
   });
 
   describe("resyncMiyoFolder()", () => {
+    it("notifies index subscribers after successful reconciliation — https://github.com/Brevilabs/obsidian-copilot-private/issues/280", async () => {
+      getFolder.mockResolvedValue(record());
+
+      await expect(resyncMiyoFolder(app, session)).resolves.toBe("verified");
+
+      expect(notifyIndexChanged).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not notify index subscribers when reconciliation fails — https://github.com/Brevilabs/obsidian-copilot-private/issues/280", async () => {
+      getFolder.mockRejectedValue(new Error("boom"));
+      checkFolderRegistration.mockResolvedValue("error");
+
+      await expect(resyncMiyoFolder(app, session)).resolves.toBe("failed");
+
+      expect(notifyIndexChanged).not.toHaveBeenCalled();
+    });
+
     it("verifies without rebuilding when the record already covers the scope", async () => {
       getFolder.mockResolvedValue(record());
 

--- a/src/miyo/miyoResync.ts
+++ b/src/miyo/miyoResync.ts
@@ -10,6 +10,7 @@ import {
   parseMiyoSyncReceipt,
   type MiyoSyncReceipt,
 } from "@/miyo/miyoUtils";
+import { notifyIndexChanged } from "@/search/indexSignal";
 import { extractAppIgnoreSettings, getSystemExcludedFolders } from "@/search/searchUtils";
 import { type CopilotSettings, getSettings, updateSetting } from "@/settings/model";
 import { err2String } from "@/utils";
@@ -416,15 +417,29 @@ export function resyncMiyoFolder(
   app: App,
   session: MiyoMutationSession
 ): Promise<MiyoResyncOutcome> {
-  return enqueueMiyoFolderMutation((lifecycle) => runResync(app, lifecycle), session).catch(
-    (error) => {
+  return enqueueMiyoFolderMutation((lifecycle) => runResync(app, lifecycle), session)
+    .then((outcome) => {
+      // A successful reconciliation is a retry boundary for Relevant Notes.
+      // Miyo stays available while its folder index changes, so reachability
+      // alone cannot tell subscribers to discard a settled setup result.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+      if (
+        outcome === "verified" ||
+        outcome === "resynced" ||
+        outcome === "resynced-grants-reset" ||
+        outcome === "resynced-scan-failed"
+      ) {
+        notifyIndexChanged();
+      }
+      return outcome;
+    })
+    .catch((error) => {
       // Preserves the never-throws contract: the only rejection the queue itself
       // raises is an expired lifecycle, which for a caller in the current one
       // reads the same as any other unfinished mutation.
       logWarn(`Miyo resync abandoned: ${err2String(error)}`);
       return "failed";
-    }
-  );
+    });
 }
 
 /** Result of a read-only scope verification against the live Miyo record. */

--- a/src/search/findRelevantNotes.test.ts
+++ b/src/search/findRelevantNotes.test.ts
@@ -126,7 +126,7 @@ describe("findRelevantNotes", () => {
       });
     });
 
-    it("returns no graph-only fallback rows when Miyo is disabled (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+    it("returns no link-only rows when Miyo is disabled (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
       mockedGetLinkedNotes.mockReturnValue([
         createMarkdownFile("linked-only.md"),
         createMarkdownFile("alpha.md"),
@@ -144,24 +144,19 @@ describe("findRelevantNotes", () => {
       expect(mockedGetBacklinkedNotes).not.toHaveBeenCalled();
     });
 
-    it("includes graph-only candidates after Miyo related-note search succeeds (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+    it("returns no link-only rows when Miyo finds no matches (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
       mockedShouldUseMiyo.mockReturnValue(true);
       mockedGetLinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);
+      mockedGetBacklinkedNotes.mockReturnValue([createMarkdownFile("beta.md")]);
 
       const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
 
-      expect(result).toHaveLength(1);
-      expect(result[0]).toMatchObject({
-        note: { path: "linked-only.md" },
-        metadata: {
-          similarityScore: undefined,
-          hasOutgoingLinks: true,
-          hasBacklinks: false,
-        },
-      });
+      expect(result).toEqual([]);
+      expect(mockedGetLinkedNotes).not.toHaveBeenCalled();
+      expect(mockedGetBacklinkedNotes).not.toHaveBeenCalled();
     });
 
-    it("ranks by Miyo similarity without boosting a backlinked lower-scoring note", async () => {
+    it("ranks by Miyo similarity and annotates only scored notes with link relationships (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
       mockedShouldUseMiyo.mockReturnValue(true);
       mockSearchRelated.mockResolvedValue({
         results: [
@@ -169,15 +164,17 @@ describe("findRelevantNotes", () => {
           { path: "vault/beta.md", score: 0.58 },
         ],
       });
+      mockedGetLinkedNotes.mockReturnValue([createMarkdownFile("alpha.md")]);
       mockedGetBacklinkedNotes.mockReturnValue([createMarkdownFile("beta.md")]);
 
       const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
 
       expect(result.map((entry) => entry.note.path)).toEqual(["alpha.md", "beta.md"]);
+      expect(result[0].metadata.hasOutgoingLinks).toBe(true);
       expect(result[1].metadata.hasBacklinks).toBe(true);
     });
 
-    it("applies the live Copilot scope to Miyo and linked candidates", async () => {
+    it("applies the live Copilot scope only to Miyo candidates", async () => {
       mockedShouldUseMiyo.mockReturnValue(true);
       mockSearchRelated.mockResolvedValue({
         results: [
@@ -192,11 +189,7 @@ describe("findRelevantNotes", () => {
       const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
 
       expect(result.map((entry) => entry.note.path)).toEqual(["beta.md"]);
-      expect(isAllowed.mock.calls.map(([path]) => path)).toEqual([
-        "beta.md",
-        "alpha.md",
-        "linked-only.md",
-      ]);
+      expect(isAllowed.mock.calls.map(([path]) => path)).toEqual(["beta.md", "alpha.md"]);
     });
 
     it("caps Miyo results at the existing 20-note limit", async () => {
@@ -215,7 +208,7 @@ describe("findRelevantNotes", () => {
       expect(result[19].note.path).toBe("note-5.md");
     });
 
-    it("rejects without building graph-only fallback rows when Miyo search fails (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+    it("rejects without building link-only rows when Miyo search fails (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
       mockedShouldUseMiyo.mockReturnValue(true);
       mockSearchRelated.mockRejectedValue(new Error("Miyo unavailable"));
       mockedGetLinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);

--- a/src/search/findRelevantNotes.test.ts
+++ b/src/search/findRelevantNotes.test.ts
@@ -126,7 +126,7 @@ describe("findRelevantNotes", () => {
       });
     });
 
-    it("returns stable links without semantic scores when Miyo is disabled instead of reading the local index (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+    it("returns no graph-only fallback rows when Miyo is disabled (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
       mockedGetLinkedNotes.mockReturnValue([
         createMarkdownFile("linked-only.md"),
         createMarkdownFile("alpha.md"),
@@ -138,17 +138,27 @@ describe("findRelevantNotes", () => {
 
       const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
 
-      expect(result.map((entry) => entry.note.path)).toEqual([
-        "linked-only.md",
-        "alpha.md",
-        "beta.md",
-      ]);
-      expect(result.every((entry) => entry.metadata.similarityScore === undefined)).toBe(true);
-      expect(result[1].metadata).toMatchObject({
-        hasOutgoingLinks: true,
-        hasBacklinks: true,
-      });
+      expect(result).toEqual([]);
       expect(mockSearchRelated).not.toHaveBeenCalled();
+      expect(mockedGetLinkedNotes).not.toHaveBeenCalled();
+      expect(mockedGetBacklinkedNotes).not.toHaveBeenCalled();
+    });
+
+    it("includes graph-only candidates after Miyo related-note search succeeds (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      mockedGetSearchBackend.mockReturnValue("miyo");
+      mockedGetLinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);
+
+      const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        note: { path: "linked-only.md" },
+        metadata: {
+          similarityScore: undefined,
+          hasOutgoingLinks: true,
+          hasBacklinks: false,
+        },
+      });
     });
 
     it("ranks by Miyo similarity without boosting a backlinked lower-scoring note", async () => {
@@ -205,17 +215,16 @@ describe("findRelevantNotes", () => {
       expect(result[19].note.path).toBe("note-5.md");
     });
 
-    it("keeps links without scores when Miyo search fails (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+    it("rejects without building graph-only fallback rows when Miyo search fails (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
       mockedGetSearchBackend.mockReturnValue("miyo");
       mockSearchRelated.mockRejectedValue(new Error("Miyo unavailable"));
       mockedGetLinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);
 
-      const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
-
-      expect(result).toHaveLength(1);
-      expect(result[0].note.path).toBe("linked-only.md");
-      expect(result[0].metadata.similarityScore).toBeUndefined();
-      expect(result[0].metadata.hasOutgoingLinks).toBe(true);
+      await expect(findRelevantNotes({ app: window.app, filePath: "source.md" })).rejects.toThrow(
+        "Miyo unavailable"
+      );
+      expect(mockedGetLinkedNotes).not.toHaveBeenCalled();
+      expect(mockedGetBacklinkedNotes).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/search/findRelevantNotes.test.ts
+++ b/src/search/findRelevantNotes.test.ts
@@ -1,50 +1,23 @@
-import { TFile } from "obsidian";
-import { getBacklinkedNotes, getLinkedNotes } from "@/noteUtils";
-import { findRelevantNotes } from "@/search/findRelevantNotes";
 import { MiyoClient } from "@/miyo/MiyoClient";
 import {
   getMiyoFilePath,
   getMiyoFolderName,
-  getVaultRelativeMiyoPath,
   getSearchBackend,
+  getVaultRelativeMiyoPath,
 } from "@/miyo/miyoUtils";
+import { getBacklinkedNotes, getLinkedNotes } from "@/noteUtils";
+import { findRelevantNotes } from "@/search/findRelevantNotes";
 import { createCopilotPatternFilter } from "@/search/searchUtils";
 import { getSettings, type CopilotSettings } from "@/settings/model";
-import VectorStoreManager from "@/search/vectorStoreManager";
+import { TFile } from "obsidian";
 
 jest.mock("@/noteUtils", () => ({
   getLinkedNotes: jest.fn(),
   getBacklinkedNotes: jest.fn(),
 }));
 
-jest.mock("@/settings/model", () => ({
-  getSettings: jest.fn(),
-}));
-
-jest.mock("@/search/searchUtils", () => ({
-  createCopilotPatternFilter: jest.fn(),
-}));
-
-const mockGetDocumentsByPath = jest.fn();
-const mockGetDb = jest.fn();
-
-jest.mock("@/search/vectorStoreManager", () => ({
-  __esModule: true,
-  default: {
-    getInstance: () => ({
-      getDocumentsByPath: mockGetDocumentsByPath,
-      getDb: mockGetDb,
-    }),
-  },
-}));
-
-const mockGetDocsByEmbedding = jest.fn();
-
-jest.mock("@/search/dbOperations", () => ({
-  DBOperations: {
-    getDocsByEmbedding: (...args: unknown[]) => mockGetDocsByEmbedding(...args) as unknown,
-  },
-}));
+jest.mock("@/settings/model", () => ({ getSettings: jest.fn() }));
+jest.mock("@/search/searchUtils", () => ({ createCopilotPatternFilter: jest.fn() }));
 
 const mockResolveBaseUrl = jest.fn();
 const mockSearchRelated = jest.fn();
@@ -66,16 +39,9 @@ jest.mock("@/miyo/miyoUtils", () => ({
 
 jest.mock("@/logger", () => ({
   logInfo: jest.fn(),
-  logWarn: jest.fn(),
   logError: jest.fn(),
 }));
 
-/**
- * Create a markdown file mock with Obsidian's TFile class.
- *
- * @param path - Vault-relative markdown path.
- * @returns Mock TFile instance.
- */
 function createMarkdownFile(path: string): TFile {
   const TFileConstructor = TFile as unknown as new (filePath: string) => TFile;
   return new TFileConstructor(path);
@@ -98,12 +64,6 @@ describe("findRelevantNotes", () => {
   const mockedGetVaultRelativeMiyoPath = getVaultRelativeMiyoPath as jest.MockedFunction<
     typeof getVaultRelativeMiyoPath
   >;
-  const mockedVectorStoreManager = VectorStoreManager as unknown as {
-    getInstance: () => {
-      getDocumentsByPath: jest.Mock;
-      getDb: jest.Mock;
-    };
-  };
   const mockedMiyoClient = MiyoClient as unknown as jest.Mock;
 
   describe("findRelevantNotes()", () => {
@@ -115,7 +75,6 @@ describe("findRelevantNotes", () => {
         debug: false,
         miyoServerUrl: "",
         enableMiyo: false,
-        enableSemanticSearchV3: false,
       } as CopilotSettings);
       mockedGetLinkedNotes.mockReturnValue([]);
       mockedGetBacklinkedNotes.mockReturnValue([]);
@@ -124,131 +83,34 @@ describe("findRelevantNotes", () => {
       mockedGetVaultRelativeMiyoPath.mockImplementation((_: unknown, path: string) =>
         path.replace(/^vault\//, "")
       );
-
-      const source = createMarkdownFile("source.md");
-      const first = createMarkdownFile("first.md");
-      const second = createMarkdownFile("second.md");
-      const alpha = createMarkdownFile("alpha.md");
-      const beta = createMarkdownFile("beta.md");
-      const linkedOnly = createMarkdownFile("linked-only.md");
-
-      const filesByPath = new Map<string, TFile>([
-        ["source.md", source],
-        ["first.md", first],
-        ["second.md", second],
-        ["alpha.md", alpha],
-        ["beta.md", beta],
-        ["linked-only.md", linkedOnly],
-      ]);
-
-      (window.app.vault.getAbstractFileByPath as jest.Mock).mockImplementation((path: string) => {
-        return filesByPath.get(path) ?? null;
-      });
-
-      mockedVectorStoreManager
-        .getInstance()
-        .getDocumentsByPath.mockImplementation(mockGetDocumentsByPath);
-      mockedVectorStoreManager.getInstance().getDb.mockImplementation(mockGetDb);
+      mockResolveBaseUrl.mockResolvedValue("http://127.0.0.1:8742");
+      mockSearchRelated.mockResolvedValue({ results: [] });
       mockedMiyoClient.mockImplementation(() => ({
         resolveBaseUrl: mockResolveBaseUrl,
         searchRelated: mockSearchRelated,
       }));
-    });
 
-    it("uses Orama similarity scoring when source note has embeddings", async () => {
-      mockGetDocumentsByPath.mockResolvedValue([
-        {
-          id: "chunk-1",
-          path: "source.md",
-          content: "chunk one",
-          embedding: [0.1, 0.2],
-        },
-        {
-          id: "chunk-2",
-          path: "source.md",
-          content: "chunk two",
-          embedding: [0.3, 0.4],
-        },
-      ]);
-      mockGetDb.mockResolvedValue({ db: "orama" });
-      mockGetDocsByEmbedding
-        .mockResolvedValueOnce([
-          { score: 0.82, document: { path: "second.md" } },
-          { score: 0.5, document: { path: "source.md" } },
-        ])
-        .mockResolvedValueOnce([
-          { score: 0.79, document: { path: "first.md" } },
-          { score: 0.66, document: { path: "second.md" } },
-        ]);
-      mockedGetBacklinkedNotes.mockReturnValue([createMarkdownFile("second.md")]);
-      mockedGetLinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);
-
-      const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
-
-      expect(result.map((entry) => entry.note.path)).toEqual([
-        "second.md",
-        "first.md",
+      const paths = [
+        "source.md",
+        "alpha.md",
+        "beta.md",
         "linked-only.md",
-      ]);
-      expect(
-        result.find((entry) => entry.note.path === "second.md")?.metadata.similarityScore
-      ).toBe(0.82);
-      expect(mockGetDb).toHaveBeenCalledTimes(1);
-      expect(mockGetDocsByEmbedding).toHaveBeenCalledTimes(2);
-      expect(mockSearchRelated).not.toHaveBeenCalled();
-    });
-
-    it("ranks by similarity only — a backlink does not boost a lower-similarity note above a higher one", async () => {
-      mockGetDocumentsByPath.mockResolvedValue([
-        { id: "chunk-1", path: "source.md", content: "chunk one", embedding: [0.1, 0.2] },
-      ]);
-      mockGetDb.mockResolvedValue({ db: "orama" });
-      // alpha (0.6) has no links; beta (0.58) is backlinked. The old merged-score
-      // ranking boosted beta above alpha despite its lower similarity.
-      mockGetDocsByEmbedding.mockResolvedValueOnce([
-        { score: 0.6, document: { path: "alpha.md" } },
-        { score: 0.58, document: { path: "beta.md" } },
-      ]);
-      mockedGetBacklinkedNotes.mockReturnValue([createMarkdownFile("beta.md")]);
-
-      const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
-
-      expect(result.map((entry) => entry.note.path)).toEqual(["alpha.md", "beta.md"]);
-      expect(result[0].metadata.similarityScore).toBe(0.6);
-      expect(result.find((entry) => entry.note.path === "beta.md")?.metadata.hasBacklinks).toBe(
-        true
+        ...Array.from({ length: 25 }, (_, index) => `note-${index}.md`),
+      ];
+      const filesByPath = new Map(paths.map((path) => [path, createMarkdownFile(path)]));
+      (window.app.vault.getAbstractFileByPath as jest.Mock).mockImplementation(
+        (path: string) => filesByPath.get(path) ?? null
       );
     });
 
-    it("uses Miyo when shouldUseMiyoForRelevantNotes is true (enableMiyo=true and valid self-host)", async () => {
+    it("uses Miyo as the only semantic scorer and preserves vault-scoped path stripping (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
       mockedGetSearchBackend.mockReturnValue("miyo");
-      mockedGetSettings.mockReturnValue({
-        debug: false,
-        miyoServerUrl: "http://127.0.0.1:8742",
-        enableMiyo: true,
-        enableSemanticSearchV3: true,
-      } as CopilotSettings);
-      mockGetDocumentsByPath.mockResolvedValue([
-        {
-          id: "chunk-a",
-          path: "source.md",
-          content: "source chunk A",
-          embedding: [],
-        },
-        {
-          id: "chunk-b",
-          path: "source.md",
-          content: "source chunk B",
-          embedding: [],
-        },
-      ]);
-      mockResolveBaseUrl.mockResolvedValue("http://127.0.0.1:8742");
       mockSearchRelated.mockResolvedValue({
         results: [
-          { id: "self", path: "vault/source.md", score: 0.99, chunk_text: "self" },
-          { id: "a-1", path: "vault/alpha.md", score: 0.45, chunk_text: "alpha1" },
-          { id: "b-1", path: "vault/beta.md", score: 0.88, chunk_text: "beta" },
-          { id: "a-2", path: "vault/alpha.md", score: 0.6, chunk_text: "alpha2" },
+          { path: "vault/source.md", score: 0.99 },
+          { path: "vault/alpha.md", score: 0.45 },
+          { path: "vault/beta.md", score: 0.88 },
+          { path: "vault/alpha.md", score: 0.6 },
         ],
       });
 
@@ -258,22 +120,59 @@ describe("findRelevantNotes", () => {
       expect(result.find((entry) => entry.note.path === "alpha.md")?.metadata.similarityScore).toBe(
         0.6
       );
-      expect(mockGetDb).not.toHaveBeenCalled();
-      expect(mockGetDocumentsByPath).not.toHaveBeenCalled();
-      expect(mockSearchRelated).toHaveBeenCalledTimes(1);
       expect(mockSearchRelated).toHaveBeenCalledWith("http://127.0.0.1:8742", "vault/source.md", {
         folderName: "vault",
         limit: 20,
       });
     });
 
-    it("applies the live Copilot scope to semantic and linked candidates", async () => {
+    it("returns stable links without semantic scores when Miyo is disabled instead of reading the local index (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      mockedGetLinkedNotes.mockReturnValue([
+        createMarkdownFile("linked-only.md"),
+        createMarkdownFile("alpha.md"),
+      ]);
+      mockedGetBacklinkedNotes.mockReturnValue([
+        createMarkdownFile("alpha.md"),
+        createMarkdownFile("beta.md"),
+      ]);
+
+      const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
+
+      expect(result.map((entry) => entry.note.path)).toEqual([
+        "linked-only.md",
+        "alpha.md",
+        "beta.md",
+      ]);
+      expect(result.every((entry) => entry.metadata.similarityScore === undefined)).toBe(true);
+      expect(result[1].metadata).toMatchObject({
+        hasOutgoingLinks: true,
+        hasBacklinks: true,
+      });
+      expect(mockSearchRelated).not.toHaveBeenCalled();
+    });
+
+    it("ranks by Miyo similarity without boosting a backlinked lower-scoring note", async () => {
       mockedGetSearchBackend.mockReturnValue("miyo");
-      mockResolveBaseUrl.mockResolvedValue("http://127.0.0.1:8742");
       mockSearchRelated.mockResolvedValue({
         results: [
-          { id: "allowed", path: "vault/beta.md", score: 0.8 },
-          { id: "excluded", path: "vault/alpha.md", score: 0.9 },
+          { path: "vault/alpha.md", score: 0.6 },
+          { path: "vault/beta.md", score: 0.58 },
+        ],
+      });
+      mockedGetBacklinkedNotes.mockReturnValue([createMarkdownFile("beta.md")]);
+
+      const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
+
+      expect(result.map((entry) => entry.note.path)).toEqual(["alpha.md", "beta.md"]);
+      expect(result[1].metadata.hasBacklinks).toBe(true);
+    });
+
+    it("applies the live Copilot scope to Miyo and linked candidates", async () => {
+      mockedGetSearchBackend.mockReturnValue("miyo");
+      mockSearchRelated.mockResolvedValue({
+        results: [
+          { path: "vault/beta.md", score: 0.8 },
+          { path: "vault/alpha.md", score: 0.9 },
         ],
       });
       mockedGetLinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);
@@ -283,7 +182,6 @@ describe("findRelevantNotes", () => {
       const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
 
       expect(result.map((entry) => entry.note.path)).toEqual(["beta.md"]);
-      expect(mockedCreateCopilotPatternFilter).toHaveBeenCalledWith(window.app);
       expect(isAllowed.mock.calls.map(([path]) => path)).toEqual([
         "beta.md",
         "alpha.md",
@@ -291,52 +189,24 @@ describe("findRelevantNotes", () => {
       ]);
     });
 
-    it("falls back to Miyo when Orama docs exist but have no embeddings and have content", async () => {
-      // enableMiyo=false ensures shouldUseMiyoForRelevantNotes() returns false,
-      // so the no-embeddings fallback path (line 212 of findRelevantNotes.ts) is exercised.
-      mockedGetSettings.mockReturnValue({
-        debug: false,
-        miyoServerUrl: "http://127.0.0.1:8742",
-        enableMiyo: false,
-        enableSemanticSearchV3: true,
-      } as CopilotSettings);
-      mockGetDocumentsByPath.mockResolvedValue([
-        { id: "chunk-a", path: "source.md", content: "source chunk content", embedding: [] },
-      ]);
-      mockResolveBaseUrl.mockResolvedValue("http://127.0.0.1:8742");
+    it("caps Miyo results at the existing 20-note limit", async () => {
+      mockedGetSearchBackend.mockReturnValue("miyo");
       mockSearchRelated.mockResolvedValue({
-        results: [
-          { id: "a-1", path: "vault/alpha.md", score: 0.75, chunk_text: "alpha chunk" },
-          { id: "self", path: "vault/source.md", score: 0.99, chunk_text: "self" },
-        ],
+        results: Array.from({ length: 25 }, (_, index) => ({
+          path: `vault/note-${index}.md`,
+          score: index / 100,
+        })),
       });
 
       const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
 
-      expect(result.map((e) => e.note.path)).toEqual(["alpha.md"]);
-      expect(result[0].metadata.similarityScore).toBe(0.75);
-      // Orama path not taken (no embeddings); Miyo called as fallback
-      expect(mockGetDocsByEmbedding).not.toHaveBeenCalled();
-      expect(mockSearchRelated).toHaveBeenCalledTimes(1);
+      expect(result).toHaveLength(20);
+      expect(result[0].note.path).toBe("note-24.md");
+      expect(result[19].note.path).toBe("note-5.md");
     });
 
-    it("falls back to link-only relevance when Miyo related-note search fails", async () => {
+    it("keeps links without scores when Miyo search fails (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
       mockedGetSearchBackend.mockReturnValue("miyo");
-      mockedGetSettings.mockReturnValue({
-        debug: false,
-        miyoServerUrl: "http://127.0.0.1:8742",
-        enableMiyo: true,
-        enableSemanticSearchV3: true,
-      } as CopilotSettings);
-      mockGetDocumentsByPath.mockResolvedValue([
-        {
-          id: "chunk-a",
-          path: "source.md",
-          content: "source chunk A",
-          embedding: [],
-        },
-      ]);
-      mockResolveBaseUrl.mockResolvedValue("http://127.0.0.1:8742");
       mockSearchRelated.mockRejectedValue(new Error("Miyo unavailable"));
       mockedGetLinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);
 
@@ -346,7 +216,6 @@ describe("findRelevantNotes", () => {
       expect(result[0].note.path).toBe("linked-only.md");
       expect(result[0].metadata.similarityScore).toBeUndefined();
       expect(result[0].metadata.hasOutgoingLinks).toBe(true);
-      expect(mockGetDocumentsByPath).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/search/findRelevantNotes.test.ts
+++ b/src/search/findRelevantNotes.test.ts
@@ -2,8 +2,8 @@ import { MiyoClient } from "@/miyo/MiyoClient";
 import {
   getMiyoFilePath,
   getMiyoFolderName,
-  getSearchBackend,
   getVaultRelativeMiyoPath,
+  shouldUseMiyo,
 } from "@/miyo/miyoUtils";
 import { getBacklinkedNotes, getLinkedNotes } from "@/noteUtils";
 import { findRelevantNotes } from "@/search/findRelevantNotes";
@@ -34,7 +34,7 @@ jest.mock("@/miyo/miyoUtils", () => ({
   getMiyoFilePath: jest.fn((_: unknown, path: string) => `vault/${path}`),
   getVaultRelativeMiyoPath: jest.fn((_: unknown, path: string) => path.replace(/^vault\//, "")),
   getMiyoCustomUrl: jest.fn().mockReturnValue(""),
-  getSearchBackend: jest.fn(),
+  shouldUseMiyo: jest.fn(),
 }));
 
 jest.mock("@/logger", () => ({
@@ -49,7 +49,7 @@ function createMarkdownFile(path: string): TFile {
 
 describe("findRelevantNotes", () => {
   const mockedGetSettings = getSettings as jest.MockedFunction<typeof getSettings>;
-  const mockedGetSearchBackend = getSearchBackend as jest.MockedFunction<typeof getSearchBackend>;
+  const mockedShouldUseMiyo = shouldUseMiyo as jest.MockedFunction<typeof shouldUseMiyo>;
   const mockedCreateCopilotPatternFilter = createCopilotPatternFilter as jest.MockedFunction<
     typeof createCopilotPatternFilter
   >;
@@ -69,7 +69,7 @@ describe("findRelevantNotes", () => {
   describe("findRelevantNotes()", () => {
     beforeEach(() => {
       jest.clearAllMocks();
-      mockedGetSearchBackend.mockReturnValue("keyword");
+      mockedShouldUseMiyo.mockReturnValue(false);
       mockedCreateCopilotPatternFilter.mockReturnValue(() => true);
       mockedGetSettings.mockReturnValue({
         debug: false,
@@ -104,7 +104,7 @@ describe("findRelevantNotes", () => {
     });
 
     it("uses Miyo as the only semantic scorer and preserves vault-scoped path stripping (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
-      mockedGetSearchBackend.mockReturnValue("miyo");
+      mockedShouldUseMiyo.mockReturnValue(true);
       mockSearchRelated.mockResolvedValue({
         results: [
           { path: "vault/source.md", score: 0.99 },
@@ -145,7 +145,7 @@ describe("findRelevantNotes", () => {
     });
 
     it("includes graph-only candidates after Miyo related-note search succeeds (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
-      mockedGetSearchBackend.mockReturnValue("miyo");
+      mockedShouldUseMiyo.mockReturnValue(true);
       mockedGetLinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);
 
       const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
@@ -162,7 +162,7 @@ describe("findRelevantNotes", () => {
     });
 
     it("ranks by Miyo similarity without boosting a backlinked lower-scoring note", async () => {
-      mockedGetSearchBackend.mockReturnValue("miyo");
+      mockedShouldUseMiyo.mockReturnValue(true);
       mockSearchRelated.mockResolvedValue({
         results: [
           { path: "vault/alpha.md", score: 0.6 },
@@ -178,7 +178,7 @@ describe("findRelevantNotes", () => {
     });
 
     it("applies the live Copilot scope to Miyo and linked candidates", async () => {
-      mockedGetSearchBackend.mockReturnValue("miyo");
+      mockedShouldUseMiyo.mockReturnValue(true);
       mockSearchRelated.mockResolvedValue({
         results: [
           { path: "vault/beta.md", score: 0.8 },
@@ -200,7 +200,7 @@ describe("findRelevantNotes", () => {
     });
 
     it("caps Miyo results at the existing 20-note limit", async () => {
-      mockedGetSearchBackend.mockReturnValue("miyo");
+      mockedShouldUseMiyo.mockReturnValue(true);
       mockSearchRelated.mockResolvedValue({
         results: Array.from({ length: 25 }, (_, index) => ({
           path: `vault/note-${index}.md`,
@@ -216,7 +216,7 @@ describe("findRelevantNotes", () => {
     });
 
     it("rejects without building graph-only fallback rows when Miyo search fails (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
-      mockedGetSearchBackend.mockReturnValue("miyo");
+      mockedShouldUseMiyo.mockReturnValue(true);
       mockSearchRelated.mockRejectedValue(new Error("Miyo unavailable"));
       mockedGetLinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);
 

--- a/src/search/findRelevantNotes.ts
+++ b/src/search/findRelevantNotes.ts
@@ -89,25 +89,8 @@ async function calculateSimilarityScoreFromMiyo(
         (error as Error).message
       }`
     );
-    return new Map();
+    throw error;
   }
-}
-
-/**
- * Calculate Relevant Notes similarity scores through Miyo.
- *
- * @param app - The Obsidian app instance.
- * @param filePath - Source note path.
- * @returns Map of note paths to max similarity score.
- */
-async function calculateSimilarityScore(app: App, filePath: string): Promise<Map<string, number>> {
-  // Links and backlinks remain useful without Miyo, but the legacy local index
-  // must not assign them semantic scores or trigger a hidden Miyo fallback.
-  // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
-  if (getSearchBackend(getSettings()) !== "miyo") {
-    return new Map();
-  }
-  return calculateSimilarityScoreFromMiyo(app, filePath);
 }
 
 /**
@@ -158,7 +141,8 @@ export type RelevantNoteEntry = {
  * @param app - The Obsidian app instance.
  * @param filePath - The file path to find relevant notes for.
  * @returns Relevant-note hits allowed by the current inclusion/exclusion rules.
- *   Empty when no allowed notes are found.
+ *   Empty when no allowed notes are found or Miyo is not enabled as the search backend.
+ * @throws When the Miyo related-note request cannot complete.
  */
 export async function findRelevantNotes({
   app,
@@ -172,7 +156,15 @@ export async function findRelevantNotes({
     return [];
   }
 
-  const similarityScoreMap = await calculateSimilarityScore(app, filePath);
+  // A graph-only fallback makes Relevant Notes look partially functional when
+  // its Miyo-backed index is unavailable. Only build graph candidates after a
+  // Miyo search can run successfully.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+  if (getSearchBackend(getSettings()) !== "miyo") {
+    return [];
+  }
+
+  const similarityScoreMap = await calculateSimilarityScoreFromMiyo(app, filePath);
   const noteLinks = getNoteLinks(app, file);
 
   // Rank purely by semantic similarity so the displayed percentages stay

--- a/src/search/findRelevantNotes.ts
+++ b/src/search/findRelevantNotes.ts
@@ -128,7 +128,7 @@ export type RelevantNoteEntry = {
   };
   metadata: {
     score: number;
-    similarityScore: number | undefined;
+    similarityScore: number;
     hasOutgoingLinks: boolean;
     hasBacklinks: boolean;
   };
@@ -165,38 +165,32 @@ export async function findRelevantNotes({
   }
 
   const similarityScoreMap = await calculateSimilarityScoreFromMiyo(app, filePath);
+  if (similarityScoreMap.size === 0) {
+    return [];
+  }
+
   const noteLinks = getNoteLinks(app, file);
 
-  // Rank purely by semantic similarity so the displayed percentages stay
-  // monotonic down the list. Linked/backlinked notes still appear, but a link
-  // never boosts ranking: link-only notes have no similarity score and sort to
-  // the bottom (they render without a meter in the UI).
-  const candidatePaths = new Set<string>([...similarityScoreMap.keys(), ...noteLinks.keys()]);
-  candidatePaths.delete(filePath);
-  const sortedPaths = Array.from(candidatePaths)
-    .filter(createCopilotPatternFilter(app))
-    .sort((aPath, bPath) => {
-      const aScore = similarityScoreMap.get(aPath);
-      const bScore = similarityScoreMap.get(bPath);
-      if (aScore == null && bScore == null) return 0;
-      if (aScore == null) return 1;
-      if (bScore == null) return -1;
-      return bScore - aScore;
-    });
-  return sortedPaths
-    .map((path) => {
+  // Links describe Miyo results but cannot make an otherwise unindexed note
+  // relevant, so every displayed row retains a semantic basis.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+  const isAllowed = createCopilotPatternFilter(app);
+  const sortedMatches = Array.from(similarityScoreMap.entries())
+    .filter(([path]) => isAllowed(path))
+    .sort(([, aScore], [, bScore]) => bScore - aScore);
+  return sortedMatches
+    .map(([path, similarityScore]) => {
       const file = app.vault.getAbstractFileByPath(path);
       if (!(file instanceof TFile) || file.extension !== "md") {
         return null;
       }
-      const similarityScore = similarityScoreMap.get(path);
       return {
         note: {
           path,
           title: file.basename,
         },
         metadata: {
-          score: similarityScore ?? 0,
+          score: similarityScore,
           similarityScore,
           hasOutgoingLinks: noteLinks.get(path)?.links ?? false,
           hasBacklinks: noteLinks.get(path)?.backlinks ?? false,

--- a/src/search/findRelevantNotes.ts
+++ b/src/search/findRelevantNotes.ts
@@ -1,4 +1,4 @@
-import { logError, logInfo, logWarn } from "@/logger";
+import { logError, logInfo } from "@/logger";
 import { MiyoClient } from "@/miyo/MiyoClient";
 import {
   getMiyoCustomUrl,
@@ -8,48 +8,11 @@ import {
   getSearchBackend,
 } from "@/miyo/miyoUtils";
 import { getBacklinkedNotes, getLinkedNotes } from "@/noteUtils";
-import { DBOperations, type CopilotOrama } from "@/search/dbOperations";
-import type { SemanticIndexDocument } from "@/search/indexBackend/SemanticIndexBackend";
 import { createCopilotPatternFilter } from "@/search/searchUtils";
-import VectorStoreManager from "@/search/vectorStoreManager";
 import { getSettings } from "@/settings/model";
-import { Result } from "@orama/orama";
 import { App, TFile } from "obsidian";
 
 const MAX_K = 20;
-
-/**
- * Determine whether Miyo-backed relevant-note scoring should be used.
- *
- * @returns True when Miyo mode and self-host access validation are active.
- */
-function shouldUseMiyoForRelevantNotes(): boolean {
-  return getSearchBackend(getSettings()) === "miyo";
-}
-
-/**
- * Gets the highest score hits for each note and removes the current file path
- * from the results.
- * @param hits - The hits to get the highest score for.
- * @param currentFilePath - The current file path.
- * @returns A map of the highest score hits for each note.
- */
-function getHighestScoreHits(hits: Result<{ path: string }>[], currentFilePath: string) {
-  const hitMap = new Map<string, number>();
-  for (const hit of hits) {
-    const path = hit.document.path;
-    const matchingScore = hitMap.get(path);
-    if (matchingScore) {
-      if (hit.score > matchingScore) {
-        hitMap.set(path, hit.score);
-      }
-    } else {
-      hitMap.set(path, hit.score);
-    }
-  }
-  hitMap.delete(currentFilePath);
-  return hitMap;
-}
 
 /**
  * Normalize a score map to the top K entries, ordered by score descending.
@@ -67,55 +30,6 @@ function capToTopK(scoreMap: Map<string, number>): Map<string, number> {
     .slice(0, MAX_K);
 
   return new Map(topK);
-}
-
-/**
- * Return true when a semantic document has a usable embedding vector.
- *
- * @param doc - Semantic document candidate.
- * @returns True when embedding data exists and is non-empty.
- */
-function hasUsableEmbedding(doc: SemanticIndexDocument): boolean {
-  return Array.isArray(doc.embedding) && doc.embedding.length > 0;
-}
-
-/**
- * Return true when the source note has non-empty chunk content.
- *
- * @param docs - Source note semantic chunks.
- * @returns True when at least one chunk has content.
- */
-function hasSourceChunkContent(docs: SemanticIndexDocument[]): boolean {
-  return docs.some((doc) => doc.content.trim().length > 0);
-}
-
-/**
- * Calculate similarity scores using the legacy Orama vector path.
- *
- * @param db - The Orama database.
- * @param filePath - The file path to calculate similarity scores for.
- * @param currentNoteEmbeddings - Embedding vectors of the source note.
- * @returns A map of note paths to their highest similarity scores.
- */
-async function calculateSimilarityScoreFromOrama({
-  db,
-  filePath,
-  currentNoteEmbeddings,
-}: {
-  db: CopilotOrama;
-  filePath: string;
-  currentNoteEmbeddings: number[][];
-}): Promise<Map<string, number>> {
-  const searchPromises = currentNoteEmbeddings.map((embedding) =>
-    DBOperations.getDocsByEmbedding(db, embedding, {
-      limit: MAX_K,
-      similarity: 0,
-    })
-  );
-  const searchResults = await Promise.all(searchPromises);
-  const allHits = searchResults.flat();
-  const aggregatedHits = getHighestScoreHits(allHits, filePath);
-  return capToTopK(aggregatedHits);
 }
 
 /**
@@ -180,44 +94,19 @@ async function calculateSimilarityScoreFromMiyo(
 }
 
 /**
- * Calculate similarity scores by selecting the best available backend strategy.
+ * Calculate Relevant Notes similarity scores through Miyo.
  *
  * @param app - The Obsidian app instance.
  * @param filePath - Source note path.
  * @returns Map of note paths to max similarity score.
  */
 async function calculateSimilarityScore(app: App, filePath: string): Promise<Map<string, number>> {
-  if (shouldUseMiyoForRelevantNotes()) {
-    return calculateSimilarityScoreFromMiyo(app, filePath);
-  }
-
-  const currentNoteDocs = await VectorStoreManager.getInstance().getDocumentsByPath(filePath);
-  if (currentNoteDocs.length === 0) {
+  // Links and backlinks remain useful without Miyo, but the legacy local index
+  // must not assign them semantic scores or trigger a hidden Miyo fallback.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+  if (getSearchBackend(getSettings()) !== "miyo") {
     return new Map();
   }
-
-  const currentNoteEmbeddings = currentNoteDocs
-    .filter((doc) => hasUsableEmbedding(doc))
-    .map((doc) => doc.embedding);
-
-  if (currentNoteEmbeddings.length > 0) {
-    try {
-      const db = await VectorStoreManager.getInstance().getDb();
-      return calculateSimilarityScoreFromOrama({
-        db,
-        filePath,
-        currentNoteEmbeddings,
-      });
-    } catch (error) {
-      logWarn("RelevantNotes(Orama): failed to compute similarity scores", error);
-      return new Map();
-    }
-  }
-
-  if (!hasSourceChunkContent(currentNoteDocs)) {
-    return new Map();
-  }
-
   return calculateSimilarityScoreFromMiyo(app, filePath);
 }
 
@@ -269,7 +158,7 @@ export type RelevantNoteEntry = {
  * @param app - The Obsidian app instance.
  * @param filePath - The file path to find relevant notes for.
  * @returns Relevant-note hits allowed by the current inclusion/exclusion rules.
- *   Empty when no allowed notes are found or the index does not exist.
+ *   Empty when no allowed notes are found.
  */
 export async function findRelevantNotes({
   app,

--- a/src/search/findRelevantNotes.ts
+++ b/src/search/findRelevantNotes.ts
@@ -5,7 +5,7 @@ import {
   getMiyoFilePath,
   getMiyoFolderName,
   getVaultRelativeMiyoPath,
-  getSearchBackend,
+  shouldUseMiyo,
 } from "@/miyo/miyoUtils";
 import { getBacklinkedNotes, getLinkedNotes } from "@/noteUtils";
 import { createCopilotPatternFilter } from "@/search/searchUtils";
@@ -141,7 +141,7 @@ export type RelevantNoteEntry = {
  * @param app - The Obsidian app instance.
  * @param filePath - The file path to find relevant notes for.
  * @returns Relevant-note hits allowed by the current inclusion/exclusion rules.
- *   Empty when no allowed notes are found or Miyo is not enabled as the search backend.
+ *   Empty when no allowed notes are found or Miyo cannot run in the current environment.
  * @throws When the Miyo related-note request cannot complete.
  */
 export async function findRelevantNotes({
@@ -156,11 +156,11 @@ export async function findRelevantNotes({
     return [];
   }
 
-  // A graph-only fallback makes Relevant Notes look partially functional when
-  // its Miyo-backed index is unavailable. Only build graph candidates after a
-  // Miyo search can run successfully.
+  // Relevant Notes has no non-Miyo scoring path. Avoid querying Miyo when the
+  // user disabled it or the current platform cannot reach it, such as mobile
+  // without a configured remote endpoint.
   // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
-  if (getSearchBackend(getSettings()) !== "miyo") {
+  if (!shouldUseMiyo(getSettings())) {
     return [];
   }
 

--- a/src/settings/v2/components/MiyoSettings.searchSkill.test.tsx
+++ b/src/settings/v2/components/MiyoSettings.searchSkill.test.tsx
@@ -102,6 +102,10 @@ jest.mock("@/miyo/miyoResync", () => ({
   resyncMiyoFolder: (...a: unknown[]) => resyncMiyoFolder(...a),
   verifyMiyoScope: (...a: unknown[]) => verifyMiyoScope(...a),
 }));
+const notifyIndexChanged = jest.fn<void, []>();
+jest.mock("@/search/indexSignal", () => ({
+  notifyIndexChanged: () => notifyIndexChanged(),
+}));
 // Capture the options the component passes to the modal so a test can invoke the
 // modal's callbacks (onRetry/onAddVault) directly — the Retry button has no
 // busy-guard, which is the real path that fires concurrent enable attempts.
@@ -181,7 +185,7 @@ beforeEach(() => {
   enqueuedSessions.length = 0;
 });
 
-it("registers through the queue with the plugin's session", async () => {
+it("registers through the queue and refreshes Relevant Notes — https://github.com/Brevilabs/obsidian-copilot-private/issues/280", async () => {
   // The Connect modal is a standalone Obsidian Modal that outlives onunload, so
   // its Add-this-vault callback is the producer most able to act for a closed
   // lifecycle. It must hand the queue the plugin's session, not a fresh one.
@@ -195,6 +199,7 @@ it("registers through the queue with the plugin's session", async () => {
   await lastModalOptions?.onAddVault?.();
 
   expect(enqueuedSessions).toEqual([mockPluginInstance.miyoMutationSession]);
+  expect(notifyIndexChanged).toHaveBeenCalledTimes(1);
 });
 
 it("verifies scope with the plugin's session, not one this tab obtained itself", async () => {

--- a/src/settings/v2/components/MiyoSettings.tsx
+++ b/src/settings/v2/components/MiyoSettings.tsx
@@ -30,6 +30,7 @@ import {
   shouldSurfaceMiyoResync,
 } from "@/miyo/miyoUtils";
 import { useMiyoStatus } from "@/miyo/useMiyoStatus";
+import { notifyIndexChanged } from "@/search/indexSignal";
 import { deriveSkillsFolder } from "@/settings/copilotFolder";
 import { getSettings, updateSetting, useSettingsValue } from "@/settings/model";
 import {
@@ -520,6 +521,11 @@ export const MiyoSettings: React.FC = () => {
       if (submission.created !== null) {
         updateSetting("miyoSyncedExclusions", submission.receipt);
       }
+      // Registration can make semantic results available without changing the
+      // endpoint or its healthy status. Retry any Relevant Notes request that
+      // previously settled on setup guidance.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+      notifyIndexChanged();
     } catch (error) {
       logWarn(`Miyo add-folder failed: ${err2String(error)}`);
       return "error";


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#280

## Why

Relevant Notes still has two semantic-scoring paths: Miyo and Copilot's retiring local embedding index. That leaves a user without Miyo looking at a **Build index** action for an index Copilot is removing.

This step gives the pane one source of results and semantic scores. Direct links and backlinks can augment a successful Miyo search, but they are not shown as a partial fallback when Miyo is disabled or unreachable.

## What

| Situation | Before | After |
| --- | --- | --- |
| Miyo returns related notes | Similarity may come from Miyo or the local index | Similarity percentages come from Miyo only |
| Miyo is disabled | The pane can offer **Build index** or graph-only rows | The pane offers **Download Miyo** and **Set up in Copilot** without result rows |
| Miyo is unavailable | The pane can lose semantic context while retaining graph-only rows | The pane offers **Open Miyo settings** without result rows |
| Miyo search succeeds | Semantic and graph candidates can be combined | Direct links and backlinks remain available, without affecting similarity ranking |

The Miyo action opens Copilot settings directly on the Miyo tab. Successful Miyo registration or resync also refreshes a settled Relevant Notes request when backend health remains stable. The status/result rendering is separated into a story-backed presentational pane so its loading, download, setup, and scored-result states can be reviewed independently of plugin state.

## Non goal

- Distinguishing an unindexed note from an available Miyo instance with no related results; the next step owns those states.
- Changing the ranking formula, result cap, or link and backlink collection after a successful Miyo search.
- Changing Miyo's API, indexing rules, or exclusion controls.
- Deleting the remaining local vector-store implementation used outside Relevant Notes.
- Building an in-plugin fallback embedding path.
- Changing the other Relevant Notes controls tracked by Brevilabs/obsidian-copilot-private#282.

## Screenshot

### No Miyo

![Relevant Notes without Miyo](https://github.com/user-attachments/assets/3c768690-b3ee-45ce-b079-3bb53dcd11b8)

The pane shows Miyo setup guidance without graph-only direct-link or backlink rows.

| State | Reviewable branch behavior |
| --- | --- |
| Before, no Miyo | The empty pane offers **Build index** for Copilot's local index |
| After, no Miyo | The pane says **Add semantic matches with Miyo** and offers **Download Miyo** and **Set up in Copilot**, without graph-only rows |
| After, Miyo unavailable | The pane says **Check your Miyo setup** and offers **Open Miyo settings**, without graph-only rows |
| After, Miyo results | Related notes carry Miyo similarity percentages; links and backlinks from the successful search remain part of the list |

The adjacent stories cover the loading, download, setup, and scored-result states with deterministic content.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Search, pane, settings-navigation, and container tests cover the changed scoring and guidance behavior |
| A defect would fail CI or be obvious on first use | ✅ | Contract tests run in CI, and a wrong empty state appears on the next pane open |
| A revert fully restores prior state, including persisted data | ✅ | This step does not migrate settings or write vault data |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Existing Miyo connection settings and credentials are unchanged |
| No public API, plugin API, message, or on-disk contract changes | ✅ | The scorer and pane boundary are internal to Relevant Notes |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | This step adds stale-request protection to the optional Relevant Notes request lifecycle |
| No hot-path behavior lacks deterministic coverage | ✅ | Miyo success, failure, disabled, empty, and graph-only paths are covered |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Layout and action placement are confined to Relevant Notes and appear immediately |

Review: skim the scorer replacement in `findRelevantNotes()` in `src/search/findRelevantNotes.ts` and the guidance/result boundary in `RelevantNotesPane` in `src/components/chat-components/ui/RelevantNotesPane.tsx`, then run Verification steps 2–5.

## Verification

1. Load the branch in an isolated Obsidian test vault with Copilot enabled and open a source note that has both an outgoing link and a backlink.
2. With Miyo enabled, open Relevant Notes while its request is pending. Confirm the neutral loading state appears without setup guidance. Close the active note and confirm setup guidance remains hidden.
3. Disable Miyo and open Relevant Notes. Confirm **Add semantic matches with Miyo** appears, both setup actions work, no result rows appear, and no **Build index** action remains.
4. Enable Miyo against an unavailable endpoint. Confirm no result rows appear and **Open Miyo settings** lands directly on **Settings → Copilot → Miyo**.
5. Connect Miyo and open an indexed source. Confirm semantic rows display Miyo similarity percentages while links and backlinks remain included.
6. Leave Relevant Notes on setup guidance, then register or resync the vault in Miyo settings. Confirm the pane starts a fresh request without changing the active note.
