### PR TITLE
[Relevant Notes on Miyo] - Step 5: Edit Index scope in Miyo settings

### DIFF
--- a/src/components/chat-components/RelevantNotes.test.tsx
+++ b/src/components/chat-components/RelevantNotes.test.tsx
@@ -285,6 +285,16 @@ describe("RelevantNotes", () => {
       await waitFor(() => expect(mockFindRelevantNotes).toHaveBeenCalledTimes(2));
     });
 
+    it("refetches Relevant Notes when the Copilot Index scope changes (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      const { rerender } = render(<RelevantNotes onAddToChat={jest.fn()} />);
+      await waitFor(() => expect(mockFindRelevantNotes).toHaveBeenCalledTimes(1));
+
+      mockSettings = { ...mockSettings, qaExclusions: "Archive" };
+      rerender(<RelevantNotes onAddToChat={jest.fn()} />);
+
+      await waitFor(() => expect(mockFindRelevantNotes).toHaveBeenCalledTimes(2));
+    });
+
     it("keeps a superseded Miyo request from overwriting newer results (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
       let resolveFirst:
         | ((notes: Awaited<ReturnType<typeof findRelevantNotes>>) => void)

--- a/src/components/chat-components/RelevantNotes.tsx
+++ b/src/components/chat-components/RelevantNotes.tsx
@@ -42,7 +42,12 @@ const UNAVAILABLE_RELEVANT_NOTES_RESULT = Object.freeze({
   semanticState: "unavailable" as const,
 });
 
-function useRelevantNotes(enableMiyo: boolean, miyoServerUrl: string) {
+function useRelevantNotes(
+  enableMiyo: boolean,
+  miyoServerUrl: string,
+  qaInclusions: string,
+  qaExclusions: string
+) {
   const app = useApp();
   const [result, setResult] = useState<RelevantNotesResult>(
     enableMiyo ? LOADING_RELEVANT_NOTES_RESULT : DISABLED_RELEVANT_NOTES_RESULT
@@ -88,7 +93,7 @@ function useRelevantNotes(enableMiyo: boolean, miyoServerUrl: string) {
     return () => {
       cancelled = true;
     };
-  }, [app, activeFile?.path, enableMiyo, miyoServerUrl, signalTick]);
+  }, [app, activeFile?.path, enableMiyo, miyoServerUrl, qaExclusions, qaInclusions, signalTick]);
 
   return { result, refresh };
 }
