### PR TITLE
Give Agent Home more room and pin overflow controls

### DIFF
--- a/src/agentMode/ui/AgentContextSection.tsx
+++ b/src/agentMode/ui/AgentContextSection.tsx
@@ -1,4 +1,3 @@
-import { SHELF_BODY_FLOOR_CLASS } from "@/agentMode/ui/AgentHomeShelf";
 import type { ProjectConfig } from "@/aiParams";
 import { ContextManageModal } from "@/components/modals/project/context-manage-modal";
 import { buildBadgeItems } from "@/components/project/ProjectContextBadgeList";
@@ -90,9 +89,8 @@ export function buildContextSummary(project: ProjectConfig | undefined): Context
  * height floor on the SAME element: that marker tells the chat container's
  * draft-attach handler (useChatFileDrop) to yield while a drag hovers this body,
  * so a taller wrapper would leave a dead strip where drops fall through to the
- * draft. The floor is the shelf panel's SHELF_BODY_FLOOR_CLASS (imported, not
- * hand-copied) and also covers this section's standalone (no-shelf) rendering;
- * `tw-grow` on the editor fills that floor.
+ * draft. The floor covers this section's standalone (no-shelf) rendering;
+ * inside a shelf, `tw-grow` lets the editor fill the shared shelf viewport.
  */
 export default function AgentContextSection({
   app,
@@ -179,7 +177,7 @@ export default function AgentContextSection({
     <div
       ref={sectionRef}
       data-copilot-drop-zone
-      className={cn(SHELF_BODY_FLOOR_CLASS, "tw-flex tw-grow tw-flex-col tw-p-2")}
+      className={cn("tw-flex tw-min-h-48 tw-grow tw-flex-col tw-p-2")}
     >
       <ProjectContextSourceEditor
         contextSource={draft}
@@ -187,7 +185,7 @@ export default function AgentContextSection({
         onManage={handleManage}
         popoverContainer={popoverContainer}
         isDragging={isDragging}
-        // Fill the shelf floor; the editor's own max-height caps it so a long
+        // Fill the available body; the editor's own max-height caps it so a long
         // context scrolls inside the box instead of taking over the whole tab.
         className="tw-grow"
       />

--- a/src/agentMode/ui/AgentHome.tsx
+++ b/src/agentMode/ui/AgentHome.tsx
@@ -766,7 +766,7 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
   const heroText = showProjectHero ? `Chat in ${projectName}` : greeting;
   const hero = (
     <div className="tw-flex tw-min-w-0 tw-items-center tw-justify-center tw-gap-3">
-      <CopilotBrandIcon className="tw-size-4 tw-shrink-0 tw-text-normal" />
+      <CopilotBrandIcon className="tw-size-6 tw-shrink-0 tw-text-normal" />
       {/* font-[330]: deliberate hero weight, a hair lighter than `font-normal`
           (400) for the airy greeting. The project's named weight tokens have no
           slot between light and normal, so this is an intentional one-off. (The
@@ -777,7 +777,7 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
           full-text tooltip while a short title keeps the icon+text pair
           centered — flex-1 would stretch the text box and break the centering. */}
       <TruncatedText
-        className="tw-min-w-0 tw-text-ui-title tw-font-[330] tw-text-normal"
+        className="tw-min-w-0 tw-text-3xl tw-font-[330] tw-text-normal"
         tooltipContent={heroText}
       >
         {heroText}
@@ -868,7 +868,7 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
                   composer still being mounted (see runSend's finally). */}
               <div
                 className={
-                  // Landing: overflow-y-auto, not hidden — the h-1/4 spacer +
+                  // Landing: overflow-y-auto, not hidden — the fixed spacer +
                   // flex-1 shelf fill the column exactly when there's room, and on
                   // a pane too short to fit the stack the column scrolls instead of
                   // clipping it out of reach. Conversation: the transcript owns its

--- a/src/agentMode/ui/AgentHomeSection.test.tsx
+++ b/src/agentMode/ui/AgentHomeSection.test.tsx
@@ -1,0 +1,47 @@
+import { AgentHomePreviewList, AgentHomeViewAllTrigger } from "@/agentMode/ui/AgentHomeSection";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+describe("AgentHomeSection", () => {
+  describe("AgentHomePreviewList()", () => {
+    it("shows the shared footer only when rows exceed the available height or preview limit (https://github.com/Brevilabs/obsidian-copilot-private/issues/169)", () => {
+      const renderPreview = (hasMoreItems: boolean) => (
+        <AgentHomePreviewList hasMoreItems={hasMoreItems} viewAll={<div>View all items</div>}>
+          <div>Preview rows</div>
+        </AgentHomePreviewList>
+      );
+      const { container, rerender } = render(renderPreview(false));
+      const viewport = container.querySelector<HTMLElement>("[data-radix-scroll-area-viewport]");
+      expect(viewport).not.toBeNull();
+      expect(screen.queryByText("View all items")).toBeNull();
+
+      Object.defineProperties(viewport, {
+        clientHeight: { configurable: true, value: 200 },
+        scrollHeight: { configurable: true, value: 300 },
+      });
+      rerender(renderPreview(false));
+      expect(screen.getByText("View all items")).toBeTruthy();
+
+      Object.defineProperty(viewport, "scrollHeight", { configurable: true, value: 180 });
+      rerender(renderPreview(false));
+      expect(screen.queryByText("View all items")).toBeNull();
+
+      rerender(renderPreview(true));
+      expect(screen.getByText("View all items")).toBeTruthy();
+    });
+  });
+
+  describe("AgentHomeViewAllTrigger()", () => {
+    it("uses the shared full-width style and activates from Enter or Space", () => {
+      const onClick = jest.fn();
+      render(<AgentHomeViewAllTrigger label="items" onClick={onClick} />);
+      const trigger = screen.getByRole("button", { name: "View all items" });
+
+      expect(trigger.classList.contains("tw-justify-between")).toBe(true);
+      expect(trigger.classList.contains("tw-text-accent")).toBe(true);
+      fireEvent.keyDown(trigger, { key: "Enter" });
+      fireEvent.keyDown(trigger, { key: " " });
+      expect(onClick).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/agentMode/ui/AgentHomeSection.tsx
+++ b/src/agentMode/ui/AgentHomeSection.tsx
@@ -31,7 +31,7 @@ import React, {
  * what keeps switching tabs from jumping (the shelf floor only covers the
  * short/empty end; see AgentHomeShelf.SHELF_BODY_FLOOR_CLASS).
  */
-export const INLINE_LIMIT = 5;
+export const INLINE_LIMIT = 10;
 
 /**
  * Rows rendered per page in the View-all popover. The list grows by this much

--- a/src/agentMode/ui/AgentHomeSection.tsx
+++ b/src/agentMode/ui/AgentHomeSection.tsx
@@ -25,10 +25,9 @@ import React, {
  */
 
 /**
- * Rows shown inline before the rest collapse behind the "View all" popover.
- * Shared by the Projects and Recent Chats shelf tabs so both preview the same
- * number of rows. AgentHomeShelf owns the shared body viewport, so every tab
- * follows the same height and scrolling contract.
+ * Maximum rows offered to the inline preview before the rest move behind the
+ * "View all" popover. The shared preview viewport can show the trigger sooner
+ * when section chrome leaves room for fewer rows.
  */
 export const INLINE_LIMIT = 10;
 
@@ -199,6 +198,110 @@ interface AgentHomeViewAllProps<TItem> {
   renderRow: (item: TItem, close: () => void) => React.ReactNode;
 }
 
+interface AgentHomePreviewListProps {
+  children: React.ReactNode;
+  /** True when the caller omitted items from the rendered preview. */
+  hasMoreItems: boolean;
+  /** Shared footer affordance. Omit while the inline list is in search mode. */
+  viewAll?: React.ReactNode;
+}
+
+const OVERFLOW_TOLERANCE_PX = 1;
+
+/**
+ * Shared bounded list region for Agent Home previews. It keeps the View-all
+ * affordance at the bottom and shows it only when rendered or omitted rows do
+ * not fit in the shelf.
+ */
+export function AgentHomePreviewList({
+  children,
+  hasMoreItems,
+  viewAll,
+}: AgentHomePreviewListProps): React.ReactElement {
+  const scrollRootRef = useRef<HTMLDivElement>(null);
+  const footerRef = useRef<HTMLDivElement>(null);
+  const [contentOverflows, setContentOverflows] = useState(false);
+  const showViewAll = viewAll != null && (hasMoreItems || contentOverflows);
+
+  const measure = useCallback(() => {
+    const root = scrollRootRef.current;
+    const viewport = root?.querySelector<HTMLElement>("[data-radix-scroll-area-viewport]");
+    if (!viewport) return;
+
+    // A visible footer reduces the viewport. Add its height back so the result
+    // answers whether the rows fit without the footer and cannot get stuck in
+    // an overflow state after content shrinks.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/169
+    const availableHeight =
+      viewport.clientHeight + (showViewAll ? (footerRef.current?.clientHeight ?? 0) : 0);
+    const nextOverflows = viewport.scrollHeight > availableHeight + OVERFLOW_TOLERANCE_PX;
+    setContentOverflows((current) => (current === nextOverflows ? current : nextOverflows));
+  }, [showViewAll]);
+
+  useLayoutEffect(measure);
+
+  useEffect(() => {
+    const root = scrollRootRef.current;
+    const viewport = root?.querySelector<HTMLElement>("[data-radix-scroll-area-viewport]");
+    const ResizeObserverConstructor = root?.ownerDocument.defaultView?.ResizeObserver;
+    if (!root || !viewport || !ResizeObserverConstructor) return;
+
+    const observer = new ResizeObserverConstructor(measure);
+    observer.observe(root);
+    observer.observe(viewport);
+    const content = viewport.firstElementChild;
+    if (content) observer.observe(content);
+    return () => observer.disconnect();
+  }, [measure]);
+
+  return (
+    <div className="tw-flex tw-min-h-0 tw-flex-1 tw-flex-col tw-divide-y tw-divide-border">
+      <ScrollArea ref={scrollRootRef} className="tw-min-h-0 tw-flex-1 tw-overflow-y-auto">
+        {children}
+      </ScrollArea>
+      {showViewAll && (
+        <div ref={footerRef} className="tw-shrink-0">
+          {viewAll}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface AgentHomeViewAllTriggerProps extends React.HTMLAttributes<HTMLDivElement> {
+  label: string;
+}
+
+/** Shared full-width trigger used by every Agent Home View-all footer. */
+export const AgentHomeViewAllTrigger = React.forwardRef<
+  HTMLDivElement,
+  AgentHomeViewAllTriggerProps
+>(function AgentHomeViewAllTrigger({ label, className, onKeyDown, ...props }, ref) {
+  return (
+    <div
+      {...props}
+      ref={ref}
+      role="button"
+      tabIndex={0}
+      className={cn(
+        "tw-flex tw-cursor-pointer tw-items-center tw-justify-between tw-rounded-md tw-px-2 tw-py-1.5",
+        "tw-text-xs tw-text-accent tw-transition-colors hover:tw-bg-modifier-hover hover:tw-text-accent-hover",
+        className
+      )}
+      onKeyDown={(event) => {
+        onKeyDown?.(event);
+        if (event.defaultPrevented || (event.key !== "Enter" && event.key !== " ")) return;
+        event.preventDefault();
+        event.currentTarget.click();
+      }}
+    >
+      <span>View all {label}</span>
+      <ChevronRight className="tw-size-3 tw-shrink-0" />
+    </div>
+  );
+});
+AgentHomeViewAllTrigger.displayName = "AgentHomeViewAllTrigger";
+
 /**
  * "View all" trigger + in-pane popover with search over the full list. Generic
  * over the item type so both projects and chats reuse it without the primitive
@@ -273,25 +376,9 @@ export function AgentHomeViewAll<TItem>({
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
-        <div
-          role="button"
-          tabIndex={0}
-          className={cn(
-            "tw-flex tw-cursor-pointer tw-items-center tw-justify-between tw-rounded-md tw-px-2 tw-py-1.5",
-            "tw-text-xs tw-text-accent tw-transition-colors hover:tw-bg-modifier-hover hover:tw-text-accent-hover"
-          )}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") {
-              e.preventDefault();
-              setOpen(true);
-            }
-          }}
-        >
-          {/* Left-aligned to the leading-tile column (no indent), matching the
-              create row. The count is omitted — the tab already shows it. */}
-          <span>View all {label}</span>
-          <ChevronRight className="tw-size-3 tw-shrink-0" />
-        </div>
+        {/* Left-aligned to the leading-tile column (no indent), matching the
+            create row. The count is omitted — the tab already shows it. */}
+        <AgentHomeViewAllTrigger label={label} />
       </PopoverTrigger>
       <PopoverContent align="start" side="bottom" className="tw-w-72 tw-p-0">
         <div className="tw-flex tw-max-h-80 tw-flex-col">

--- a/src/agentMode/ui/AgentHomeSection.tsx
+++ b/src/agentMode/ui/AgentHomeSection.tsx
@@ -27,9 +27,8 @@ import React, {
 /**
  * Rows shown inline before the rest collapse behind the "View all" popover.
  * Shared by the Projects and Recent Chats shelf tabs so both preview the same
- * number of rows — full tabs then land within ~10px of each other, which is
- * what keeps switching tabs from jumping (the shelf floor only covers the
- * short/empty end; see AgentHomeShelf.SHELF_BODY_FLOOR_CLASS).
+ * number of rows. AgentHomeShelf owns the shared body viewport, so every tab
+ * follows the same height and scrolling contract.
  */
 export const INLINE_LIMIT = 10;
 

--- a/src/agentMode/ui/AgentHomeShelf.test.tsx
+++ b/src/agentMode/ui/AgentHomeShelf.test.tsx
@@ -100,6 +100,7 @@ describe("AgentHomeShelf", () => {
       expect(panel.classList.contains("tw-h-96")).toBe(true);
       expect(panel.classList.contains("tw-max-h-96")).toBe(true);
       expect(panel.classList.contains("tw-overflow-y-auto")).toBe(true);
+      expect(panelBody.classList.contains("tw-h-full")).toBe(true);
       expect(panelBody.classList.contains("tw-min-h-full")).toBe(true);
 
       fireEvent.click(screen.getByRole("tab", { name: /Projects/ }));

--- a/src/agentMode/ui/AgentHomeShelf.test.tsx
+++ b/src/agentMode/ui/AgentHomeShelf.test.tsx
@@ -92,6 +92,21 @@ describe("AgentHomeShelf", () => {
       expect(screen.getByRole("tab", { name: /Recent Chats/ }).textContent ?? "").not.toMatch(/\d/);
     });
 
+    it("uses the shared ten-row viewport for every section body", () => {
+      renderShelf([chats, projectsEnabled]);
+      const panel = screen.getByRole("tabpanel");
+      const panelBody = panel.firstElementChild as HTMLElement;
+
+      expect(panel.classList.contains("tw-h-96")).toBe(true);
+      expect(panel.classList.contains("tw-max-h-96")).toBe(true);
+      expect(panel.classList.contains("tw-overflow-y-auto")).toBe(true);
+      expect(panelBody.classList.contains("tw-min-h-full")).toBe(true);
+
+      fireEvent.click(screen.getByRole("tab", { name: /Projects/ }));
+      expect(screen.getByRole("tabpanel")).toBe(panel);
+      expect(screen.queryByText("PROJECTS BODY")).not.toBeNull();
+    });
+
     it("hides the count badge when the count is zero", () => {
       renderShelf([withCount(0)]);
       expect(screen.getByRole("tab", { name: /Recent Chats/ }).textContent ?? "").not.toContain(

--- a/src/agentMode/ui/AgentHomeShelf.tsx
+++ b/src/agentMode/ui/AgentHomeShelf.tsx
@@ -65,7 +65,7 @@ function AgentHomeShelfViewport({
       aria-labelledby={labelledBy}
       className="tw-h-96 tw-max-h-96 tw-min-h-0 tw-overflow-y-auto"
     >
-      <div className="tw-flex tw-min-h-full tw-flex-col tw-pb-1">{children}</div>
+      <div className="tw-flex tw-h-full tw-min-h-full tw-flex-col tw-pb-1">{children}</div>
     </div>
   );
 }

--- a/src/agentMode/ui/AgentHomeShelf.tsx
+++ b/src/agentMode/ui/AgentHomeShelf.tsx
@@ -2,16 +2,6 @@ import { AgentHomeTab } from "@/agentMode/ui/AgentHomeTab";
 import { cn } from "@/lib/utils";
 import React, { useId, useState } from "react";
 
-/**
- * Reserved floor for the shelf's panel body. Deliberately a *floor*, not an
- * equal-height lock: full tabs (INLINE_LIMIT rows) all land within ~10px of
- * each other naturally, and this floor just keeps short/empty lists from
- * collapsing the card — the standard reserve-space-to-avoid-layout-shift
- * pattern. AgentContextSection imports this for its standalone (no-shelf)
- * rendering so the two surfaces can't drift.
- */
-export const SHELF_BODY_FLOOR_CLASS = "tw-min-h-48";
-
 export interface AgentHomeShelfSection {
   /** Stable id used for tab selection. */
   id: string;
@@ -53,12 +43,39 @@ interface AgentHomeShelfProps {
   onSectionSelect?: (id: string) => void;
 }
 
+interface AgentHomeShelfViewportProps {
+  id: string;
+  labelledBy: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Shared body viewport for every Agent Home shelf tab. A single component owns
+ * the height and overflow contract so individual sections cannot drift.
+ */
+function AgentHomeShelfViewport({
+  id,
+  labelledBy,
+  children,
+}: AgentHomeShelfViewportProps): React.ReactElement {
+  return (
+    <div
+      id={id}
+      role="tabpanel"
+      aria-labelledby={labelledBy}
+      className="tw-h-96 tw-max-h-96 tw-min-h-0 tw-overflow-y-auto"
+    >
+      <div className="tw-flex tw-min-h-full tw-flex-col tw-pb-1">{children}</div>
+    </div>
+  );
+}
+
 /**
  * Agent Home landing shelf: a persistent card whose header is a segmented tab
  * bar (one tab per section) over a single panel body. Exactly one tab is always
- * selected — clicking another swaps the body; there is no collapsed state. The
- * section bodies are sized to lead with the same number of rows, so switching
- * tabs doesn't change the card height.
+ * selected — clicking another swaps the body; there is no collapsed state.
+ * Every section renders through the same bounded viewport, so switching tabs
+ * never changes the card's height or scrolling rules.
  */
 export function AgentHomeShelf({
   sections,
@@ -93,9 +110,8 @@ export function AgentHomeShelf({
   return (
     <div
       className={cn(
-        // Flex column with min-h-0 so the card can shrink below its content when
-        // the region is short (see the panel comment) — then `overflow-hidden`
-        // still clips the rounded corners while the panel scrolls inside.
+        // Flex column with min-h-0 so the shared viewport can shrink when the
+        // region is short while overflow-hidden still clips the rounded corners.
         "tw-flex tw-min-h-0 tw-flex-col tw-overflow-hidden tw-rounded-md tw-border tw-border-solid tw-border-border tw-bg-primary",
         className
       )}
@@ -125,26 +141,9 @@ export function AgentHomeShelf({
           />
         ))}
       </div>
-      {/* The panel is the scroll container; the inner wrapper carries the
-          min-height floor (SHELF_BODY_FLOOR_CLASS) so a short/empty list can't
-          collapse the card. It is also a flex column so a section can tw-grow
-          to fill the floor (centering its empty-state copy). With room the card
-          sizes to that content and sits at the top of the region; on a pane
-          too short to fit it the card shrinks (min-h-0 on the card + min-h-0 here)
-          and this panel scrolls its list internally while the tab bar stays
-          pinned — instead of the card being clipped out of reach. The floor lives
-          on the inner div, not this scroll element, because `min-height` would
-          otherwise win over the shrink and re-break the overflow. */}
-      <div
-        id={panelId}
-        role="tabpanel"
-        aria-labelledby={tabId(active.id)}
-        className="tw-min-h-0 tw-overflow-y-auto"
-      >
-        <div className={cn(SHELF_BODY_FLOOR_CLASS, "tw-flex tw-flex-col tw-pb-1")}>
-          {active.renderBody()}
-        </div>
-      </div>
+      <AgentHomeShelfViewport id={panelId} labelledBy={tabId(active.id)}>
+        {active.renderBody()}
+      </AgentHomeShelfViewport>
     </div>
   );
 }

--- a/src/agentMode/ui/AgentLandingStack.stories.tsx
+++ b/src/agentMode/ui/AgentLandingStack.stories.tsx
@@ -2,7 +2,7 @@ import { AgentHomeShelf, type AgentHomeShelfSection } from "@/agentMode/ui/Agent
 import { AgentLandingStack } from "@/agentMode/ui/AgentLandingStack";
 import { CopilotBrandIcon } from "@/components/ui/CopilotBrandIcon";
 import type { Meta, StoryObj } from "@/lib/story";
-import { MessageSquare } from "lucide-react";
+import { FileSearch, Folder, MessageSquare, RefreshCw } from "lucide-react";
 import React from "react";
 
 type AgentLandingStackProps = React.ComponentProps<typeof AgentLandingStack>;
@@ -32,6 +32,73 @@ const sections: AgentHomeShelfSection[] = [
     ),
   },
 ];
+
+const relevantNotes = [
+  ["Bay Area Events This Week", "26%"],
+  ["2026 Inspiration", "23%"],
+  ["Summer Travel Ideas", "21%"],
+  ["Restaurants to Try", "18%"],
+  ["Weekend Reading List", "16%"],
+  ["Places to Revisit", "14%"],
+] as const;
+
+const relevantNotesSections: AgentHomeShelfSection[] = [
+  {
+    id: "relevant-notes",
+    icon: <FileSearch className="tw-size-4" />,
+    title: "Relevant Notes",
+    renderBody: () => (
+      <div className="tw-flex tw-min-h-0 tw-flex-1 tw-flex-col">
+        <div className="tw-flex tw-shrink-0 tw-items-center tw-gap-2 tw-rounded-md tw-border tw-border-solid tw-border-border tw-bg-secondary tw-px-2 tw-py-1.5 tw-text-ui-smaller tw-text-muted">
+          <span className="tw-min-w-0 tw-flex-1">
+            Open Relevant Notes in its own pane to keep it while you chat.
+          </span>
+          <span className="tw-shrink-0 tw-text-normal">Open pane</span>
+        </div>
+        <div className="tw-flex tw-shrink-0 tw-items-center tw-justify-between tw-border-b tw-border-solid tw-border-border tw-p-2 tw-text-ui-small">
+          <span className="tw-text-normal">
+            Relevant to <span className="tw-font-medium tw-text-normal">Weekend Food Trip</span>
+          </span>
+          <span className="tw-flex tw-items-center tw-gap-1 tw-rounded-md tw-bg-secondary tw-px-2 tw-py-1 tw-font-medium tw-text-normal">
+            <RefreshCw className="tw-size-3.5" />
+            Build index
+          </span>
+        </div>
+        <div className="tw-relative tw-min-h-0 tw-flex-1">
+          <div className="tw-absolute tw-inset-0 tw-overflow-y-auto tw-p-2">
+            <div className="tw-flex tw-flex-col tw-gap-0.5">
+              {relevantNotes.map(([title, score]) => (
+                <div key={title} className="tw-flex tw-flex-col tw-gap-2 tw-rounded-md tw-p-2">
+                  <div className="tw-flex tw-items-center tw-justify-between tw-gap-3 tw-text-ui-small">
+                    <span className="tw-min-w-0 tw-truncate tw-font-medium tw-text-normal">
+                      {title}
+                    </span>
+                    <span className="tw-shrink-0 tw-text-normal">{score}</span>
+                  </div>
+                  <div className="tw-h-1 tw-rounded-full tw-bg-secondary">
+                    <div className="tw-h-full tw-w-1/4 tw-rounded-full tw-bg-interactive-accent" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    ),
+  },
+];
+
+const projectSections: AgentHomeShelfSection[] = [
+  {
+    id: "projects",
+    icon: <Folder className="tw-size-4" />,
+    title: "Projects",
+    count: 4,
+    renderBody: () => null,
+  },
+];
+
+const allSections = [...sections, ...relevantNotesSections, ...projectSections];
 
 const meta = {
   title: "Agent Mode/Agent Landing Stack",
@@ -67,4 +134,12 @@ export const FullPreview: StoryObj<AgentLandingStackProps> = {
       />
     </div>
   ),
+};
+
+/** The Relevant Notes tab exercises a content-rich shelf inside the shared body viewport. */
+export const RelevantNotesPreview: StoryObj<AgentLandingStackProps> = {
+  args: {
+    shelf: <AgentHomeShelf sections={allSections} activeSectionId="relevant-notes" />,
+  },
+  render: FullPreview.render,
 };

--- a/src/agentMode/ui/AgentLandingStack.stories.tsx
+++ b/src/agentMode/ui/AgentLandingStack.stories.tsx
@@ -7,6 +7,11 @@ import React from "react";
 
 type AgentLandingStackProps = React.ComponentProps<typeof AgentLandingStack>;
 
+interface LandingStackCanvasProps {
+  args: AgentLandingStackProps;
+  shelf?: React.ReactNode;
+}
+
 const rows = Array.from({ length: 10 }, (_, index) => `Recent chat ${index + 1}`);
 const sections: AgentHomeShelfSection[] = [
   {
@@ -100,6 +105,37 @@ const projectSections: AgentHomeShelfSection[] = [
 
 const allSections = [...sections, ...relevantNotesSections, ...projectSections];
 
+function LandingStackCanvas({ args, shelf = args.shelf }: LandingStackCanvasProps) {
+  return (
+    <div className="tw-flex tw-size-full tw-flex-col tw-overflow-y-auto tw-px-2">
+      <AgentLandingStack
+        hero={args.hero ?? null}
+        composer={args.composer ?? null}
+        floating={args.floating}
+        context={args.context}
+        shelf={shelf}
+      />
+    </div>
+  );
+}
+
+function RelevantNotesPreviewCanvas({ args }: Pick<LandingStackCanvasProps, "args">) {
+  const [activeSectionId, setActiveSectionId] = React.useState("relevant-notes");
+
+  return (
+    <LandingStackCanvas
+      args={args}
+      shelf={
+        <AgentHomeShelf
+          sections={allSections}
+          activeSectionId={activeSectionId}
+          onSectionSelect={setActiveSectionId}
+        />
+      }
+    />
+  );
+}
+
 const meta = {
   title: "Agent Mode/Agent Landing Stack",
   component: AgentLandingStack,
@@ -123,23 +159,10 @@ export default meta;
 
 /** The ten-row preview exercises the landing's full-height centered composition. */
 export const FullPreview: StoryObj<AgentLandingStackProps> = {
-  render: (args) => (
-    <div className="tw-flex tw-size-full tw-flex-col tw-overflow-y-auto tw-px-2">
-      <AgentLandingStack
-        hero={args.hero ?? null}
-        composer={args.composer ?? null}
-        floating={args.floating}
-        context={args.context}
-        shelf={args.shelf}
-      />
-    </div>
-  ),
+  render: (args) => <LandingStackCanvas args={args} />,
 };
 
 /** The Relevant Notes tab exercises a content-rich shelf inside the shared body viewport. */
 export const RelevantNotesPreview: StoryObj<AgentLandingStackProps> = {
-  args: {
-    shelf: <AgentHomeShelf sections={allSections} activeSectionId="relevant-notes" />,
-  },
-  render: FullPreview.render,
+  render: (args) => <RelevantNotesPreviewCanvas args={args} />,
 };

--- a/src/agentMode/ui/AgentLandingStack.stories.tsx
+++ b/src/agentMode/ui/AgentLandingStack.stories.tsx
@@ -1,0 +1,70 @@
+import { AgentHomeShelf, type AgentHomeShelfSection } from "@/agentMode/ui/AgentHomeShelf";
+import { AgentLandingStack } from "@/agentMode/ui/AgentLandingStack";
+import { CopilotBrandIcon } from "@/components/ui/CopilotBrandIcon";
+import type { Meta, StoryObj } from "@/lib/story";
+import { MessageSquare } from "lucide-react";
+import React from "react";
+
+type AgentLandingStackProps = React.ComponentProps<typeof AgentLandingStack>;
+
+const rows = Array.from({ length: 10 }, (_, index) => `Recent chat ${index + 1}`);
+const sections: AgentHomeShelfSection[] = [
+  {
+    id: "chats",
+    icon: <MessageSquare className="tw-size-4" />,
+    title: "Recent Chats",
+    renderBody: () => (
+      <div className="tw-flex tw-flex-col">
+        <div className="tw-p-1">
+          <div className="tw-h-7 tw-rounded-md tw-border tw-border-solid tw-border-border tw-px-2 tw-text-ui-small tw-leading-7 tw-text-normal">
+            Search chats...
+          </div>
+        </div>
+        <div className="tw-flex tw-flex-col tw-divide-y tw-divide-border">
+          {rows.map((row) => (
+            <div key={row} className="tw-min-h-9 tw-px-2 tw-py-1.5 tw-text-ui-small">
+              {row}
+            </div>
+          ))}
+          <div className="tw-px-2 tw-py-1.5 tw-text-xs tw-text-accent">View all chats</div>
+        </div>
+      </div>
+    ),
+  },
+];
+
+const meta = {
+  title: "Agent Mode/Agent Landing Stack",
+  component: AgentLandingStack,
+  args: {
+    hero: (
+      <div className="tw-flex tw-items-center tw-justify-center tw-gap-3">
+        <CopilotBrandIcon className="tw-size-6 tw-text-normal" />
+        <span className="tw-text-3xl tw-font-[330] tw-text-normal">Where should we start?</span>
+      </div>
+    ),
+    composer: (
+      <div className="tw-rounded-md tw-border tw-border-solid tw-border-border tw-bg-primary tw-p-4 tw-text-ui-small tw-text-normal">
+        Ask Copilot...
+      </div>
+    ),
+    shelf: <AgentHomeShelf sections={sections} />,
+  },
+  parameters: { gallery: { host: "leaf", layout: "fullscreen" } },
+} satisfies Meta<AgentLandingStackProps>;
+export default meta;
+
+/** The ten-row preview exercises the landing's full-height centered composition. */
+export const FullPreview: StoryObj<AgentLandingStackProps> = {
+  render: (args) => (
+    <div className="tw-flex tw-size-full tw-flex-col tw-overflow-y-auto tw-px-2">
+      <AgentLandingStack
+        hero={args.hero ?? null}
+        composer={args.composer ?? null}
+        floating={args.floating}
+        context={args.context}
+        shelf={args.shelf}
+      />
+    </div>
+  ),
+};

--- a/src/agentMode/ui/AgentLandingStack.stories.tsx
+++ b/src/agentMode/ui/AgentLandingStack.stories.tsx
@@ -8,7 +8,7 @@ import React from "react";
 type AgentLandingStackProps = React.ComponentProps<typeof AgentLandingStack>;
 
 interface LandingStackCanvasProps {
-  args: AgentLandingStackProps;
+  args: Partial<AgentLandingStackProps>;
   shelf?: React.ReactNode;
 }
 

--- a/src/agentMode/ui/AgentLandingStack.test.tsx
+++ b/src/agentMode/ui/AgentLandingStack.test.tsx
@@ -1,0 +1,29 @@
+import { AgentLandingStack } from "@/agentMode/ui/AgentLandingStack";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+describe("AgentLandingStack", () => {
+  describe("AgentLandingStack()", () => {
+    it("renders supplied regions in reading order without reserving space for absent regions", () => {
+      const { container } = render(
+        <AgentLandingStack
+          hero={<div>Hero</div>}
+          composer={<div>Composer</div>}
+          context={<div>Context</div>}
+          shelf={<div>Shelf</div>}
+        />
+      );
+
+      expect(
+        screen.getAllByText(/Hero|Composer|Context|Shelf/).map((node) => node.textContent)
+      ).toEqual(["Hero", "Composer", "Context", "Shelf"]);
+      expect(Array.from(container.children).map((node) => node.textContent)).toEqual([
+        "",
+        "Hero",
+        "Composer",
+        "Context",
+        "Shelf",
+      ]);
+    });
+  });
+});

--- a/src/agentMode/ui/AgentLandingStack.tsx
+++ b/src/agentMode/ui/AgentLandingStack.tsx
@@ -31,11 +31,10 @@ interface AgentLandingStackProps {
  * variants render through this so the mount order is frozen in one place:
  * `hero → composer → [floating] → [context] → shelf`.
  *
- * The composer is **top-anchored**, not centered: a fixed-fraction (`h-1/4`)
- * spacer pins it a quarter of the way down so its own height changes (e.g. a
- * context chip appearing) don't shift it — the flex-1 shelf region below absorbs
- * the slack instead. This matches the shipped global landing (decision #2550);
- * the wireframe's vertically-centered hero is intentionally dropped.
+ * The composer is top-anchored by a fixed-fraction spacer so its own height
+ * changes (for example, a context chip appearing) don't shift the hero. The
+ * one-fifth offset balances the complete ten-row shelf around the middle of a
+ * full-height pane, while the flex-1 region below absorbs remaining space.
  *
  * Presentational only: the parent owns the scrolling/padded column wrapper and
  * feeds each slot.
@@ -49,7 +48,7 @@ export function AgentLandingStack({
 }: AgentLandingStackProps): React.ReactElement {
   return (
     <>
-      <div className="tw-h-1/4 tw-shrink-0" />
+      <div className="tw-h-1/5 tw-shrink-0" />
       <div className="tw-shrink-0 tw-pb-7">{hero}</div>
       <div className="tw-shrink-0">{composer}</div>
       {/* floating + context own their own padding (`tw-px-2 tw-pb-1`), so the

--- a/src/agentMode/ui/GlobalRecentChatsSection.stories.tsx
+++ b/src/agentMode/ui/GlobalRecentChatsSection.stories.tsx
@@ -1,0 +1,60 @@
+import { AgentHomeShelf, type AgentHomeShelfSection } from "@/agentMode/ui/AgentHomeShelf";
+import { GlobalRecentChatsSection } from "@/agentMode/ui/GlobalRecentChatsSection";
+import type { Meta, StoryObj } from "@/lib/story";
+import { MessageSquare } from "lucide-react";
+import React from "react";
+
+type GlobalRecentChatsSectionProps = React.ComponentProps<typeof GlobalRecentChatsSection>;
+
+const noop = async () => {};
+const noopSync = () => {};
+
+const items: GlobalRecentChatsSectionProps["items"] = Array.from({ length: 14 }, (_, index) => ({
+  id: `recent-chat-${index + 1}`,
+  title:
+    index === 3
+      ? "Plan the fall product launch and collect the open questions"
+      : `Recent chat ${index + 1}`,
+  createdAt: new Date("2026-08-28T18:00:00Z"),
+  lastAccessedAt: new Date(Date.parse("2026-08-28T22:00:00Z") - index * 60_000),
+}));
+
+const defaultArgs: GlobalRecentChatsSectionProps = {
+  items,
+  onLoadChat: noop,
+  onUpdateTitle: noop,
+  onDeleteChat: noop,
+  onOpenSourceFile: noop,
+  onLoadHistory: noopSync,
+};
+
+const meta = {
+  title: "Agent Mode/Global Recent Chats Section",
+  component: GlobalRecentChatsSection,
+  args: defaultArgs,
+  parameters: { gallery: { host: "leaf", layout: "padded" } },
+} satisfies Meta<GlobalRecentChatsSectionProps>;
+export default meta;
+
+function renderShelf(args: Partial<GlobalRecentChatsSectionProps>) {
+  const props: GlobalRecentChatsSectionProps = { ...defaultArgs, ...args };
+  const sections: AgentHomeShelfSection[] = [
+    {
+      id: "chats",
+      icon: <MessageSquare className="tw-size-4" />,
+      title: "Recent Chats",
+      renderBody: () => <GlobalRecentChatsSection {...props} />,
+    },
+  ];
+
+  return <AgentHomeShelf sections={sections} />;
+}
+
+export const FitsWithoutFooter: StoryObj<GlobalRecentChatsSectionProps> = {
+  args: { items: items.slice(0, 5) },
+  render: renderShelf,
+};
+
+export const Overflow: StoryObj<GlobalRecentChatsSectionProps> = {
+  render: renderShelf,
+};

--- a/src/agentMode/ui/GlobalRecentChatsSection.test.tsx
+++ b/src/agentMode/ui/GlobalRecentChatsSection.test.tsx
@@ -153,9 +153,17 @@ describe("GlobalRecentChatsSection", () => {
 
     it("caps the inline preview at 10 chats and offers a View-all trigger on overflow", () => {
       const items = Array.from({ length: 12 }, (_, i) => makeItem(`overflow-${i}`));
-      renderSection({ items });
+      const { container } = renderSection({ items });
       expect(screen.getAllByText(/^Chat overflow-/)).toHaveLength(10);
       expect(screen.getByText("View all chats")).toBeTruthy();
+
+      const scrollRegion = container.querySelector(
+        "[data-radix-scroll-area-viewport]"
+      )?.parentElement;
+      expect(scrollRegion?.classList.contains("tw-min-h-0")).toBe(true);
+      expect(scrollRegion?.classList.contains("tw-flex-1")).toBe(true);
+      expect(scrollRegion?.classList.contains("tw-max-h-56")).toBe(false);
+      expect(scrollRegion?.parentElement?.classList.contains("tw-flex-1")).toBe(true);
     });
 
     it("renders project badges in the View-all popover from the global landing", () => {

--- a/src/agentMode/ui/GlobalRecentChatsSection.test.tsx
+++ b/src/agentMode/ui/GlobalRecentChatsSection.test.tsx
@@ -151,15 +151,15 @@ describe("GlobalRecentChatsSection", () => {
       expect(titleElement.getAttribute("title")).toBe(title);
     });
 
-    it("caps the inline preview at 5 chats and offers a View-all trigger on overflow", () => {
-      const items = Array.from({ length: 7 }, (_, i) => makeItem(`overflow-${i}`));
+    it("caps the inline preview at 10 chats and offers a View-all trigger on overflow", () => {
+      const items = Array.from({ length: 12 }, (_, i) => makeItem(`overflow-${i}`));
       renderSection({ items });
-      expect(screen.getAllByText(/^Chat overflow-/)).toHaveLength(5);
+      expect(screen.getAllByText(/^Chat overflow-/)).toHaveLength(10);
       expect(screen.getByText("View all chats")).toBeTruthy();
     });
 
     it("renders project badges in the View-all popover from the global landing", () => {
-      const items = Array.from({ length: 6 }, (_, i) =>
+      const items = Array.from({ length: 11 }, (_, i) =>
         makeItem(`project-overflow-${i}`, { projectId: "project-1" })
       );
       renderSection({
@@ -167,9 +167,9 @@ describe("GlobalRecentChatsSection", () => {
         projectNamesById: { "project-1": "Product research" },
       });
 
-      expect(screen.getAllByLabelText("Project: Product research")).toHaveLength(5);
+      expect(screen.getAllByLabelText("Project: Product research")).toHaveLength(10);
       fireEvent.click(screen.getByText("View all chats"));
-      expect(screen.getAllByLabelText("Project: Product research")).toHaveLength(11);
+      expect(screen.getAllByLabelText("Project: Product research")).toHaveLength(21);
     });
 
     it("shows every match (no cap, no View-all) while searching", () => {

--- a/src/agentMode/ui/GlobalRecentChatsSection.tsx
+++ b/src/agentMode/ui/GlobalRecentChatsSection.tsx
@@ -1,9 +1,12 @@
 import { backendRegistry } from "@/agentMode/backends/registry";
-import { INLINE_LIMIT } from "@/agentMode/ui/AgentHomeSection";
+import {
+  AgentHomePreviewList,
+  AgentHomeViewAllTrigger,
+  INLINE_LIMIT,
+} from "@/agentMode/ui/AgentHomeSection";
 import { RecentChatProjectBadge, RecentChatTitle } from "@/agentMode/ui/RecentChatTitle";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { SearchBar } from "@/components/ui/SearchBar";
 import {
   ChatHistoryItem,
@@ -14,16 +17,7 @@ import { cn } from "@/lib/utils";
 import { isNativeChatId } from "@/utils/nativeChatId";
 import { formatCompactRelativeTime } from "@/utils/formatRelativeTime";
 import { sortByStrategy } from "@/utils/recentUsageManager";
-import {
-  ArrowUpRight,
-  Check,
-  ChevronRight,
-  Edit2,
-  LoaderCircle,
-  MessageCircle,
-  Trash2,
-  X,
-} from "lucide-react";
+import { ArrowUpRight, Check, Edit2, LoaderCircle, MessageCircle, Trash2, X } from "lucide-react";
 import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { safeAsyncHandler } from "@/utils/safeAsyncHandler";
 
@@ -385,7 +379,7 @@ export const GlobalRecentChatsSection = memo(function GlobalRecentChatsSection({
     () => (isSearching ? filteredItems : filteredItems.slice(0, INLINE_LIMIT)),
     [filteredItems, isSearching]
   );
-  const hasOverflow = !isSearching && filteredItems.length > INLINE_LIMIT;
+  const hasMoreItems = !isSearching && filteredItems.length > visibleItems.length;
 
   const handleStartEdit = useCallback((id: string, title: string) => {
     setConfirmDeleteId(null);
@@ -443,10 +437,10 @@ export const GlobalRecentChatsSection = memo(function GlobalRecentChatsSection({
     <div
       role={title ? "group" : undefined}
       aria-label={title}
-      // tw-grow fills the shelf panel's fixed floor (AgentHomeShelf) so the
+      // h-full fills the shelf panel's fixed floor (AgentHomeShelf) so the
       // empty / no-match copy below can center inside the card instead of
       // hugging the top of a mostly blank panel.
-      className={cn("tw-flex tw-grow tw-flex-col tw-gap-2", className)}
+      className={cn("tw-flex tw-h-full tw-min-h-0 tw-flex-col tw-gap-2", className)}
     >
       {items.length > 0 && (
         <div className="tw-p-1">
@@ -469,67 +463,24 @@ export const GlobalRecentChatsSection = memo(function GlobalRecentChatsSection({
               : "No recent chats"}
         </div>
       ) : (
-        // Outer divide-y separates the scroll region from the "View all" row
-        // below with the same hairline the rows use between themselves — the
-        // exact look of the Projects tab, where the trigger sits in the list's
-        // divide-y container.
-        <div className="tw-flex tw-flex-col tw-divide-y tw-divide-border">
-          {/* max-h-56 keeps a long search-result list scrolling INSIDE the card
-              near the inline preview's height, so searching doesn't balloon the
-              card. The inline (non-search) 5-row preview never reaches this cap,
-              and the "View all" row lives outside the scroll region so it can't
-              scroll out of reach. */}
-          <ScrollArea className="tw-max-h-56 tw-overflow-y-auto">
-            <div className="tw-flex tw-flex-col tw-divide-y tw-divide-border">
-              {visibleItems.map((item) => (
-                <RecentChatRow
-                  key={item.id}
-                  item={item}
-                  projectName={getProjectName(item)}
-                  isEditing={editingId === item.id}
-                  // Only the row being renamed needs the live draft; passing a
-                  // stable "" to the rest keeps their memo from re-rendering on
-                  // every keystroke.
-                  editingTitle={editingId === item.id ? editingTitle : ""}
-                  confirmingDelete={confirmDeleteId === item.id}
-                  onOpen={handleOpen}
-                  onStartEdit={handleStartEdit}
-                  onEditingTitleChange={setEditingTitle}
-                  // Only the editing row needs the live save handler (it changes
-                  // per keystroke via editingTitle); the rest get a stable noop so
-                  // their memo isn't defeated mid-rename.
-                  onSaveEdit={editingId === item.id ? handleSaveEdit : NOOP_SAVE}
-                  onCancelEdit={handleCancelEdit}
-                  onStartDelete={setConfirmDeleteId}
-                  onConfirmDelete={handleConfirmDelete}
-                  onCancelDelete={handleCancelDelete}
-                  canOpenSourceFile={!isNativeChatId(item.id)}
-                  onOpenSourceFile={handleOpenSourceFile}
-                  isRunning={runningChatIds?.has(item.id) ?? false}
-                  hasAttention={!!item.needsAttention || (attentionChatIds?.has(item.id) ?? false)}
-                />
-              ))}
-            </div>
-          </ScrollArea>
-          {hasOverflow && (
-            <ChatHistoryPopover
-              chatHistory={items}
-              onUpdateTitle={onUpdateTitle}
-              onDeleteChat={onDeleteChat}
-              onLoadChat={onLoadChat}
-              onOpenSourceFile={onOpenSourceFile}
-              getIcon={resolveChatIcon}
-              getBadge={renderProjectBadge}
-              // Full-width row near the pane's lower half: open downward like
-              // an accordion. Radix flips to "top" if the area below is tight.
-              side="bottom"
-              align="start"
-            >
-              {/* Trigger styled identically to the Projects tab's "View all
-                  projects" row (AgentHomeViewAll) so the two shelf tabs read as
-                  one component family.
-
-                  DESIGN NOTE: unlike these inline rows, the popover's rows show
+        <AgentHomePreviewList
+          hasMoreItems={hasMoreItems}
+          viewAll={
+            !isSearching ? (
+              <ChatHistoryPopover
+                chatHistory={items}
+                onUpdateTitle={onUpdateTitle}
+                onDeleteChat={onDeleteChat}
+                onLoadChat={onLoadChat}
+                onOpenSourceFile={onOpenSourceFile}
+                getIcon={resolveChatIcon}
+                getBadge={renderProjectBadge}
+                // Full-width row near the pane's lower half: open downward like
+                // an accordion. Radix flips to "top" if the area below is tight.
+                side="bottom"
+                align="start"
+              >
+                {/* DESIGN NOTE: unlike these inline rows, the popover's rows show
                   the open-source-note action for native (autosave-off) chats
                   too — pre-existing shared ChatHistoryPopover behavior (same
                   exposure as the control bar's History button; the click
@@ -551,27 +502,42 @@ export const GlobalRecentChatsSection = memo(function GlobalRecentChatsSection({
                   shows near-identical data. A "refresh only on open" fix would
                   need ChatHistoryPopover to expose onOpenChange — not worth
                   touching the shared base for this. */}
-              <div
-                role="button"
-                tabIndex={0}
-                className={cn(
-                  "tw-flex tw-cursor-pointer tw-items-center tw-justify-between tw-rounded-md tw-px-2 tw-py-1.5",
-                  "tw-text-xs tw-text-accent tw-transition-colors hover:tw-bg-modifier-hover hover:tw-text-accent-hover"
-                )}
-                onClick={() => onLoadHistory?.()}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    e.currentTarget.click();
-                  }
-                }}
-              >
-                <span>View all chats</span>
-                <ChevronRight className="tw-size-3 tw-shrink-0" />
-              </div>
-            </ChatHistoryPopover>
-          )}
-        </div>
+                <AgentHomeViewAllTrigger label="chats" onClick={() => onLoadHistory?.()} />
+              </ChatHistoryPopover>
+            ) : undefined
+          }
+        >
+          <div className="tw-flex tw-flex-col tw-divide-y tw-divide-border">
+            {visibleItems.map((item) => (
+              <RecentChatRow
+                key={item.id}
+                item={item}
+                projectName={getProjectName(item)}
+                isEditing={editingId === item.id}
+                // Only the row being renamed needs the live draft; passing a
+                // stable "" to the rest keeps their memo from re-rendering on
+                // every keystroke.
+                editingTitle={editingId === item.id ? editingTitle : ""}
+                confirmingDelete={confirmDeleteId === item.id}
+                onOpen={handleOpen}
+                onStartEdit={handleStartEdit}
+                onEditingTitleChange={setEditingTitle}
+                // Only the editing row needs the live save handler (it changes
+                // per keystroke via editingTitle); the rest get a stable noop so
+                // their memo isn't defeated mid-rename.
+                onSaveEdit={editingId === item.id ? handleSaveEdit : NOOP_SAVE}
+                onCancelEdit={handleCancelEdit}
+                onStartDelete={setConfirmDeleteId}
+                onConfirmDelete={handleConfirmDelete}
+                onCancelDelete={handleCancelDelete}
+                canOpenSourceFile={!isNativeChatId(item.id)}
+                onOpenSourceFile={handleOpenSourceFile}
+                isRunning={runningChatIds?.has(item.id) ?? false}
+                hasAttention={!!item.needsAttention || (attentionChatIds?.has(item.id) ?? false)}
+              />
+            ))}
+          </div>
+        </AgentHomePreviewList>
       )}
     </div>
   );

--- a/src/agentMode/ui/ProjectPickerList.stories.tsx
+++ b/src/agentMode/ui/ProjectPickerList.stories.tsx
@@ -1,6 +1,8 @@
+import { AgentHomeShelf, type AgentHomeShelfSection } from "@/agentMode/ui/AgentHomeShelf";
 import { ProjectPickerList } from "@/agentMode/ui/ProjectPickerList";
 import { useApp } from "@/context";
 import type { Meta, StoryObj } from "@/lib/story";
+import { Folder } from "lucide-react";
 import React from "react";
 
 type ProjectPickerListProps = React.ComponentProps<typeof ProjectPickerList>;
@@ -39,16 +41,44 @@ const projects: ProjectPickerListProps["projects"] = [
   },
 ];
 
-const ProjectPickerDemo: React.FC = () => {
+const overflowProjects: ProjectPickerListProps["projects"] = Array.from(
+  { length: 14 },
+  (_, index) => ({
+    id: `project-${index + 1}`,
+    name: index === 4 ? "Long-running competitive research" : `Project ${index + 1}`,
+    systemPrompt: "",
+    projectModelKey: "",
+    modelConfigs: {},
+    contextSource: {},
+    created: now - index * 86_400_000,
+    UsageTimestamps: now - index * 60_000,
+  })
+);
+
+interface ProjectPickerDemoProps {
+  projects: ProjectPickerListProps["projects"];
+}
+
+const ProjectPickerDemo = ({ projects: demoProjects }: ProjectPickerDemoProps) => {
   const app = useApp();
-  return (
-    <ProjectPickerList
-      app={app}
-      projects={projects}
-      onSelect={() => undefined}
-      onCreate={() => undefined}
-    />
-  );
+  const sections: AgentHomeShelfSection[] = [
+    {
+      id: "projects",
+      icon: <Folder className="tw-size-4" />,
+      title: "Projects",
+      count: demoProjects.length,
+      renderBody: () => (
+        <ProjectPickerList
+          app={app}
+          projects={demoProjects}
+          onSelect={() => undefined}
+          onCreate={() => undefined}
+        />
+      ),
+    },
+  ];
+
+  return <AgentHomeShelf sections={sections} />;
 };
 
 const meta = {
@@ -60,5 +90,10 @@ export default meta;
 
 /** Project identities use the same neutral folder treatment in every row. */
 export const Default: StoryObj<ProjectPickerListProps> = {
-  render: () => <ProjectPickerDemo />,
+  render: () => <ProjectPickerDemo projects={projects} />,
+};
+
+/** Overflow uses the same bottom-pinned View-all footer as Recent Chats. */
+export const Overflow: StoryObj<ProjectPickerListProps> = {
+  render: () => <ProjectPickerDemo projects={overflowProjects} />,
 };

--- a/src/agentMode/ui/ProjectPickerList.test.tsx
+++ b/src/agentMode/ui/ProjectPickerList.test.tsx
@@ -8,13 +8,12 @@ jest.mock("@/components/modals/project/context-manage-modal", () => ({
 import { ProjectConfig } from "@/aiParams";
 import { ProjectPickerList } from "@/agentMode/ui/ProjectPickerList";
 import { RecentUsageManager } from "@/utils/recentUsageManager";
-import { act, render } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import { App } from "obsidian";
 import React from "react";
 
 // jsdom lacks Obsidian's `activeDocument`; the View-all popover portals into it.
-// The tests below keep to the inline list (≤ INLINE_LIMIT projects) and never
-// open that surface, but alias defensively.
+// The tests below never open the View-all surface, but alias defensively.
 beforeAll(() => {
   (window as unknown as { activeDocument: Document }).activeDocument = window.document;
 });
@@ -90,6 +89,17 @@ describe("ProjectPickerList", () => {
       expect(plusSlot?.classList.contains("tw-size-6")).toBe(true);
       expect(folderSlot?.classList.contains("tw-size-6")).toBe(true);
       expect(folderSlot?.classList.contains("tw-justify-center")).toBe(true);
+    });
+
+    it("shows up to 10 projects before offering the View-all trigger", () => {
+      const projects = Array.from({ length: 11 }, (_, index) =>
+        makeProject(`Project ${index + 1}`, index)
+      );
+
+      render(<ProjectPickerList projects={projects} onSelect={noop} app={app} />);
+
+      expect(screen.getAllByText(/^Project \d+$/)).toHaveLength(10);
+      expect(screen.getByText("View all projects")).toBeTruthy();
     });
 
     it("falls back to persisted order when no usage manager is provided", () => {

--- a/src/agentMode/ui/ProjectPickerList.tsx
+++ b/src/agentMode/ui/ProjectPickerList.tsx
@@ -1,6 +1,7 @@
 import {
   AgentHomeCreateRow,
   AgentHomeListRow,
+  AgentHomePreviewList,
   AgentHomeViewAll,
   INLINE_LIMIT,
 } from "@/agentMode/ui/AgentHomeSection";
@@ -112,10 +113,10 @@ ProjectRow.displayName = "ProjectRow";
 /**
  * Project browser for the Agent Home landing (design A.2 + B.2).
  *
- * Shows the {@link INLINE_LIMIT} most-recent projects inline with a "View all
- * projects" affordance opening an in-pane search popover (not a fullscreen
- * modal). Selection and the optional create action are delegated to the caller;
- * this component never mutates project state directly. Entering a project (via the
+ * Offers up to {@link INLINE_LIMIT} recent projects inline, then uses the shared
+ * overflow-aware "View all projects" footer to open an in-pane search popover.
+ * Selection and the optional create action are delegated to the caller; this
+ * component never mutates project state directly. Entering a project (via the
  * caller) touches usage on the shared manager, which reorders this list live.
  */
 export const ProjectPickerList = memo(
@@ -134,31 +135,27 @@ export const ProjectPickerList = memo(
     const inlineProjects = useMemo(() => sortedProjects.slice(0, INLINE_LIMIT), [sortedProjects]);
 
     const total = projects.length;
-    const hasOverflow = total > INLINE_LIMIT;
+    const hasMoreItems = total > inlineProjects.length;
 
     return (
-      // tw-grow fills the shelf panel's fixed floor (AgentHomeShelf) so the
+      // h-full fills the shelf panel's fixed floor (AgentHomeShelf) so the
       // empty-state copy below can center inside the card; the "New project"
       // action row stays pinned at the top either way.
-      <div className={cn("tw-flex tw-grow tw-flex-col tw-divide-y tw-divide-border", className)}>
+      <div
+        className={cn(
+          "tw-flex tw-h-full tw-min-h-0 tw-flex-col tw-divide-y tw-divide-border",
+          className
+        )}
+      >
         {onCreate && <AgentHomeCreateRow label="New project" onClick={onCreate} />}
         {total === 0 ? (
           <div className="tw-flex tw-flex-1 tw-items-center tw-justify-center tw-px-2 tw-py-1.5 tw-text-xs tw-text-muted">
             No projects available
           </div>
         ) : (
-          <>
-            {inlineProjects.map((project) => (
-              <ProjectRow
-                key={project.id}
-                project={project}
-                timeMs={effectiveLastUsedMs(project, projectUsageTimestampsManager)}
-                onSelect={onSelect}
-                app={app}
-                onDeleted={onProjectDeleted}
-              />
-            ))}
-            {hasOverflow && (
+          <AgentHomePreviewList
+            hasMoreItems={hasMoreItems}
+            viewAll={
               <AgentHomeViewAll
                 items={sortedProjects}
                 total={total}
@@ -183,8 +180,21 @@ export const ProjectPickerList = memo(
                   />
                 )}
               />
-            )}
-          </>
+            }
+          >
+            <div className="tw-flex tw-flex-col tw-divide-y tw-divide-border">
+              {inlineProjects.map((project) => (
+                <ProjectRow
+                  key={project.id}
+                  project={project}
+                  timeMs={effectiveLastUsedMs(project, projectUsageTimestampsManager)}
+                  onSelect={onSelect}
+                  app={app}
+                  onDeleted={onProjectDeleted}
+                />
+              ))}
+            </div>
+          </AgentHomePreviewList>
         )}
       </div>
     );

--- a/src/components/project/ProjectContextSourceEditor.tsx
+++ b/src/components/project/ProjectContextSourceEditor.tsx
@@ -183,9 +183,8 @@ export function ProjectContextSourceEditor({
   const editorBox = (
     <div
       className={cn(
-        // min/max keep the box ≈ one shelf-tab tall (the home Recent Chats / project
-        // tabs land near the `SHELF_BODY_FLOOR_CLASS` floor at ~200px), so the
-        // Context tab matches its siblings instead of growing with the chip count;
+        // min/max keep the box about one compact shelf section tall, so the Context
+        // tab matches its siblings instead of growing with the chip count;
         // a long context scrolls inside the box. The caller's `tw-grow` fills up to
         // this cap.
         "tw-flex tw-max-h-60 tw-min-h-[200px] tw-flex-col tw-rounded-xl tw-border tw-p-3 tw-transition-colors",


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#169

## Why

Agent Home hides recent chats and projects after five rows, gives Relevant Notes a shorter body, and makes the rotating greeting easy to miss. When a list does overflow, "View all" should stay at the bottom of the shelf and should not appear while the same shelf still has unused space.

## What

> **Before:** Agent Home shows five chats or projects before "View all", each tab follows its own height rule, and the 20px greeting uses a 16px icon.
>
> **After:** Agent Home offers up to ten chats or projects inside one shared 24rem shelf, gives Relevant Notes the same height, and uses a 30px greeting with a 24px icon. Recent Chats and Projects use the available list height before showing the same bottom-pinned "View all" control.

The landing stack starts slightly higher so the complete hero, composer, and shelf composition sits nearer the middle of a full-height pane.

## Non goal

This PR does not make hero and composer spacing responsive to short-window height. Short panes keep the existing outer scrolling fallback, and the broader height-responsive behavior remains in issue 169.

## Screenshot

Landing composition at 600px in the deterministic Obsidian component gallery:

Before

![Agent Home before](https://github.com/user-attachments/assets/71d570bd-2d82-4f0c-9d25-69c33420e633)

After

![Agent Home after](https://github.com/user-attachments/assets/5c14c45c-0789-45b3-b283-3c823982309a)

The reported Recent Chats gap:

Before

![Recent Chats before](https://github.com/user-attachments/assets/2ee14b7f-29bb-427d-95f6-e3f672c1bf3c)

After

![Recent Chats after](https://github.com/user-attachments/assets/42241f2b-cad2-49ae-af4a-a70001d17a05)

Projects follows the same bottom-pinned overflow rule:

![Projects after](https://github.com/user-attachments/assets/ceb9ba27-da62-4bb4-b075-e9b506dc34bc)

Relevant Notes uses the same shelf height:

Before

![Relevant Notes before](https://github.com/user-attachments/assets/c618724b-cd6e-4808-90d0-576c1cd77284)

After

![Relevant Notes after](https://github.com/user-attachments/assets/1abfaa2b-2871-4300-a1a5-87281f47648a)

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Focused preview, shelf, chat, project, and landing tests cover the changed row limits, overflow decisions, and shared height contract |
| A defect would fail CI or be obvious on first use | ✅ | The behavioral tests run in CI, and misplaced or premature controls are visible as soon as Agent Home opens |
| A revert fully restores prior state, including persisted data | ✅ | The change writes no user data and adds no migration |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | The change only affects Agent Home presentation and list navigation |
| No public API, plugin API, message, or on-disk contract changes | ✅ | All changes stay inside the plugin's Agent Home UI |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | The change only measures rendered list space and updates layout state |
| No hot-path behavior lacks deterministic coverage | ✅ | Tests cover fitting content, rendered overflow, omitted rows, tab switching, and both View-all triggers |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Visual alignment is confined to Agent Home and appears on the first landing view |

Review: skim Why and What, run Verification steps 2-5, confirm CI is green, and merge without reading the diff.

## Verification

1. With the Copilot test vault configured, run `npm run test:vault`, reload Obsidian, and open Component Gallery.
2. Select `Agent Mode / Agent Landing Stack / FullPreview` at 600px and confirm the larger greeting and icon, the higher landing stack, and the ten-row shelf.
3. Select `Agent Mode / Global Recent Chats Section / FitsWithoutFooter`, then `Overflow`; confirm the fitting state has no "View all chats" control and the overflow state pins it to the shelf bottom while the rows scroll above it.
4. Select `Agent Mode / Project Picker List / Default`, then `Overflow`; confirm "View all projects" follows the same visibility, placement, and styling rules as Recent Chats.
5. Select `Agent Mode / Agent Landing Stack / RelevantNotesPreview`, switch among all three tabs, and confirm each tab keeps the same shelf height with internal scrolling when needed.
