### PR TITLE
Keep focused Agent Chat quiet without changing attention dots

### DIFF
--- a/src/agentMode/session/AgentSessionManager.test.ts
+++ b/src/agentMode/session/AgentSessionManager.test.ts
@@ -248,7 +248,13 @@ const sessionCreateSpy = jest.spyOn(AgentSession, "start").mockImplementation((o
   })
 );
 
-type MockAgentChatFocus = "none" | "inside" | "outside" | "other-leaf" | "unfocused-window";
+type MockAgentChatFocus =
+  | "none"
+  | "inside"
+  | "inside-sidebar"
+  | "outside"
+  | "other-leaf"
+  | "unfocused-window";
 let mockAgentChatFocus: MockAgentChatFocus = "none";
 
 function buildWorkspace(): unknown {
@@ -257,21 +263,37 @@ function buildWorkspace(): unknown {
   const ownerDocument = {
     hasFocus: () => mockAgentChatFocus !== "unfocused-window",
     get activeElement() {
-      return mockAgentChatFocus === "outside" ? outside : inside;
+      return ["inside", "inside-sidebar", "unfocused-window"].includes(mockAgentChatFocus)
+        ? inside
+        : outside;
     },
   } as Document;
   const containerEl = {
+    doc: ownerDocument,
     ownerDocument,
     contains: (element: Element | null) => element === inside,
   } as HTMLElement;
-  const leaf = {
+  const chatLeaf = {
     view: {
       containerEl,
-      getViewType: () => (mockAgentChatFocus === "other-leaf" ? "markdown" : CHAT_AGENT_VIEWTYPE),
+      getViewType: () => CHAT_AGENT_VIEWTYPE,
+    },
+  };
+  const otherLeaf = {
+    view: {
+      containerEl: { ownerDocument } as HTMLElement,
+      getViewType: () => "markdown",
     },
   };
   return {
-    getMostRecentLeaf: jest.fn(() => (mockAgentChatFocus === "none" ? null : leaf)),
+    getMostRecentLeaf: jest.fn(() => {
+      if (mockAgentChatFocus === "none") return null;
+      if (["inside-sidebar", "other-leaf"].includes(mockAgentChatFocus)) return otherLeaf;
+      return chatLeaf;
+    }),
+    getLeavesOfType: jest.fn((viewType: string) =>
+      viewType === CHAT_AGENT_VIEWTYPE ? [chatLeaf] : []
+    ),
   };
 }
 
@@ -1138,18 +1160,24 @@ describe("AgentSessionManager attention tracking", () => {
     expect(playNotificationSound).toHaveBeenCalledTimes(1);
   });
 
-  it("stays silent when focus is inside the active Agent Chat (https://github.com/logancyang/obsidian-copilot/issues/2987)", async () => {
-    mockAgentChatFocus = "inside";
-    const mgr = buildManager();
-    const session = await mgr.createSession();
-    const handle = getSessionTestHandle(session);
+  it.each([
+    ["the most recent Agent Chat", "inside"],
+    ["a sidebar Agent Chat whose leaf is not most recent", "inside-sidebar"],
+  ] as const)(
+    "stays silent when focus is inside %s (https://github.com/logancyang/obsidian-copilot/issues/2987)",
+    async (_label, focus) => {
+      mockAgentChatFocus = focus;
+      const mgr = buildManager();
+      const session = await mgr.createSession();
+      const handle = getSessionTestHandle(session);
 
-    handle.setStatus("running");
-    handle.setStatus("idle");
+      handle.setStatus("running");
+      handle.setStatus("idle");
 
-    expect(playNotificationSound).not.toHaveBeenCalled();
-    expect(session.getNeedsAttention()).toBe(false);
-  });
+      expect(playNotificationSound).not.toHaveBeenCalled();
+      expect(session.getNeedsAttention()).toBe(false);
+    }
+  );
 
   it.each([
     ["a modal outside the chat has focus", "outside"],

--- a/src/agentMode/session/AgentSessionManager.test.ts
+++ b/src/agentMode/session/AgentSessionManager.test.ts
@@ -1138,14 +1138,14 @@ describe("AgentSessionManager attention tracking", () => {
     expect(b.getNeedsAttention()).toBe(true);
   });
 
-  it("flags the active session when its chat is not focused (https://github.com/logancyang/obsidian-copilot/issues/2987)", async () => {
+  it("does not flag the active session even when its chat is not focused (https://github.com/logancyang/obsidian-copilot/issues/2987)", async () => {
     const mgr = buildManager();
     const a = await mgr.createSession();
     expect(mgr.getActiveSession()).toBe(a);
     const aHandle = getSessionTestHandle(a);
     aHandle.setStatus("running");
     aHandle.setStatus("idle");
-    expect(a.getNeedsAttention()).toBe(true);
+    expect(a.getNeedsAttention()).toBe(false);
   });
 
   it("chimes when a turn ends (https://github.com/logancyang/obsidian-copilot/issues/2987)", async () => {
@@ -1195,7 +1195,7 @@ describe("AgentSessionManager attention tracking", () => {
       handle.setStatus("idle");
 
       expect(playNotificationSound).toHaveBeenCalledWith("piano");
-      expect(session.getNeedsAttention()).toBe(true);
+      expect(session.getNeedsAttention()).toBe(false);
     }
   );
 
@@ -1208,7 +1208,7 @@ describe("AgentSessionManager attention tracking", () => {
     aHandle.setStatus("awaiting_permission");
 
     expect(playNotificationSound).toHaveBeenCalledTimes(1);
-    expect(a.getNeedsAttention()).toBe(true);
+    expect(a.getNeedsAttention()).toBe(false);
   });
 
   it("stays silent when the focused Agent Chat starts awaiting permission (https://github.com/logancyang/obsidian-copilot/issues/2987)", async () => {
@@ -1243,13 +1243,15 @@ describe("AgentSessionManager attention tracking", () => {
     mockNotificationSound = false;
     const mgr = buildManager();
     const a = await mgr.createSession();
-    const aHandle = getSessionTestHandle(a);
+    const b = await mgr.createSession();
+    mgr.setActiveSession(a.internalId);
+    const bHandle = getSessionTestHandle(b);
 
-    aHandle.setStatus("running");
-    aHandle.setStatus("idle");
+    bHandle.setStatus("running");
+    bHandle.setStatus("idle");
 
     expect(playNotificationSound).not.toHaveBeenCalled();
-    expect(a.getNeedsAttention()).toBe(true);
+    expect(b.getNeedsAttention()).toBe(true);
   });
 
   it("stays silent on the starting → idle transition of a fresh session (https://github.com/logancyang/obsidian-copilot/issues/2987)", async () => {
@@ -1273,19 +1275,6 @@ describe("AgentSessionManager attention tracking", () => {
     bHandle.setStatus("starting");
     bHandle.setStatus("idle");
     expect(b.getNeedsAttention()).toBe(false);
-  });
-
-  it("clears an unfocused active session's flag when the user clicks its tab (https://github.com/logancyang/obsidian-copilot/issues/2987)", async () => {
-    const mgr = buildManager();
-    const session = await mgr.createSession();
-    const handle = getSessionTestHandle(session);
-    handle.setStatus("running");
-    handle.setStatus("idle");
-    expect(session.getNeedsAttention()).toBe(true);
-
-    mgr.setActiveSession(session.internalId);
-
-    expect(session.getNeedsAttention()).toBe(false);
   });
 
   it("clears the flag when the user activates the tab", async () => {
@@ -1436,8 +1425,7 @@ describe("AgentSessionManager.getAttentionChatIds", () => {
     expect(mgr.getAttentionChatIds().has(nativeId)).toBe(true);
   });
 
-  it("does not include the focused active session (https://github.com/logancyang/obsidian-copilot/issues/2987)", async () => {
-    mockAgentChatFocus = "inside";
+  it("does not include the active session even when its chat is not focused (https://github.com/logancyang/obsidian-copilot/issues/2987)", async () => {
     const mgr = buildManager();
     const a = await mgr.createSession();
     const aHandle = getSessionTestHandle(a);

--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -2480,9 +2480,6 @@ export class AgentSessionManager {
   setActiveSession(id: string): void {
     const session = this.sessions.get(id);
     if (!session) return;
-    // An active session can be marked while its chat lacks focus, so clicking
-    // that same tab must still acknowledge it. https://github.com/logancyang/obsidian-copilot/issues/2987
-    session.clearNeedsAttention();
     if (this.activeSessionId === id) return;
     if (session.projectId !== this.activeProjectId) {
       this.parkActiveScope();
@@ -2493,6 +2490,7 @@ export class AgentSessionManager {
     this.detachedFromTabIds.delete(id);
     this.activeSessionId = id;
     this.lastActiveByScope.set(session.projectId, id);
+    session.clearNeedsAttention();
     this.notify();
   }
 
@@ -3358,7 +3356,7 @@ export class AgentSessionManager {
   /**
    * Watch this session's status transitions out of `running` into a state
    * that demands the user's eye (turn ended, errored, or paused for
-   * permission) and raise the two attention signals.
+   * permission) and raise the applicable attention signals.
    */
   private attachAttentionTracking(session: AgentSession): void {
     let prev = session.getStatus();
@@ -3394,12 +3392,14 @@ export class AgentSessionManager {
     });
   }
 
-  /** Raise the visual and audible attention signals from one shared focus decision. */
+  /** Raise visual attention for background tabs and audible attention outside the active chat. */
   private signalSessionNeedsAttention(session: AgentSession): void {
-    // Focus inside this exact chat is the only reliable proof that neither
-    // signal is needed. https://github.com/logancyang/obsidian-copilot/issues/2987
+    // The dot identifies a different Agent tab that wants the user; keyboard
+    // focus does not change which tab is selected. https://github.com/logancyang/obsidian-copilot/issues/2987
+    if (this.activeSessionId !== session.internalId) session.markNeedsAttention();
+    // Sound follows real focus so a selected but unattended chat can still
+    // call the user back. https://github.com/logancyang/obsidian-copilot/issues/2987
     if (this.isSessionFocused(session)) return;
-    session.markNeedsAttention();
     this.playConfiguredNotificationSound();
   }
 

--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -3384,13 +3384,14 @@ export class AgentSessionManager {
   /** Whether keyboard focus is currently inside this session's active Agent Chat leaf. */
   private isSessionFocused(session: AgentSession): boolean {
     if (this.activeSessionId !== session.internalId) return false;
-    const leaf = this.app.workspace.getMostRecentLeaf();
-    if (leaf?.view.getViewType() !== CHAT_AGENT_VIEWTYPE) return false;
-    const container = leaf.view.containerEl;
-    const doc = container.ownerDocument;
-    if (!doc.hasFocus()) return false;
-    const activeElement = doc.activeElement;
-    return activeElement !== null && container.contains(activeElement);
+    // A sidebar input can own keyboard focus while Obsidian keeps the center
+    // editor as its most recent leaf. https://github.com/logancyang/obsidian-copilot/issues/2987
+    return this.app.workspace.getLeavesOfType(CHAT_AGENT_VIEWTYPE).some((leaf) => {
+      const container = leaf.view.containerEl;
+      const doc = container.doc;
+      const activeElement = doc.activeElement;
+      return doc.hasFocus() && activeElement !== null && container.contains(activeElement);
+    });
   }
 
   /** Raise the visual and audible attention signals from one shared focus decision. */


### PR DESCRIPTION
Relates to #2987

## Why

When Agent Chat sits in the sidebar, its input can own keyboard focus while Obsidian still treats the center pane as the most recent leaf. A finished turn then plays a sound even though the user is already in that chat.

The selected Agent tab can also receive an attention dot whenever focus is elsewhere. Before notification sounds were added, the dot only identified a different Agent tab that had finished and needed a look.

## What

| Condition when the turn stops | Before | After |
| --- | --- | --- |
| Selected sidebar Agent Chat, focus inside its input | Dot and sound | No dot or sound |
| Selected Agent Chat, focus elsewhere | Dot and sound | Sound only |
| Different Agent tab is selected | Dot and sound | Dot and sound |
| Different Agent tab is selected, sound setting off | Dot only | Dot only |

## Non goal

No changes to which turn states trigger alerts, event-specific sounds, custom sound files, operating-system notifications or badges, non-agent chat alerts, or volume controls.

## Screenshot

Not included because the layout is unchanged, and a static image cannot demonstrate which element owns keyboard focus or whether audio played. The dot and sound combinations are covered by the table above and the verification path below.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Manager tests independently cover dot selection and sound focus behavior |
| A defect would fail CI or be obvious on first use | ✅ | Manager tests assert every dot and sound combination in the table |
| A revert fully restores prior state, including persisted data | ✅ | The change writes no persisted data |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Only notification classification changes |
| No public API, plugin API, message, or on-disk contract changes | ✅ | The change stays inside the manager's existing attention decisions |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Existing status transitions are unchanged |
| No hot-path behavior lacks deterministic coverage | ✅ | Focused, selected-unfocused, background, and muted paths run through deterministic manager tests |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | A wrong result appears on the next Agent Chat completion |

Review: run Verification steps 2–6 and confirm CI is green.

## Verification

1. Deploy the branch to a non-production vault with `npm run test:vault`, then enable **Notification sound** in Agent settings.
2. Open Agent Chat in the right sidebar with a note or another leaf open in the center pane.
3. Start a turn in an existing Agent Chat and keep the cursor in its input until the reply finishes; expect no attention dot and no sound.
4. Start another turn, move focus to the center pane before it finishes, and keep the same Agent tab selected; expect no attention dot and one notification sound.
5. Start another turn and switch to a different Agent tab before it finishes; expect an attention dot on the background tab and one notification sound.
6. Turn off **Notification sound** and repeat step 5; expect the background-tab dot without a sound.