@@ -381,7 +386,12 @@ export const RelevantNotes = memo(
     const app = useApp();
     const activeFile = useActiveFile();
     const settings = useSettingsValue();
-    const { result, refresh } = useRelevantNotes(settings.enableMiyo, settings.miyoServerUrl);
+    const { result, refresh } = useRelevantNotes(
+      settings.enableMiyo,
+      settings.miyoServerUrl,
+      settings.qaInclusions,
+      settings.qaExclusions
+    );
     const relevantNotes = result.notes;
 
     // The active note itself is excluded from the index (by the QA

--- a/src/components/chat-components/RelevantNotes.tsx
+++ b/src/components/chat-components/RelevantNotes.tsx
@@ -445,7 +445,7 @@ export const RelevantNotes = memo(
                 </span>
                 <span className="tw-text-sm tw-text-muted">
                   It falls outside your semantic index settings, so related notes can&apos;t be
-                  shown here. Adjust inclusions or exclusions in Copilot settings to include it.
+                  shown here. Adjust Index scope in the Miyo tab of Copilot settings to include it.
                 </span>
               </div>
             </div>

--- a/src/settings/v2/SettingsMainV2.tsx
+++ b/src/settings/v2/SettingsMainV2.tsx
@@ -29,8 +29,8 @@ import { SelfHostSettings } from "./components/SelfHostSettings";
 //     (LegacyVaultIndexSetting), the off switch a vault not using Miyo needs to
 //     stop indexing; it reads as the legacy index because that is all the flag
 //     still controls once Miyo owns semantic search.
-//   - qaInclusions/qaExclusions — still consumed (Miyo registration snapshot);
-//     their edit UI is deferred per issue #195 ("defer include/exclude").
+//   - qaInclusions/qaExclusions — edited from the Miyo tab's "Index scope"
+//     section, which is where semantic search now lives.
 //   - embeddingModelKey / maxSourceChunks / enableInlineCitations / indexing
 //     limits — still read at runtime (embeddingManager, SearchTools,
 //     VaultQAChainRunner, CopilotPlusChainRunner) with their defaults; a

--- a/src/settings/v2/components/MiyoSettings.searchSkill.test.tsx
+++ b/src/settings/v2/components/MiyoSettings.searchSkill.test.tsx
@@ -147,7 +147,12 @@ jest.mock("@/plusUtils", () => ({ createPlusPageUrl: () => "https://example.com"
 jest.mock("@/utils/vaultPath", () => ({ getVaultBase: () => "/vault" }));
 
 const NoticeMock = jest.fn();
+// Keep the shared mock's classes (Modal / FuzzySuggestModal) — the Index scope
+// editor pulls the pattern-picker modals into this module graph, and they extend
+// those at import time. Only Notice and Platform are overridden, so the tests can
+// read back messages and pin the platform.
 jest.mock("obsidian", () => ({
+  ...jest.requireActual<Record<string, unknown>>("obsidian"),
   Notice: class {
     constructor(message: string) {
       NoticeMock(message);
@@ -600,5 +605,66 @@ describe("scope resync banner", () => {
     fireEvent.click(await screen.findByText("Connect"));
 
     await waitFor(() => expect(verifyMiyoScope).toHaveBeenCalledTimes(2));
+  });
+});
+
+describe("index scope", () => {
+  it("renders the persisted exclusion and inclusion patterns as removable badges", async () => {
+    currentSettings = {
+      ...DEFAULT_SETTINGS,
+      qaExclusions: "notes/private,*.pdf",
+      qaInclusions: "wiki",
+    };
+    render(<MiyoSettings />);
+
+    expect(await screen.findByLabelText("Remove notes/private")).toBeTruthy();
+    expect(screen.getByLabelText("Remove *.pdf")).toBeTruthy();
+    expect(screen.getByLabelText("Remove wiki")).toBeTruthy();
+  });
+
+  it("persists the narrowed list to qaExclusions when an exclusion is removed", async () => {
+    currentSettings = {
+      ...DEFAULT_SETTINGS,
+      qaExclusions: "notes/private,*.pdf",
+      qaInclusions: "wiki",
+    };
+    render(<MiyoSettings />);
+
+    fireEvent.click(await screen.findByLabelText("Remove notes/private"));
+
+    expect(updateSetting).toHaveBeenCalledWith("qaExclusions", "*.pdf");
+  });
+
+  it("persists to qaInclusions when an inclusion is removed, leaving exclusions untouched", async () => {
+    currentSettings = {
+      ...DEFAULT_SETTINGS,
+      qaExclusions: "notes/private",
+      qaInclusions: "wiki",
+    };
+    render(<MiyoSettings />);
+
+    fireEvent.click(await screen.findByLabelText("Remove wiki"));
+
+    expect(updateSetting).toHaveBeenCalledWith("qaInclusions", "");
+    expect(updateSetting).not.toHaveBeenCalledWith("qaExclusions", expect.anything());
+  });
+
+  it("stays editable while Miyo is disconnected", async () => {
+    // These patterns filter Copilot's own retrieval and Relevant Notes whether
+    // or not Miyo is reachable, and the Relevant Notes "This note is excluded"
+    // state points here for the fix — gating them on the connection would
+    // strand a user with an excluded note and no way to include it.
+    mockMiyoBackend = "unavailable";
+    currentSettings = {
+      ...DEFAULT_SETTINGS,
+      enableMiyo: false,
+      qaExclusions: "notes/private",
+      qaInclusions: "",
+    };
+    render(<MiyoSettings />);
+
+    fireEvent.click(await screen.findByLabelText("Remove notes/private"));
+
+    expect(updateSetting).toHaveBeenCalledWith("qaExclusions", "");
   });
 });

--- a/src/settings/v2/components/MiyoSettings.tsx
+++ b/src/settings/v2/components/MiyoSettings.tsx
@@ -38,6 +38,7 @@ import {
   MiyoConnectModal,
 } from "@/settings/v2/components/MiyoConnectModal";
 import { MiyoStatusRow } from "@/settings/v2/components/MiyoStatusRow";
+import { PatternListEditor } from "@/settings/v2/components/PatternListEditor";
 import { err2String } from "@/utils";
 import { getVaultBase } from "@/utils/vaultPath";
 import { extractAppIgnoreSettings, getSystemExcludedFolders } from "@/search/searchUtils";
@@ -1045,6 +1046,38 @@ export const MiyoSettings: React.FC = () => {
           </div>
         </div>
       </div>
+
+      {/* Index scope — `qaExclusions` / `qaInclusions`. Deliberately NOT
+          connection-gated: these patterns filter Copilot's own retrieval,
+          Relevant Notes, and project context whether or not Miyo is reachable,
+          so gating them would strand a user whose note is excluded with no way
+          to include it. */}
+      <SettingSection
+        label="Index scope"
+        description="Which notes Copilot searches and shows in Relevant Notes; your Copilot folder is always excluded. Miyo's own index keeps the scope it was registered with until you re-add this folder in the Miyo app."
+      >
+        <SettingItem
+          type="custom"
+          title="Exclusions"
+          description="Skip these folders, tags, notes, or file extensions."
+        >
+          <PatternListEditor
+            value={settings.qaExclusions}
+            onChange={(value) => updateSetting("qaExclusions", value)}
+          />
+        </SettingItem>
+
+        <SettingItem
+          type="custom"
+          title="Inclusions"
+          description="Search only these folders, tags, or notes. Leave empty to cover the whole vault; exclusions take precedence."
+        >
+          <PatternListEditor
+            value={settings.qaInclusions}
+            onChange={(value) => updateSetting("qaInclusions", value)}
+          />
+        </SettingItem>
+      </SettingSection>
     </div>
   );
 };

--- a/src/settings/v2/components/PatternListEditor.stories.tsx
+++ b/src/settings/v2/components/PatternListEditor.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@/lib/story";
+import { PatternListEditor, type PatternListEditorProps } from "./PatternListEditor";
+
+const meta = {
+  title: "Settings/Pattern List Editor",
+  component: PatternListEditor,
+  args: {
+    value: "",
+    onChange: () => {},
+  },
+  parameters: { gallery: { host: "settings-tab", layout: "padded" } },
+} satisfies Meta<PatternListEditorProps>;
+export default meta;
+
+/** No patterns yet — the state a vault with an untouched Index scope shows. */
+export const Empty: StoryObj<PatternListEditorProps> = {};
+
+/** One badge per pattern kind, so the icon and colour of each stays checkable. */
+export const AllPatternKinds: StoryObj<PatternListEditorProps> = {
+  args: { value: "notes/private,#archive,[[Daily Note]],*.pdf" },
+};
+
+/** A path long enough to truncate inside its badge rather than widen the row. */
+export const LongPatternTruncates: StoryObj<PatternListEditorProps> = {
+  args: { value: "Archive/2024/Quarterly Reviews/Engineering/Retrospectives" },
+};
+
+/** Past the collapsed height the list fades out and offers "Show N items". */
+export const OverflowsCollapsed: StoryObj<PatternListEditorProps> = {
+  args: {
+    value: [
+      "copilot",
+      "Archive",
+      "Templates",
+      "Attachments",
+      "Journal/2023",
+      "Journal/2024",
+      "#draft",
+      "#private",
+      "*.pdf",
+      "*.canvas",
+      "[[Scratchpad]]",
+      "[[Inbox]]",
+    ].join(","),
+  },
+};

--- a/src/settings/v2/components/PatternListEditor.tsx
+++ b/src/settings/v2/components/PatternListEditor.tsx
@@ -37,7 +37,7 @@ const PATTERN_TYPE_CONFIG = {
 
 type PatternType = keyof typeof PATTERN_TYPE_CONFIG;
 
-interface PatternListEditorProps {
+export interface PatternListEditorProps {
   value: string;
   onChange: (value: string) => void;
   maxCollapsedHeight?: number;


### PR DESCRIPTION
Fixes Brevilabs/obsidian-copilot-private#280

## Why

Relevant Notes applies Copilot's inclusion and exclusion rules after Miyo scores candidates, but those rules are not editable from the Miyo tab where users now configure semantic search. The prerequisite editor change already preserves hidden property rules, so this layer only exposes the controls and refreshes the open pane.

The open pane must also react when Index scope changes. Otherwise it continues showing results that the newly saved rule should include or exclude until some unrelated refresh occurs.

## What

| Situation | Before | After |
| --- | --- | --- |
| User opens **Settings → Copilot → Miyo** | Index scope controls are absent | Inclusion and exclusion editors appear under **Index scope** |
| Miyo is disconnected | Search capability controls are gated | Index scope remains editable because Copilot still applies it locally |
| Relevant Notes is already open | Saved scope changes may leave stale results | Inclusion or exclusion changes trigger a fresh result request |

The editor story shows representative folder, tag, note, and extension badges without requiring plugin state.

## Non goal

- Updating Miyo's registered folder filters; the next step owns server synchronization.
- Making tags, individual notes, or property patterns representable in Miyo.
- Changing the meaning or precedence of Copilot's inclusion and exclusion rules.
- Changing Miyo connection, registration, or semantic-scoring behavior.

## Screenshot

Exact settings screenshots were not captured because loading this split branch would overwrite the shared Obsidian test-vault plugin and gallery build used by parallel workspaces. The reviewable before/after contract is:

| Surface | Before | After |
| --- | --- | --- |
| **Settings → Copilot → Miyo** | **Search scope** selects current-vault versus unrestricted Miyo retrieval; no pattern editors appear | An **Index scope** section adds **Included files** and **Excluded files** editors beneath the Miyo search controls |
| Disconnected Miyo | Miyo-only capabilities are disabled | Both Index scope editors remain enabled and continue controlling Copilot filtering |
| Pattern badge editor | Folder, tag, note, and extension badges render | The same badges render; hidden property-rule preservation is inherited from the prerequisite PR |

The adjacent `PatternListEditor` story supplies deterministic rendered fixtures for each visible badge type.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Settings and Relevant Notes tests cover writes, disconnected editing, and result refresh; the prerequisite PR directly covers hidden-rule preservation |
| A defect would fail CI or be obvious on first use | ✅ | Persisted update and refresh contracts run in CI |
| A revert fully restores prior state, including persisted data | ❌ | A user can save existing inclusion and exclusion settings while this code is active; reverting code does not undo those user edits |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | The existing pattern input surface and settings storage are reused |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Existing `qaInclusions` and `qaExclusions` fields retain their format and meaning |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Settings writes are synchronous store updates and the pane uses its existing request lifecycle |
| No hot-path behavior lacks deterministic coverage | ✅ | Disconnected and live-refetch paths are covered here; remove and custom-add paths are covered by the prerequisite PR |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | The editors and refreshed pane are visible immediately in Miyo settings and Relevant Notes |

Review: inspect settings writes and availability in `MiyoSettings` in `src/settings/v2/components/MiyoSettings.tsx` and scope dependencies in `useRelevantNotes()` in `src/components/chat-components/RelevantNotes.tsx`; then run Verification steps 2–5, including an existing property rule.

## Verification

1. Load the branch in an isolated Obsidian test vault and open **Settings → Copilot → Miyo**.
2. With Miyo disconnected, add and remove folder, tag, note, and extension patterns in both Index scope editors. Reload settings and confirm the saved values remain.
3. Confirm the prerequisite property-filter preservation test remains green while exercising the newly exposed editor.
4. Keep Relevant Notes open, add an exclusion matching one displayed result, and confirm that result disappears without switching notes.
5. Remove the exclusion and confirm the result returns. Confirm the surrounding Miyo connection and Search scope controls behave as before.


