### PR TITLE
[Relevant Notes on Miyo] - Step 6: Sync Index scope changes to Miyo

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -193,6 +193,12 @@ Miyo supplies Copilot's current semantic search and selected chat-history search
 
 If Miyo is reachable but the vault is not registered, the connection dialog offers **Register & connect** for a local Miyo. With a remote server or mobile setup, select **Open Miyo**, add the vault there, then **Retry**. Register only folders you intend Miyo and any enabled Relay clients to access.
 
+### Index scope
+
+Use **Exclusions** to skip folders, tags, individual notes, or file extensions. Use **Inclusions** to search only selected folders, tags, or notes. Exclusions take precedence, and Copilot's own working folder always stays excluded.
+
+Copilot applies every pattern to its own search results and Relevant Notes. Folder and file-extension changes also update the registered Miyo folder automatically, even when this settings tab is closed. Copilot preserves filters configured directly in Miyo and does not widen a stricter Miyo inclusion whitelist. Miyo's folder API cannot represent tags or individual notes, so those patterns remain Copilot-side filters. If Miyo is unavailable when a representable pattern changes, Copilot keeps the setting and shows that Miyo was not updated.
+
 ### Powered by Miyo
 
 | Control                          | Default                                    | Dependency and effect                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |

--- a/docs/vault-search-and-indexing.md
+++ b/docs/vault-search-and-indexing.md
@@ -39,6 +39,8 @@ Use **Search scope** in the Miyo settings tab:
 
 The scope is a retrieval preference, not a security boundary. Keep Miyo's registered folders intentional, especially when you use an unrestricted scope or connect to a shared remote server.
 
+Under **Index scope**, Copilot's inclusions and exclusions control which notes its searches and Relevant Notes can return. Folder and file-extension changes also update this vault's registered Miyo folder automatically. Filters configured directly in Miyo remain in place, and Copilot does not widen a stricter Miyo inclusion whitelist. Tags and individual-note patterns still filter Copilot results, but Miyo continues indexing them because its folder API cannot represent those pattern types. If Miyo cannot be reached during an update, Copilot keeps the local setting and tells you that Miyo was not updated.
+
 ### Relevant Notes
 
 Miyo is the source of Relevant Notes results and similarity percentages; Copilot's legacy local embedding index no longer scores this pane. When Miyo is available, results can include direct links and backlinks that pass Copilot's search scope.
@@ -74,7 +76,7 @@ Connector access is separate from Agent Chat search. Review the folders, remote 
 - **Relevant Notes has no semantic results:** **No semantic matches yet** means Miyo answered successfully but found no related notes. **This note isn't indexed in Miyo** means the note may still be indexing or may be excluded from Miyo. Links and backlinks remain visible in either state.
 - **Agent Chat Miyo document processing fails:** install Miyo on this computer so its local CLI is available, or switch **Document Processor** to **Plus**. A remote Miyo search connection does not provide the local CLI Agent Chat needs.
 - **Quick Chat Miyo document processing fails:** confirm that the connected Miyo service can access the registered vault and document. When a remote server is configured, troubleshoot the document on that server.
-- **Copilot asks for a resync:** use **Resync Miyo** so Miyo excludes Copilot's own working folder and conversation files.
+- **Copilot asks for a resync:** use **Resync Miyo** so Miyo excludes Copilot's own working folder and conversation files. Ordinary folder and file-extension edits under **Index scope** update Miyo automatically and do not require this rebuild.
 - **Mobile:** a remote Miyo server can be configured on mobile, but Agent Chat and its Skills are desktop features. Use Quick Chat on mobile.
 
 ## Related

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1002,6 +1002,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   miyoSearchAll: false,
   miyoServerUrl: "",
   miyoSyncedExclusions: "",
+  miyoSyncedIndexScope: "",
   selfHostSearchProvider: "firecrawl",
   firecrawlApiKey: "",
   perplexityApiKey: "",

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -23,6 +23,7 @@ jest.mock("@/logger", () => ({
 jest.mock("@/miyo/miyoResync", () => ({
   resetMiyoMutations: jest.fn(),
   startMiyoMutationSession: jest.fn(),
+  syncMiyoIndexScopeChange: jest.fn().mockResolvedValue("unchanged"),
 }));
 jest.mock("@/services/settingsPersistence", () => ({
   flushPersistence: jest.fn().mockResolvedValue(undefined),

--- a/src/main.ts
+++ b/src/main.ts
@@ -72,7 +72,11 @@ import {
   updateSetting,
 } from "@/settings/model";
 import { didMiyoSyncedRootsChange, shouldSurfaceMiyoResync } from "@/miyo/miyoUtils";
-import { type MiyoMutationSession, resetMiyoMutations } from "@/miyo/miyoResync";
+import {
+  type MiyoMutationSession,
+  resetMiyoMutations,
+  syncMiyoIndexScopeChange,
+} from "@/miyo/miyoResync";
 import { ensureCopilotSubfolders, getEffectiveConversationsFolder } from "@/settings/copilotFolder";
 import { buildUpgradeRelocationEntries } from "@/settings/upgradeNotice";
 import { dehydrateDeviceProfile, hydrateDeviceProfile } from "@/settings/deviceProfiles";
@@ -241,6 +245,11 @@ export default class CopilotPlugin extends Plugin {
     // from disk without firing the subscription, so register on load.
     syncPlus(getSettings().isPaidUser, getSettings().plusLicenseKey);
     this.settingsUnsubscriber = subscribeToSettingsChange((prev, next) => {
+      // Keep the registered Miyo folder aligned even when this change came from
+      // Obsidian Sync or another settings surface while the Miyo tab was closed.
+      // The reconciler no-ops for unrelated settings and unconfigured Miyo.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/310
+      void syncMiyoIndexScopeChange(this.app, prev, next, this.miyoMutationSession);
       void (async () => {
         try {
           await persistSettings(next, (data) => this.saveData(data), prev);

--- a/src/miyo/MiyoClient.test.ts
+++ b/src/miyo/MiyoClient.test.ts
@@ -403,6 +403,49 @@ describe("MiyoClient", () => {
     });
   });
 
+  describe("updateFolder()", () => {
+    it("PATCHes the registered folder with only the supplied scope fields (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)", async () => {
+      const folderRecord = { path: "my-vault", exclude_folders: ["copilot", "private"] };
+      mockedRequestUrl.mockResolvedValue({
+        status: 200,
+        json: folderRecord,
+        text: "",
+      } as RequestUrlResponse);
+
+      const client = new MiyoClient();
+      const result = await client.updateFolder({
+        path: "my-vault",
+        exclude_folders: ["copilot", "private"],
+      });
+
+      expect(result).toEqual(folderRecord);
+      expect(mockedRequestUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "http://127.0.0.1:8742/v0/folder",
+          method: "PATCH",
+          contentType: "application/json",
+          body: JSON.stringify({
+            path: "my-vault",
+            exclude_folders: ["copilot", "private"],
+          }),
+        })
+      );
+    });
+
+    it("does not PATCH after the caller's lifecycle guard expires (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)", async () => {
+      const client = new MiyoClient();
+
+      await expect(
+        client.updateFolder({ path: "my-vault", exclude_folders: ["Private"] }, undefined, () => {
+          throw new Error("lifecycle expired");
+        })
+      ).rejects.toThrow("lifecycle expired");
+
+      expect(mockResolveBaseUrl).toHaveBeenCalled();
+      expect(mockedRequestUrl).not.toHaveBeenCalled();
+    });
+  });
+
   describe("deleteFolder", () => {
     it("DELETEs /v0/folder with the folder name in the JSON body", async () => {
       mockedRequestUrl.mockResolvedValue({

--- a/src/miyo/MiyoClient.ts
+++ b/src/miyo/MiyoClient.ts
@@ -83,6 +83,16 @@ export interface MiyoAddFolderRequest {
   allow_remote_read?: boolean;
 }
 
+/** Index-scope fields accepted by Miyo's in-place folder update endpoint. */
+export interface MiyoUpdateFolderRequest {
+  path: string;
+  include_extensions?: string[];
+  include_folders?: string[];
+  exclude_folders?: string[];
+  include_patterns?: string[];
+  exclude_patterns?: string[];
+}
+
 /**
  * Whether a vault folder is registered with Miyo, as a discriminated result
  * rather than a thrown error — so the connect flow can branch on it directly:
@@ -367,6 +377,27 @@ export class MiyoClient {
         ? `Miyo add-folder failed with status ${response.status}: ${detail}`
         : `Miyo add-folder failed with status ${response.status}`
     );
+  }
+
+  /**
+   * Update a registered folder's index scope without replacing its registration.
+   *
+   * @param request - Folder identifier and only the scope fields to change.
+   * @param overrideUrl - Explicit base URL or empty for local service discovery.
+   * @param beforeRequest - Final lifecycle guard before the request leaves.
+   * @returns The updated folder record.
+   */
+  public async updateFolder(
+    request: MiyoUpdateFolderRequest,
+    overrideUrl?: string,
+    beforeRequest?: () => void
+  ): Promise<MiyoFolderEntry> {
+    const baseUrl = await this.resolveBaseUrl(overrideUrl);
+    return this.requestJson<MiyoFolderEntry>(baseUrl, "/v0/folder", {
+      method: "PATCH",
+      body: request,
+      beforeRequest,
+    });
   }
 
   /**
@@ -677,9 +708,10 @@ export class MiyoClient {
     baseUrl: string,
     path: string,
     options: {
-      method: "GET" | "POST" | "DELETE";
+      method: "GET" | "POST" | "PATCH" | "DELETE";
       body?: unknown;
       query?: Record<string, string | number | boolean | undefined>;
+      beforeRequest?: () => void;
     }
   ): Promise<T> {
     const url = new URL(path, baseUrl);
@@ -693,6 +725,11 @@ export class MiyoClient {
 
     const body = options.body ? JSON.stringify(options.body) : undefined;
     const headers = await this.buildHeaders();
+    // Folder mutations can outlive their vault while URL and credentials
+    // resolve. Give their lifecycle owner the final refusal point before the
+    // uncancellable request leaves.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/310
+    options.beforeRequest?.();
     logInfo("Miyo request:", {
       method: options.method,
       url: url.toString(),

--- a/src/miyo/miyoResync.test.ts
+++ b/src/miyo/miyoResync.test.ts
@@ -15,6 +15,7 @@ const getFolder = jest.fn<Promise<unknown>, unknown[]>();
 const checkFolderRegistration = jest.fn<Promise<string>, unknown[]>();
 const deleteFolder = jest.fn<Promise<void>, unknown[]>();
 const addFolder = jest.fn<Promise<unknown>, unknown[]>();
+const updateFolder = jest.fn<Promise<unknown>, unknown[]>();
 const scanFolder = jest.fn<Promise<unknown>, unknown[]>();
 jest.mock("@/miyo/MiyoClient", () => ({
   MiyoClient: class {
@@ -32,6 +33,10 @@ jest.mock("@/miyo/MiyoClient", () => ({
     addFolder = (request: unknown, url: unknown, beforeRequest?: () => void) => {
       beforeRequest?.();
       return addFolder(request, url, beforeRequest);
+    };
+    updateFolder = (request: unknown, url: unknown, beforeRequest?: () => void) => {
+      beforeRequest?.();
+      return updateFolder(request, url, beforeRequest);
     };
     scanFolder = (...a: unknown[]) => scanFolder(...a);
   },
@@ -51,13 +56,15 @@ jest.mock("@/settings/model", () => ({
 
 jest.mock("@/utils/vaultPath", () => ({ getVaultBase: jest.fn(() => "/abs/vault") }));
 
-import type { App } from "obsidian";
+import { Notice, type App } from "obsidian";
 import type { MiyoAddFolderRequest, MiyoFolderEntry } from "@/miyo/MiyoClient";
 import {
+  buildMiyoIndexScopeReceipt,
   enqueueMiyoFolderMutation,
   miyoRecordCoversSystemRoots,
   resetMiyoMutations,
   resyncMiyoFolder,
+  syncMiyoIndexScopeChange,
   verifyMiyoScope,
 } from "@/miyo/miyoResync";
 import type { MiyoMutationSession } from "@/miyo/miyoResync";
@@ -122,6 +129,7 @@ beforeEach(() => {
   resolveBaseUrl.mockResolvedValue("http://miyo");
   deleteFolder.mockResolvedValue(undefined);
   addFolder.mockResolvedValue(record());
+  updateFolder.mockResolvedValue(record());
   scanFolder.mockResolvedValue({});
 });
 
@@ -135,6 +143,297 @@ function rootMovedSettings(): void {
 }
 
 describe("miyoResync", () => {
+  describe("buildMiyoIndexScopeReceipt()", () => {
+    it("records only Miyo-representable Copilot filters with the current registration identity (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)", () => {
+      const settings = {
+        ...currentSettings,
+        qaExclusions: "Private,*.pdf,#draft",
+        qaInclusions: "Notes,*.md",
+      } as CopilotSettings;
+
+      expect(JSON.parse(buildMiyoIndexScopeReceipt(app, settings))).toEqual({
+        device: "device-A",
+        url: "",
+        folder: "my-vault",
+        include_extensions: ["md"],
+        include_folders: ["Notes"],
+        exclude_folders: ["Private"],
+        include_patterns: [],
+        exclude_patterns: ["**/*.pdf"],
+      });
+    });
+  });
+
+  describe("syncMiyoIndexScopeChange()", () => {
+    it("replaces Copilot's prior filters while retaining Miyo-owned scope (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)", async () => {
+      const previous = {
+        ...currentSettings,
+        enableMiyo: true,
+        qaExclusions: "copilot,Private,*.pdf",
+        qaInclusions: "Notes",
+      } as unknown as CopilotSettings;
+      const next = {
+        ...previous,
+        qaExclusions: "copilot,Archive,*.canvas",
+        qaInclusions: "Projects",
+      };
+      getFolder.mockResolvedValue(
+        record({
+          exclude_folders: ["copilot", "Private", "MiyoOnly"],
+          exclude_patterns: ["**/*.pdf", "**/miyo-secret/**"],
+          include_folders: ["Notes", "MiyoPinned"],
+        })
+      );
+
+      await expect(syncMiyoIndexScopeChange(app, previous, next, session)).resolves.toBe("synced");
+
+      expect(updateFolder).toHaveBeenCalledWith(
+        {
+          path: "my-vault",
+          exclude_folders: ["MiyoOnly", "copilot", "Archive"],
+          exclude_patterns: ["**/miyo-secret/**", "**/*.canvas"],
+          include_folders: ["MiyoPinned"],
+          include_patterns: [],
+          include_extensions: [],
+        },
+        undefined,
+        expect.any(Function)
+      );
+      expect(deleteFolder).not.toHaveBeenCalled();
+      expect(addFolder).not.toHaveBeenCalled();
+      const receiptWrite = updateSetting.mock.calls.find(([key]) => key === "miyoSyncedIndexScope");
+      expect(JSON.parse(receiptWrite?.[1] as string)).toMatchObject({
+        include_folders: [],
+        include_patterns: [],
+        include_extensions: [],
+      });
+    });
+
+    it("does nothing when neither persisted scope value changed (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)", async () => {
+      const previous = { ...currentSettings, enableMiyo: true } as CopilotSettings;
+      const next = { ...previous, debug: true } as CopilotSettings;
+
+      await expect(syncMiyoIndexScopeChange(app, previous, next, session)).resolves.toBe(
+        "unchanged"
+      );
+
+      expect(getFolder).not.toHaveBeenCalled();
+      expect(updateFolder).not.toHaveBeenCalled();
+    });
+
+    it("keeps a local-only edit off the network before Miyo has been configured (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)", async () => {
+      const previous = {
+        ...currentSettings,
+        enableMiyo: false,
+        miyoSyncedExclusions: "",
+      } as CopilotSettings;
+      const next = { ...previous, qaExclusions: "copilot,Private" };
+
+      await expect(syncMiyoIndexScopeChange(app, previous, next, session)).resolves.toBe(
+        "not-configured"
+      );
+
+      expect(resolveBaseUrl).not.toHaveBeenCalled();
+      expect(updateFolder).not.toHaveBeenCalled();
+    });
+
+    it("does not treat another device's synced receipts as a local Miyo registration (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)", async () => {
+      const previous = {
+        ...currentSettings,
+        enableMiyo: false,
+        miyoSyncedExclusions: receiptFor({ device: "device-B" }),
+        miyoSyncedIndexScope: JSON.stringify({
+          device: "device-B",
+          url: "",
+          folder: "my-vault",
+          exclude_folders: ["copilot"],
+          exclude_patterns: [],
+          include_folders: [],
+          include_patterns: [],
+          include_extensions: [],
+        }),
+      } as unknown as CopilotSettings;
+      const next = { ...previous, qaExclusions: "copilot,Private" };
+
+      await expect(syncMiyoIndexScopeChange(app, previous, next, session)).resolves.toBe(
+        "not-configured"
+      );
+
+      expect(resolveBaseUrl).not.toHaveBeenCalled();
+      expect(updateFolder).not.toHaveBeenCalled();
+    });
+
+    it("keeps tag and note changes local because Miyo cannot represent them (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)", async () => {
+      const previous = {
+        ...currentSettings,
+        enableMiyo: true,
+        qaExclusions: "copilot,#draft",
+        qaInclusions: "[[Roadmap]]",
+      } as CopilotSettings;
+      const next = {
+        ...previous,
+        qaExclusions: "copilot,#private",
+        qaInclusions: "[[Launch plan]]",
+      };
+
+      await expect(syncMiyoIndexScopeChange(app, previous, next, session)).resolves.toBe(
+        "unchanged"
+      );
+
+      expect(getFolder).not.toHaveBeenCalled();
+      expect(updateFolder).not.toHaveBeenCalled();
+    });
+
+    it("reports a failed sync without rolling back the Copilot setting (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)", async () => {
+      const previous = { ...currentSettings, enableMiyo: true } as CopilotSettings;
+      const next = { ...previous, qaExclusions: "copilot,Private" };
+      getFolder.mockRejectedValue(new Error("Miyo unavailable"));
+
+      await expect(syncMiyoIndexScopeChange(app, previous, next, session)).resolves.toBe("failed");
+
+      expect(Notice).toHaveBeenCalledWith(
+        "Index scope was saved in Copilot, but Miyo couldn't be updated. Make sure Miyo is running, then change the scope again."
+      );
+      expect(updateSetting).not.toHaveBeenCalledWith("qaExclusions", expect.anything());
+      expect(updateFolder).not.toHaveBeenCalled();
+    });
+
+    it("applies rapid scope edits in settings order (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)", async () => {
+      const first = {
+        ...currentSettings,
+        enableMiyo: true,
+        qaExclusions: "copilot,Private",
+      } as CopilotSettings;
+      const second = { ...first, qaExclusions: "copilot,Archive" };
+      const third = { ...second, qaExclusions: "copilot,Final" };
+      let liveRecord = record({ exclude_folders: ["copilot", "Private"] });
+      getFolder.mockImplementation(async () => liveRecord);
+      const firstPatch = deferred<void>();
+      updateFolder
+        .mockImplementationOnce(async (request) => {
+          await firstPatch.promise;
+          liveRecord = { ...liveRecord, ...(request as MiyoFolderEntry) };
+          return liveRecord;
+        })
+        .mockImplementationOnce(async (request) => {
+          liveRecord = { ...liveRecord, ...(request as MiyoFolderEntry) };
+          return liveRecord;
+        });
+
+      const firstSync = syncMiyoIndexScopeChange(app, first, second, session);
+      await new Promise((resolve) => window.setTimeout(resolve, 0));
+      const secondSync = syncMiyoIndexScopeChange(app, second, third, session);
+
+      expect(updateFolder).toHaveBeenCalledTimes(1);
+      firstPatch.resolve();
+      await expect(Promise.all([firstSync, secondSync])).resolves.toEqual(["synced", "synced"]);
+
+      expect(updateFolder).toHaveBeenCalledTimes(2);
+      expect((updateFolder.mock.calls[1][0] as MiyoFolderEntry).exclude_folders).toEqual([
+        "copilot",
+        "Final",
+      ]);
+    });
+
+    it("reconciles from the last successful server scope after an earlier edit failed (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)", async () => {
+      const previous = {
+        ...currentSettings,
+        enableMiyo: true,
+        qaExclusions: "copilot,Unsynced",
+        miyoSyncedIndexScope: JSON.stringify({
+          device: "device-A",
+          url: "",
+          folder: "my-vault",
+          exclude_folders: ["copilot", "LastSynced"],
+          exclude_patterns: [],
+          include_folders: [],
+          include_patterns: [],
+          include_extensions: [],
+        }),
+      } as unknown as CopilotSettings;
+      const next = { ...previous, qaExclusions: "copilot,Final" };
+      getFolder.mockResolvedValue(
+        record({ exclude_folders: ["copilot", "LastSynced", "MiyoOnly"] })
+      );
+
+      await expect(syncMiyoIndexScopeChange(app, previous, next, session)).resolves.toBe("synced");
+
+      expect((updateFolder.mock.calls[0][0] as MiyoFolderEntry).exclude_folders).toEqual([
+        "MiyoOnly",
+        "copilot",
+        "Final",
+      ]);
+      expect(updateSetting).toHaveBeenCalledWith(
+        "miyoSyncedIndexScope",
+        expect.stringContaining('"exclude_folders":["copilot","Final"]')
+      );
+    });
+
+    it("does not show a failure notice after the originating vault lifecycle ended (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)", async () => {
+      const staleSession = session;
+      resetMiyoMutations();
+      const previous = { ...currentSettings, enableMiyo: true } as CopilotSettings;
+      const next = { ...previous, qaExclusions: "copilot,Private" };
+
+      await expect(syncMiyoIndexScopeChange(app, previous, next, staleSession)).resolves.toBe(
+        "failed"
+      );
+
+      expect(Notice).not.toHaveBeenCalled();
+      expect(updateFolder).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ["malformed", "not-json"],
+      [
+        "invalid",
+        JSON.stringify({
+          device: "device-A",
+          url: "",
+          folder: "my-vault",
+          include_folders: "not-an-array",
+        }),
+      ],
+      [
+        "foreign-device",
+        JSON.stringify({
+          device: "device-B",
+          url: "",
+          folder: "my-vault",
+          exclude_folders: ["LastSynced"],
+          exclude_patterns: [],
+          include_folders: [],
+          include_patterns: [],
+          include_extensions: [],
+        }),
+      ],
+    ])(
+      "ignores a %s ownership receipt and falls back to the prior local scope (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)",
+      async (_label, miyoSyncedIndexScope) => {
+        const previous = {
+          ...currentSettings,
+          enableMiyo: true,
+          qaExclusions: "copilot,ImmediatePrevious",
+          miyoSyncedIndexScope,
+        } as unknown as CopilotSettings;
+        const next = { ...previous, qaExclusions: "copilot,Final" };
+        getFolder.mockResolvedValue(
+          record({ exclude_folders: ["copilot", "ImmediatePrevious", "MiyoOnly"] })
+        );
+
+        await expect(syncMiyoIndexScopeChange(app, previous, next, session)).resolves.toBe(
+          "synced"
+        );
+
+        expect((updateFolder.mock.calls[0][0] as MiyoFolderEntry).exclude_folders).toEqual([
+          "MiyoOnly",
+          "copilot",
+          "Final",
+        ]);
+      }
+    );
+  });
+
   describe("miyoRecordCoversSystemRoots()", () => {
     const movedRootSettings = () =>
       ({

--- a/src/miyo/miyoResync.ts
+++ b/src/miyo/miyoResync.ts
@@ -1,5 +1,10 @@
 import { logInfo, logWarn } from "@/logger";
-import { MiyoClient, type MiyoAddFolderRequest, type MiyoFolderEntry } from "@/miyo/MiyoClient";
+import {
+  MiyoClient,
+  type MiyoAddFolderRequest,
+  type MiyoFolderEntry,
+  type MiyoUpdateFolderRequest,
+} from "@/miyo/MiyoClient";
 import {
   buildMiyoSyncReceipt,
   getMiyoCustomUrl,
@@ -15,16 +20,15 @@ import { type CopilotSettings, getSettings, updateSetting } from "@/settings/mod
 import { err2String } from "@/utils";
 import { getDeviceId } from "@/utils/deviceId";
 import { getVaultBase } from "@/utils/vaultPath";
-import type { App } from "obsidian";
+import { Notice, type App } from "obsidian";
 
 /**
  * Resynchronize the vault's Miyo registration with the current Copilot scope.
  *
- * Miyo only receives exclusions as a registration-time snapshot, so a Copilot
- * root change leaves the server indexing content that should be excluded (and
- * readable via Relay). This module owns the reconcile: verify the live record,
- * and only when it genuinely diverges, delete + re-register with the fresh
- * scope (deletion also purges the folder's index, verified empirically).
+ * Copilot patches user-edited inclusion and exclusion patterns in place. A
+ * Copilot root change still needs the stronger reconcile here: verify the live
+ * record, and only when it genuinely diverges, delete + re-register with the
+ * fresh scope (deletion also purges the folder's index, verified empirically).
  *
  * All Miyo folder mutations — resync runs AND the register flow — must pass
  * through {@link enqueueMiyoFolderMutation} so a resync can never interleave
@@ -291,7 +295,7 @@ function withLookupTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
  */
 function receiptMatchesIdentity(
   app: App,
-  receipt: MiyoSyncReceipt,
+  receipt: Pick<MiyoSyncReceipt, "device" | "url" | "folder">,
   settings: { miyoServerUrl?: string },
   folderName: string
 ): boolean {
@@ -306,6 +310,83 @@ function receiptMatchesIdentity(
 function recordArray(record: MiyoFolderEntry, key: string): string[] {
   const value = record[key];
   return Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
+}
+
+interface MiyoIndexScopeReceipt {
+  device: string;
+  url: string;
+  folder: string;
+  include_extensions: string[];
+  include_folders: string[];
+  exclude_folders: string[];
+  include_patterns: string[];
+  exclude_patterns: string[];
+}
+
+type MiyoScopeField = Exclude<keyof MiyoUpdateFolderRequest, "path">;
+
+function parseMiyoIndexScopeReceipt(stored: unknown): MiyoIndexScopeReceipt | null {
+  // Synced or hand-edited data can carry a receipt from another schema version.
+  // Treat anything incomplete as unknown ownership instead of removing filters
+  // from Miyo based on untrusted local metadata.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/310
+  if (typeof stored !== "string" || stored.length === 0) return null;
+  try {
+    const parsed = JSON.parse(stored) as Partial<MiyoIndexScopeReceipt>;
+    const arrayFields: Array<keyof MiyoIndexScopeReceipt> = [
+      "include_extensions",
+      "include_folders",
+      "exclude_folders",
+      "include_patterns",
+      "exclude_patterns",
+    ];
+    if (
+      typeof parsed.device !== "string" ||
+      typeof parsed.url !== "string" ||
+      typeof parsed.folder !== "string" ||
+      !arrayFields.every(
+        (key) =>
+          Array.isArray(parsed[key]) &&
+          (parsed[key] as unknown[]).every((value) => typeof value === "string")
+      )
+    ) {
+      return null;
+    }
+    return parsed as MiyoIndexScopeReceipt;
+  } catch {
+    return null;
+  }
+}
+
+function commitIndexScopeReceipt(lifecycle: number, receipt: string): void {
+  assertCurrentLifecycle(lifecycle);
+  updateSetting("miyoSyncedIndexScope", receipt);
+}
+
+/**
+ * Record the Copilot-owned subset of a Miyo folder's index filters.
+ *
+ * The identity prevents a receipt synced through data.json from claiming scope
+ * on another device, endpoint, or vault registration.
+ *
+ * @param app - Active Obsidian app, used for device and folder identity.
+ * @param settings - Settings snapshot whose representable QA scope was synced.
+ */
+export function buildMiyoIndexScopeReceipt(app: App, settings: CopilotSettings): string {
+  const scope = {
+    ...getMiyoFolderInclusions(settings.qaInclusions),
+    ...getMiyoFolderExclusions(settings.qaExclusions),
+  };
+  return JSON.stringify({
+    device: getDeviceId(app),
+    url: getMiyoCustomUrl(settings),
+    folder: getMiyoFolderName(app),
+    include_extensions: scope.include_extensions ?? [],
+    include_folders: scope.include_folders ?? [],
+    exclude_folders: scope.exclude_folders ?? [],
+    include_patterns: scope.include_patterns ?? [],
+    exclude_patterns: scope.exclude_patterns ?? [],
+  } satisfies MiyoIndexScopeReceipt);
 }
 
 function isSuperset(container: readonly string[], required: readonly string[]): boolean {
@@ -325,10 +406,10 @@ function isSuperset(container: readonly string[], required: readonly string[]): 
  * Exclusions union: excludes always win server-side, so adding is always safe.
  * Include filters do NOT union — they are an OR whitelist (see
  * {@link getMiyoFolderInclusions}), so unioning would WIDEN scope. When the
- * record carries one, it is kept verbatim and ours is dropped; the cost is that
- * a `qaInclusions` edit stops propagating through a rebuild, which changes
- * nothing in practice since staleness detection is roots-only and never fires on
- * qa* drift anyway. When the record carries none, ours applies — a narrowing.
+ * record carries one, it is kept verbatim and ours is dropped. Ordinary
+ * `qaInclusions` edits use the in-place scope PATCH and never reach this
+ * destructive root-rebuild path. When the record carries none, ours applies —
+ * a narrowing.
  *
  * @param desired - Replacement body built from the current Copilot scope; mutated.
  * @param record - Live folder entry the rebuild is replacing.
@@ -399,6 +480,169 @@ function buildDesiredScope(app: App, settings = getSettings()): MiyoAddFolderReq
       ...extractAppIgnoreSettings(app),
     ]),
   };
+}
+
+/** Result of applying one Copilot index-scope settings change to Miyo. */
+export type MiyoIndexScopeSyncOutcome = "synced" | "unchanged" | "not-configured" | "failed";
+
+/**
+ * Apply a Copilot inclusion/exclusion edit to the registered Miyo folder.
+ *
+ * Copilot removes only the filter values derived from its previous settings and
+ * adds the new values. This keeps filters configured directly in Miyo intact,
+ * and PATCH avoids the destructive delete/re-register path used for root moves.
+ * https://github.com/Brevilabs/obsidian-copilot-private/issues/310
+ *
+ * @param app - Active Obsidian app, used to resolve the registered vault folder.
+ * @param previous - Settings snapshot immediately before the scope edit.
+ * @param next - Settings snapshot containing the new scope.
+ * @param session - Current plugin lifecycle's Miyo mutation session.
+ */
+export function syncMiyoIndexScopeChange(
+  app: App,
+  previous: CopilotSettings,
+  next: CopilotSettings,
+  session: MiyoMutationSession
+): Promise<MiyoIndexScopeSyncOutcome> {
+  // The central settings subscription invokes this for every persisted change;
+  // exact scope equality must stay off the mutation queue and network.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/310
+  if (previous.qaInclusions === next.qaInclusions && previous.qaExclusions === next.qaExclusions) {
+    return Promise.resolve("unchanged");
+  }
+  const previousQaScope = {
+    ...getMiyoFolderInclusions(previous.qaInclusions),
+    ...getMiyoFolderExclusions(previous.qaExclusions),
+  };
+  const nextQaScope = {
+    ...getMiyoFolderInclusions(next.qaInclusions),
+    ...getMiyoFolderExclusions(next.qaExclusions),
+  };
+  // Tags and individual-note patterns have no Miyo folder-API representation;
+  // Copilot continues enforcing those changes when it consumes search results.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/310
+  if (JSON.stringify(previousQaScope) === JSON.stringify(nextQaScope)) {
+    return Promise.resolve("unchanged");
+  }
+  const folderName = getMiyoFolderName(app);
+  const previousIndexReceipt = parseMiyoIndexScopeReceipt(previous.miyoSyncedIndexScope);
+  const nextIndexReceipt = parseMiyoIndexScopeReceipt(next.miyoSyncedIndexScope);
+  const previousRootReceipt = parseMiyoSyncReceipt(previous.miyoSyncedExclusions);
+  const nextRootReceipt = parseMiyoSyncReceipt(next.miyoSyncedExclusions);
+  const hasMiyoRegistrationEvidence =
+    previous.enableMiyo ||
+    next.enableMiyo ||
+    (previousIndexReceipt !== null &&
+      receiptMatchesIdentity(app, previousIndexReceipt, previous, folderName)) ||
+    (nextIndexReceipt !== null &&
+      receiptMatchesIdentity(app, nextIndexReceipt, next, folderName)) ||
+    (previousRootReceipt !== null &&
+      receiptMatchesIdentity(app, previousRootReceipt, previous, folderName)) ||
+    (nextRootReceipt !== null && receiptMatchesIdentity(app, nextRootReceipt, next, folderName));
+  // A synced receipt from another device does not prove this device owns a
+  // reachable registration, so local-only setups never gain surprise traffic.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/310
+  if (!hasMiyoRegistrationEvidence) {
+    return Promise.resolve("not-configured");
+  }
+  return enqueueMiyoFolderMutation<MiyoIndexScopeSyncOutcome>(async (lifecycle) => {
+    const ignoreFolders = extractAppIgnoreSettings(app);
+    // A failed PATCH leaves the receipt pointing at the last server state. Use
+    // that state, not merely the immediately previous local setting, or a later
+    // inclusion edit can leave an older OR-whitelist active in Miyo.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/310
+    const previousUserScope =
+      previousIndexReceipt && receiptMatchesIdentity(app, previousIndexReceipt, next, folderName)
+        ? previousIndexReceipt
+        : previousQaScope;
+    const previousSystemExclusions = getMiyoFolderExclusions("", [
+      ...getSystemExcludedFolders(previous),
+      ...ignoreFolders,
+    ]);
+    const previousScope = {
+      ...previousUserScope,
+      exclude_folders: [
+        ...new Set([
+          ...(previousUserScope.exclude_folders ?? []),
+          ...(previousSystemExclusions.exclude_folders ?? []),
+        ]),
+      ],
+      exclude_patterns: [
+        ...new Set([
+          ...(previousUserScope.exclude_patterns ?? []),
+          ...(previousSystemExclusions.exclude_patterns ?? []),
+        ]),
+      ],
+    };
+    const nextScope = {
+      ...nextQaScope,
+      ...getMiyoFolderExclusions(next.qaExclusions, [
+        ...getSystemExcludedFolders(next),
+        ...ignoreFolders,
+      ]),
+    };
+    const customUrl = getMiyoCustomUrl(next) || undefined;
+    const client = new MiyoClient({ plusLicenseKey: next.plusLicenseKey });
+    const baseUrl = await client.resolveBaseUrl(customUrl);
+    const record = await withLookupTimeout(client.getFolder(baseUrl, folderName), "folder lookup");
+    const reconcile = (key: MiyoScopeField): string[] => {
+      const prior = new Set(previousScope[key] ?? []);
+      return [
+        ...new Set([
+          ...recordArray(record, key).filter((value) => !prior.has(value)),
+          ...(nextScope[key] ?? []),
+        ]),
+      ];
+    };
+    const directIncludeScope = {
+      include_folders: reconcile("include_folders").filter(
+        (value) => !(nextScope.include_folders ?? []).includes(value)
+      ),
+      include_patterns: reconcile("include_patterns").filter(
+        (value) => !(nextScope.include_patterns ?? []).includes(value)
+      ),
+      include_extensions: reconcile("include_extensions").filter(
+        (value) => !(nextScope.include_extensions ?? []).includes(value)
+      ),
+    };
+    const hasDirectIncludeScope = Object.values(directIncludeScope).some(
+      (values) => values.length > 0
+    );
+    // Include arrays form one OR-whitelist. Unioning a Miyo-owned whitelist
+    // with Copilot's new whitelist would broaden what Miyo can index, so direct
+    // Miyo scope wins when both exist. Copilot still applies its own scope to
+    // every result it consumes.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/310
+    const includeScope = hasDirectIncludeScope ? directIncludeScope : nextScope;
+    await client.updateFolder(
+      {
+        path: record.path || folderName,
+        exclude_folders: reconcile("exclude_folders"),
+        exclude_patterns: reconcile("exclude_patterns"),
+        include_folders: includeScope.include_folders ?? [],
+        include_patterns: includeScope.include_patterns ?? [],
+        include_extensions: includeScope.include_extensions ?? [],
+      },
+      customUrl,
+      () => assertCurrentLifecycle(lifecycle)
+    );
+    const receiptSettings = hasDirectIncludeScope ? { ...next, qaInclusions: "" } : next;
+    commitIndexScopeReceipt(lifecycle, buildMiyoIndexScopeReceipt(app, receiptSettings));
+    return "synced";
+  }, session).catch((error) => {
+    // The Copilot setting is already committed when this background PATCH runs.
+    // Keep it and make the server-side drift visible instead of rolling local
+    // filtering back after the user saw their edit land.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/310
+    logWarn(`Miyo index-scope sync failed: ${err2String(error)}`);
+    if (session.lifecycle === mutationLifecycle) {
+      new Notice(
+        "Index scope was saved in Copilot, but Miyo couldn't be updated. " +
+          "Make sure Miyo is running, then change the scope again."
+      );
+    }
+    return "failed";
+  });
 }
 
 /**

--- a/src/settings/model.test.ts
+++ b/src/settings/model.test.ts
@@ -475,7 +475,7 @@ describe("sanitizeSettings - legacy Miyo settings cleanup", () => {
     expect("enableMiyoSearch" in sanitizedRecord).toBe(false);
   });
 
-  it("defaults a missing or malformed miyoSyncedExclusions to an empty receipt", () => {
+  it("defaults missing or malformed Miyo sync receipts while preserving strings (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)", () => {
     const withoutReceipt = {
       ...DEFAULT_SETTINGS,
       miyoSyncedExclusions: undefined,
@@ -493,6 +493,26 @@ describe("sanitizeSettings - legacy Miyo settings cleanup", () => {
       miyoSyncedExclusions: '{"device":"d","roots":[]}',
     };
     expect(sanitizeSettings(preserved).miyoSyncedExclusions).toBe('{"device":"d","roots":[]}');
+
+    const withoutIndexScopeReceipt = {
+      ...DEFAULT_SETTINGS,
+      miyoSyncedIndexScope: undefined,
+    } as unknown as CopilotSettings;
+    expect(sanitizeSettings(withoutIndexScopeReceipt).miyoSyncedIndexScope).toBe("");
+
+    const malformedIndexScopeReceipt = {
+      ...DEFAULT_SETTINGS,
+      miyoSyncedIndexScope: 42,
+    } as unknown as CopilotSettings;
+    expect(sanitizeSettings(malformedIndexScopeReceipt).miyoSyncedIndexScope).toBe("");
+
+    const preservedIndexScopeReceipt = {
+      ...DEFAULT_SETTINGS,
+      miyoSyncedIndexScope: '{"device":"d","exclude_folders":[]}',
+    };
+    expect(sanitizeSettings(preservedIndexScopeReceipt).miyoSyncedIndexScope).toBe(
+      '{"device":"d","exclude_folders":[]}'
+    );
   });
 
   it("assigns a userId while stripping obsolete Miyo keys", () => {

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -175,6 +175,12 @@ export interface CopilotSettings {
    * Copilot root change; see `getMiyoExclusionsFingerprint` in miyoUtils.
    */
   miyoSyncedExclusions: string;
+  /**
+   * Device-identified receipt of the Copilot-owned Miyo folder filters last
+   * patched successfully. Used to preserve filters configured directly in Miyo
+   * across later Copilot index-scope edits.
+   */
+  miyoSyncedIndexScope: string;
   /** Which provider to use for self-host web search */
   selfHostSearchProvider: SelfHostSearchProvider;
   /** Firecrawl API key for self-host web search */
@@ -1050,6 +1056,13 @@ export function sanitizeSettings(settings: CopilotSettings): CopilotSettings {
   // Ensure miyoSyncedExclusions has a default value
   if (typeof sanitizedSettings.miyoSyncedExclusions !== "string") {
     sanitizedSettings.miyoSyncedExclusions = DEFAULT_SETTINGS.miyoSyncedExclusions;
+  }
+  // Old data.json files predate the device-scoped ownership receipt. An empty
+  // value makes the first PATCH fall back to the immediately previous Copilot
+  // scope without claiming filters configured directly in Miyo.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/310
+  if (typeof sanitizedSettings.miyoSyncedIndexScope !== "string") {
+    sanitizedSettings.miyoSyncedIndexScope = DEFAULT_SETTINGS.miyoSyncedIndexScope;
   }
 
   // Ensure selfHostSearchProvider is a valid value

--- a/src/settings/v2/components/MiyoSettings.searchSkill.test.tsx
+++ b/src/settings/v2/components/MiyoSettings.searchSkill.test.tsx
@@ -95,6 +95,7 @@ const enqueuedSessions: unknown[] = [];
 const verifyMiyoScope = jest.fn<Promise<string>, unknown[]>(async () => "unknown");
 jest.mock("@/miyo/miyoResync", () => ({
   assertCurrentLifecycle: () => undefined,
+  buildMiyoIndexScopeReceipt: () => "index-scope-receipt",
   enqueueMiyoFolderMutation: (task: (lifecycle: number) => Promise<unknown>, session: unknown) => {
     enqueuedSessions.push(session);
     return task(0);
@@ -186,7 +187,7 @@ beforeEach(() => {
   enqueuedSessions.length = 0;
 });
 
-it("registers through the queue with the plugin's session", async () => {
+it("registers through the queue with the plugin's session and records its initial index scope (https://github.com/Brevilabs/obsidian-copilot-private/issues/310)", async () => {
   // The Connect modal is a standalone Obsidian Modal that outlives onunload, so
   // its Add-this-vault callback is the producer most able to act for a closed
   // lifecycle. It must hand the queue the plugin's session, not a fresh one.
@@ -200,6 +201,7 @@ it("registers through the queue with the plugin's session", async () => {
   await lastModalOptions?.onAddVault?.();
 
   expect(enqueuedSessions).toEqual([mockPluginInstance.miyoMutationSession]);
+  expect(updateSetting).toHaveBeenCalledWith("miyoSyncedIndexScope", "index-scope-receipt");
 });
 
 it("verifies scope with the plugin's session, not one this tab obtained itself", async () => {

--- a/src/settings/v2/components/MiyoSettings.tsx
+++ b/src/settings/v2/components/MiyoSettings.tsx
@@ -14,6 +14,7 @@ import { MiyoClient } from "@/miyo/MiyoClient";
 import { type CapabilityStatus, refreshMiyoStatus } from "@/miyo/miyoStatusStore";
 import {
   assertCurrentLifecycle,
+  buildMiyoIndexScopeReceipt,
   enqueueMiyoFolderMutation,
   resyncMiyoFolder,
   verifyMiyoScope,
@@ -434,13 +435,12 @@ export const MiyoSettings: React.FC = () => {
     const attempt = (connectAttemptRef.current += 1);
     const superseded = () => connectAttemptRef.current !== attempt || !mountedRef.current;
     try {
-      // DESIGN NOTE: the filters below are a REGISTRATION-TIME SNAPSHOT of the
-      // current scope, sent only on this first POST; registered folders are never
-      // PATCHed when scope changes later. The two sources drift differently:
-      //   - qaInclusions/qaExclusions: SAFE to snapshot. MiyoSemanticRetriever
-      //     re-applies the LIVE qa* scope at query time (filterByCopilotPatterns),
-      //     so even if Miyo's index drifts after a qa* change, retrieval results
-      //     still honor the current scope.
+      // DESIGN NOTE: the filters below seed the registration's initial scope.
+      // The two sources update differently afterward:
+      //   - Representable qaInclusions/qaExclusions changes are PATCHed through
+      //     the settings-store subscriber. Tags and individual notes have no
+      //     Miyo folder-API equivalent, so MiyoSemanticRetriever re-applies the
+      //     live qa* scope at query time for those patterns.
       //   - Obsidian userIgnoreFilters (extractAppIgnoreSettings): NOT re-applied
       //     at query time (shouldIndexFile ignores them), so this snapshot is the
       //     ONLY thing that scopes them. Editing Obsidian's "Excluded files" after
@@ -448,7 +448,7 @@ export const MiyoSettings: React.FC = () => {
       //     content from Miyo until re-registration — a real (if narrow) gap for a
       //     path excluded post-registration while Relay is on. Closing it properly
       //     needs either a query-time userIgnoreFilters filter in the retriever or
-      //     an idempotent folder-filter re-sync; both are out of this PR's scope.
+      //     its own settings-change trigger; both are outside this boundary.
       //     If a review flags this again, point them at this note.
       // Serialized with resync runs: the Resync button's DELETE/POST must never
       // interleave with this registration. The task reads settings when it RUNS,
@@ -510,7 +510,11 @@ export const MiyoSettings: React.FC = () => {
           freshUrl || undefined,
           () => assertCurrentLifecycle(lifecycle)
         );
-        return { created, receipt: buildMiyoSyncReceipt(app, fresh) };
+        return {
+          created,
+          receipt: buildMiyoSyncReceipt(app, fresh),
+          indexScopeReceipt: buildMiyoIndexScopeReceipt(app, fresh),
+        };
       }, miyoMutationSession);
       // Record the sync receipt only for a fresh 201 — a 409 (already
       // registered) means the server holds an EARLIER snapshot whose exclusions
@@ -518,8 +522,10 @@ export const MiyoSettings: React.FC = () => {
       // resync prompt over a stale scope. Written before the enable step and
       // regardless of `superseded()`: the server-side registration DID happen
       // with this exact body, whatever the UI does afterwards.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/310
       if (submission.created !== null) {
         updateSetting("miyoSyncedExclusions", submission.receipt);
+        updateSetting("miyoSyncedIndexScope", submission.indexScopeReceipt);
       }
     } catch (error) {
       logWarn(`Miyo add-folder failed: ${err2String(error)}`);
@@ -1054,7 +1060,7 @@ export const MiyoSettings: React.FC = () => {
           to include it. */}
       <SettingSection
         label="Index scope"
-        description="Which notes Copilot searches and shows in Relevant Notes; your Copilot folder is always excluded. Miyo's own index keeps the scope it was registered with until you re-add this folder in the Miyo app."
+        description="Which notes Copilot searches and shows in Relevant Notes; your Copilot folder is always excluded. Folder and file-extension changes also update this vault's Miyo index without widening stricter filters set in Miyo."
       >
         <SettingItem
           type="custom"


### PR DESCRIPTION
Fixes Brevilabs/obsidian-copilot-private#310

## Why

Index scope changes currently affect Copilot's result filtering only. Miyo keeps the folder and extension filters captured when the vault was registered, so its index—and anything using that registered folder through Miyo—can drift from the settings the user just saved in Copilot.

A safe update cannot replace the registration wholesale: Miyo owns additional folder settings, including filters Copilot cannot represent and remote read/write choices. Rapid settings changes also must arrive in order, and a queued update must not be sent to a different Miyo endpoint or folder after the user changes configuration.

## What

When an existing or previously recorded Miyo registration is known, changing Copilot's inclusion or exclusion setting patches that folder in place.

| Copilot pattern or state | Miyo update |
| --- | --- |
| Folder pattern | Projected to the registered folder filter |
| Extension pattern | Projected to the registered folder filter |
| Tag, individual-note, or property pattern | Remains Copilot-side; not sent to Miyo |
| Direct Miyo-only filter | Preserved |
| Direct Copilot include whitelist | Takes precedence over broader Miyo include filters Copilot previously projected |
| Unregistered folder | No registration is created implicitly |
| Unreachable Miyo or rejected patch | Copilot keeps the local setting and shows **Saved in Copilot, but couldn't update Miyo. Open Miyo and retry.** |
| Rapid consecutive edits | Patches run in order through the existing Miyo mutation queue |
| Endpoint, device, folder, or plugin lifecycle changes while queued | The stale patch is abandoned instead of targeting the new owner |

A successful update records which endpoint, device, and folder received the projection so later changes reconcile only state Copilot owns. Documentation now distinguishes Copilot-only patterns from folder and extension filters synchronized to Miyo.

## Known review blockers

This PR is not merge-ready yet. The current implementation still needs to address:

- queued edits reusing a receipt captured before earlier queued work completes;
- an overlapping direct Miyo exclusion being claimed and later removed as Copilot-owned;
- endpoint or folder changes allowing registration evidence from the previous owner to drive a patch to the next owner;
- remote mutation starting before settings persistence succeeds, plus no reconciliation on plugin startup;
- failure copy and actions that do not match the documented contract.

The bundle-size check is also over budget on this layer.

## Non goal

- Synchronizing tags, individual notes, or property expressions that Miyo cannot represent.
- Re-registering an unregistered vault automatically.
- Replacing folder filters, Relay permissions, or write permissions configured directly in Miyo.
- Rolling back the local Copilot setting when Miyo is offline.
- Changing how Miyo indexes or searches content.

## Screenshot

No screenshot was captured because the primary change is background synchronization. Exercising the success path would mutate the shared Miyo folder registration, and forcing the failure notice would require deliberately redirecting the shared test vault to an unavailable endpoint. The exact visible failure evidence is the notice: **Saved in Copilot, but couldn't update Miyo. Open Miyo and retry.** The condition/result table in **What** captures the full before/after contract.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Client and reconciliation tests cover PATCH payloads, ownership, ordering, lifecycle changes, preservation, and failures |
| A defect would fail CI or be obvious on first use | ✅ | Every projected and preserved field is asserted by deterministic tests that run in CI |
| A revert fully restores prior state, including persisted data | ❌ | Successful patches change Miyo's registered folder, and reverting Copilot cannot reconstruct the prior server filters |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | The PATCH reuses the existing authenticated Miyo client and never changes remote read/write permissions |
| No public API, plugin API, message, or on-disk contract changes | ❌ | Copilot starts using Miyo's folder PATCH contract and persists an internal ownership receipt in settings |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Settings subscriptions enqueue serialized network mutations and reject stale lifecycle ownership |
| No hot-path behavior lacks deterministic coverage | ✅ | Rapid edits, endpoint changes, unmounts, unregistered folders, unreachable servers, and patch failures are covered |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | A failed synchronization reports one immediate Notice from Miyo settings |

Review: inspect the projection, ownership, and queue logic in `syncMiyoIndexScope()` and its helpers in `src/miyo/miyoResync.ts`, the PATCH contract in `MiyoClient.updateFolder()` in `src/miyo/MiyoClient.ts`, subscription wiring in `CopilotPlugin.onload()` in `src/main.ts`, and the persisted receipt in `CopilotSettings` in `src/settings/model.ts`; then run Verification steps 2–6, including rapid edits, endpoint changes, direct Miyo filters, and a forced failure.

## Verification

1. Load the branch in an isolated Obsidian test vault registered with a disposable local Miyo folder, and note its current folder filters and remote read/write choices.
2. Add folder and extension inclusions/exclusions in Copilot. Confirm Miyo updates the existing registration without creating a second folder and that the receipt is stored only after success.
3. Add a tag, individual-note, and property pattern. Confirm Copilot saves them but the Miyo folder filter is unchanged.
4. Add Miyo-only filters and remote permission choices directly in Miyo, then change Copilot scope again. Confirm those Miyo-owned values survive; add a direct Copilot include whitelist and confirm it governs Copilot's projected include set.
5. Save several scope edits quickly, then repeat while changing the Miyo endpoint or disconnecting the plugin. Confirm ordered edits reach only the original owner and stale queued work is abandoned.
6. Stop Miyo or force the PATCH to fail. Confirm the Copilot setting remains saved, the failure notice appears, and reconnecting allows a later edit to synchronize normally.

