### PR TITLE
[Live Plus catalog] - Step 3: Gate OpenCode on catalog settlement

### DIFF
--- a/src/agentMode/backends/opencode/OpencodeBackend.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.test.ts
@@ -9,6 +9,7 @@ import type {
   ProviderOrigin,
   ProviderRegistry,
   ProviderType,
+  CopilotPlusCatalogSnapshot,
 } from "@/modelManagement";
 import type { Skill } from "@/agentMode/skills";
 import {
@@ -29,7 +30,6 @@ import {
   buildAgentSystemPrompt,
   COPILOT_PROMPT_BASE,
 } from "@/agentMode/backends/shared/agentSystemPrompt";
-import { CopilotPlusUsageReader } from "@/agentMode/backends/shared/copilotPlusUsage";
 import {
   MIYO_SEARCH_FOLDER_ENV,
   MIYO_SEARCH_SCOPE_ENV,
@@ -160,10 +160,14 @@ function okEntry(provider: Provider, model: ConfiguredModel): EnabledBackendEntr
 function makeDeps(args: {
   resolved: EnabledBackendEntry[];
   keys?: Record<string, string | null>;
-  /** Published effort levels keyed by wire id; a missing key answers null. */
-  efforts?: Record<string, readonly string[] | null>;
+  plusCatalog?: CopilotPlusCatalogSnapshot;
 }): OpencodeModelDeps {
   const keys = args.keys ?? {};
+  const plusModels = args.resolved.flatMap((entry) =>
+    entry.state === "ok" && entry.provider.origin.kind === "copilot-plus"
+      ? [entry.configuredModel.info]
+      : []
+  );
   return {
     backendConfigRegistry: {
       resolveEnabled: (backend: string) => (backend === "opencode" ? args.resolved : []),
@@ -171,13 +175,11 @@ function makeDeps(args: {
     providerRegistry: {
       getApiKey: async (providerId: string) => keys[providerId] ?? null,
     } as unknown as ProviderRegistry,
+    getCopilotPlusCatalog: () => args.plusCatalog ?? { status: "ready", models: plusModels },
     getSelfHostWebSearchChannel: async () => ({
       url: "http://127.0.0.1:1234/search",
       token: "session-token",
     }),
-    ...(args.efforts
-      ? { getReasoningEfforts: async (id: string) => args.efforts?.[id] ?? null }
-      : {}),
   };
 }
 
@@ -194,7 +196,7 @@ function makePlusProvider(): Provider {
   );
 }
 
-/** A Copilot Plus reasoning model, as `COPILOT_PLUS_MODELS` snapshots it. */
+/** A Copilot Plus reasoning model shaped like the persisted live-catalog snapshot. */
 function makePlusReasoningModel(wireId: string): ConfiguredModel {
   const model = makeModel("p-plus", wireId);
   model.info.reasoning = true;
@@ -684,16 +686,57 @@ describe("buildOpencodeConfig — provider/model injection", () => {
     expect(cp.models).toEqual({ "copilot-plus-flash": {} });
   });
 
+  it("injects only Plus ids authorized by the current server catalog (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", async () => {
+    const provider = makePlusProvider();
+    const cached = makeModel("p-plus", "cached-model");
+    const current = makeModel("p-plus", "tomorrow-model");
+    const deps = makeDeps({
+      resolved: [okEntry(provider, cached), okEntry(provider, current)],
+      keys: { "p-plus": "plus-token-123" },
+      plusCatalog: {
+        status: "ready",
+        models: [{ id: "tomorrow-model", displayName: "Tomorrow Model" }],
+      },
+    });
+
+    const cfg = (await buildOpencodeConfig(getSettings(), deps)) as {
+      provider: Record<string, { models?: Record<string, unknown> }>;
+    };
+
+    expect(cfg.provider["copilot-plus"].models).toEqual({ "tomorrow-model": {} });
+  });
+
+  it("does not inject persisted Plus rows while the server catalog is loading or unavailable (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", async () => {
+    const entry = okEntry(makePlusProvider(), makeModel("p-plus", "cached-model"));
+    const loading = makeDeps({
+      resolved: [entry],
+      keys: { "p-plus": "plus-token-123" },
+      plusCatalog: { status: "loading", models: [] },
+    });
+    const unavailable = makeDeps({
+      resolved: [entry],
+      keys: { "p-plus": "plus-token-123" },
+      plusCatalog: { status: "error", models: [] },
+    });
+
+    await expect(buildOpencodeConfig(getSettings(), loading)).resolves.toMatchObject({
+      provider: {},
+    });
+    await expect(buildOpencodeConfig(getSettings(), unavailable)).resolves.toMatchObject({
+      provider: {},
+    });
+  });
+
   it("declares the effort levels Copilot Plus published, and disables the rest (https://github.com/logancyang/obsidian-copilot/issues/2917)", async () => {
     // Left to itself opencode infers the menu from the model id — a fixed
     // low/medium/high plus its own per-model special cases — which offers levels that
     // are synonyms of one another and misses levels the model has. The disables are
     // what removes an inferred level, since config variants merge over the guess.
     const model = makePlusReasoningModel("copilot-plus-flash");
+    model.info.reasoningEfforts = ["high", "max"];
     const deps = makeDeps({
       resolved: [okEntry(makePlusProvider(), model)],
       keys: { "p-plus": "plus-token-123" },
-      efforts: { "copilot-plus-flash": ["high", "max"] },
     });
 
     const cfg = (await buildOpencodeConfig(getSettings(), deps)) as {
@@ -714,14 +757,42 @@ describe("buildOpencodeConfig — provider/model injection", () => {
     });
   });
 
+  it("builds from synchronized Plus metadata without waiting on the catalog endpoint (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", async () => {
+    const model = makePlusReasoningModel("copilot-plus-flash");
+    model.info.reasoningEfforts = ["high", "max"];
+    // Supply the former network dependency as a probe: startup must ignore it.
+    const getReasoningEfforts = jest.fn(async () => ["low"]);
+    const deps = {
+      ...makeDeps({
+        resolved: [okEntry(makePlusProvider(), model)],
+        keys: { "p-plus": "plus-token-123" },
+      }),
+      getReasoningEfforts,
+    };
+
+    const cfg = (await buildOpencodeConfig(getSettings(), deps)) as {
+      provider: Record<string, { models?: Record<string, Record<string, unknown>> }>;
+    };
+
+    expect(getReasoningEfforts).not.toHaveBeenCalled();
+    expect(cfg.provider["copilot-plus"].models?.["copilot-plus-flash"]).toMatchObject({
+      reasoning: true,
+      variants: {
+        high: { reasoningEffort: "high" },
+        max: { reasoningEffort: "max" },
+      },
+    });
+  });
+
   it("offers no effort control for a Copilot Plus model that honors no level (https://github.com/logancyang/obsidian-copilot/issues/2917)", async () => {
     // opencode builds the menu only for models it is told reason, so withholding the
     // flag is what makes the control disappear. A menu whose every entry does nothing
     // is worse than no menu.
+    const model = makePlusReasoningModel("honors-no-level");
+    model.info.reasoningEfforts = [];
     const deps = makeDeps({
-      resolved: [okEntry(makePlusProvider(), makePlusReasoningModel("honors-no-level"))],
+      resolved: [okEntry(makePlusProvider(), model)],
       keys: { "p-plus": "plus-token-123" },
-      efforts: { "honors-no-level": [] },
     });
 
     const cfg = (await buildOpencodeConfig(getSettings(), deps)) as {
@@ -737,7 +808,6 @@ describe("buildOpencodeConfig — provider/model injection", () => {
     const deps = makeDeps({
       resolved: [okEntry(makePlusProvider(), makePlusReasoningModel("copilot-plus-flash"))],
       keys: { "p-plus": "plus-token-123" },
-      efforts: { "copilot-plus-flash": null },
     });
 
     const cfg = (await buildOpencodeConfig(getSettings(), deps)) as {
@@ -753,18 +823,16 @@ describe("buildOpencodeConfig — provider/model injection", () => {
     const provider = makeProvider("p-anthropic", { kind: "byok", catalogProviderId: "anthropic" });
     const model = makeModel("p-anthropic", "copilot-plus-flash");
     model.info.reasoning = true;
-    const getReasoningEfforts = jest.fn(async () => ["none", "low"]);
-    const deps = {
-      ...makeDeps({ resolved: [okEntry(provider, model)], keys: { "p-anthropic": "anth-123" } }),
-      getReasoningEfforts,
-    };
+    const deps = makeDeps({
+      resolved: [okEntry(provider, model)],
+      keys: { "p-anthropic": "anth-123" },
+    });
 
     const cfg = (await buildOpencodeConfig(getSettings(), deps)) as {
       provider: Record<string, { models?: Record<string, Record<string, unknown>> }>;
     };
 
     expect(cfg.provider.anthropic.models?.["copilot-plus-flash"]).toEqual({ reasoning: true });
-    expect(getReasoningEfforts).not.toHaveBeenCalled();
   });
 
   it("skips Copilot Plus when its provisioned relay token is unavailable (https://github.com/logancyang/obsidian-copilot/issues/2895)", async () => {
@@ -1337,9 +1405,8 @@ describe("OpencodeBackend.buildSpawnDescriptor", () => {
   });
 
   it("skips building the generated config when an override replaces it (https://github.com/logancyang/obsidian-copilot/issues/2917)", async () => {
-    // The override wins wholesale, so building a config would only spend a Copilot Plus
-    // catalog read on JSON that is thrown away — and an unreachable models host makes
-    // that read wait out its deadline before every spawn.
+    // The override wins wholesale, so resolving enabled models and building a generated
+    // config would only spend work on JSON that is thrown away.
     updateSetting("agentMode", {
       byok: {},
       activeBackend: "opencode",
@@ -1355,10 +1422,6 @@ describe("OpencodeBackend.buildSpawnDescriptor", () => {
         },
       },
     });
-    const readReasoningEfforts = jest.spyOn(
-      CopilotPlusUsageReader.prototype,
-      "readReasoningEfforts"
-    );
     const resolveEnabled = jest.fn(() => [
       okEntry(makePlusProvider(), makePlusReasoningModel("copilot-plus-flash")),
     ]);
@@ -1371,8 +1434,6 @@ describe("OpencodeBackend.buildSpawnDescriptor", () => {
 
     expect(desc.env.OPENCODE_CONFIG_CONTENT).toBe('{"model":"custom"}');
     expect(resolveEnabled).not.toHaveBeenCalled();
-    expect(readReasoningEfforts).not.toHaveBeenCalled();
-    readReasoningEfforts.mockRestore();
   });
 
   it("does not warn about the override when no cacheRoot is resolved", async () => {

--- a/src/agentMode/backends/opencode/OpencodeBackend.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.ts
@@ -19,6 +19,7 @@ import { copilotPlusModelId, mapProviderToOpencodeId } from "./opencodeModelReso
 import type { PlanUsageReading } from "@/agentMode/session/planUsage";
 import { CopilotPlusUsageReader } from "@/agentMode/backends/shared/copilotPlusUsage";
 import type { SelfHostWebSearchAgentChannel } from "@/LLMProviders/selfHostServices";
+import type { CopilotPlusCatalogSnapshot } from "@/modelManagement";
 
 /**
  * Maps Copilot's `ChatModelProviders` to OpenCode's provider id. Used for the
@@ -75,13 +76,8 @@ export interface OpencodeModelDeps {
   getCacheRoot?: () => string | undefined;
   /** Starts or reuses the owning plugin lifecycle's provider-credential-free channel. */
   getSelfHostWebSearchChannel?: () => Promise<Readonly<SelfHostWebSearchAgentChannel>>;
-  /**
-   * Resolves the thinking-effort levels the Copilot Plus service publishes for a bare
-   * Plus model id, or null when they cannot be read. Injected so the config builder
-   * never reaches for the catalog itself. When omitted, no model gets a declared level
-   * set and opencode falls back to inferring one, which is the behavior this replaces.
-   */
-  getReasoningEfforts?: (modelId: string) => Promise<readonly string[] | null>;
+  /** Current lifecycle's server-authoritative Plus catalog. */
+  getCopilotPlusCatalog?: () => CopilotPlusCatalogSnapshot;
 }
 
 /**
@@ -100,10 +96,11 @@ export class OpencodeBackend implements AcpBackend {
    * dies with the process that owns it, and shared with any other backend serving the
    * same hosted models.
    */
-  readonly #copilotPlus = new CopilotPlusUsageReader();
+  readonly #copilotPlus: CopilotPlusUsageReader;
 
   constructor(deps: OpencodeModelDeps) {
     this.#deps = deps;
+    this.#copilotPlus = new CopilotPlusUsageReader(deps.getCopilotPlusCatalog ?? (() => undefined));
   }
 
   /** Copilot Plus account caps, read from the models host that enforces them. */
@@ -159,17 +156,7 @@ export class OpencodeBackend implements AcpBackend {
     // thrown away — and an unreachable models host makes that read wait out its deadline
     // before every spawn. https://github.com/logancyang/obsidian-copilot/issues/2917
     let configContent =
-      configOverride ??
-      JSON.stringify(
-        await buildOpencodeConfig(
-          settings,
-          {
-            ...this.#deps,
-            getReasoningEfforts: (modelId) => this.#copilotPlus.readReasoningEfforts(modelId),
-          },
-          cacheRoot
-        )
-      );
+      configOverride ?? JSON.stringify(await buildOpencodeConfig(settings, this.#deps, cacheRoot));
     if (settings.enableSelfHostMode === true && configOverride !== undefined) {
       // An explicit config override must not reopen agent-native web tools while
       // Self-Host mode promises that queries stay on the configured route.
@@ -342,6 +329,17 @@ export async function buildOpencodeConfig(
     // identity and must be registered explicitly as `@ai-sdk/openai-compatible`
     // pointed at its own baseURL.
     const origin = entry.provider.origin;
+    if (origin.kind === "copilot-plus") {
+      const catalog = deps.getCopilotPlusCatalog?.();
+      const modelId = entry.configuredModel.info.id;
+      // Persisted provider rows preserve an offline user's saved selection, but
+      // only this lifecycle's successful endpoint response may authorize a Plus
+      // model to enter OpenCode's runtime configuration.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/319
+      if (catalog?.status !== "ready" || !catalog.models.some((model) => model.id === modelId)) {
+        continue;
+      }
+    }
     const catalogProviderId = origin.kind === "byok" ? origin.catalogProviderId : undefined;
     const hasCatalogIdentity = !!catalogProviderId;
 
@@ -417,15 +415,11 @@ export async function buildOpencodeConfig(
     // OpenAI-compatible providers, so without this it defaults to non-reasoning and
     // the effort picker shows "na". Mirrors the modalities injection above.
     if (info.reasoning) {
-      // Copilot Plus publishes the levels each of its models really has; a BYOK model
-      // has no such list and keeps opencode's own inference. Null means the catalog
-      // could not be read, which must not be mistaken for "no levels" — dropping a
-      // working control over a transient outage is worse than an imperfect menu.
-      // https://github.com/logancyang/obsidian-copilot/issues/2917
-      const published =
-        origin.kind === "copilot-plus"
-          ? ((await deps.getReasoningEfforts?.(info.id)) ?? null)
-          : null;
+      // Plus reconciliation snapshots the endpoint's effort levels onto the
+      // configured model before eligible OpenCode startup. Never fetch them
+      // here: the plugin-level one-shot catalog owns that wait and failure path.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/319
+      const published = origin.kind === "copilot-plus" ? (info.reasoningEfforts ?? null) : null;
       // A model that honors no level gets no control at all: opencode builds the menu
       // only for models it is told reason, so leaving `reasoning` unset is how the
       // menu disappears rather than showing entries that do nothing.
@@ -465,7 +459,7 @@ export async function buildOpencodeConfig(
   //
   // Both agents also carry a Copilot-authored `prompt` that overrides
   // opencode's provider-default prompt picker (`session/system.ts`). Without
-  // this override, Copilot Plus model names (e.g. `copilot-plus-flash`) miss
+  // this override, server-provided Copilot Plus model names miss
   // every substring branch and fall through to the generic `default.txt`
   // CLI-coding-agent prompt — wrong domain for an Obsidian vault assistant.
   // opencode's `cfg.agent.<id>` merge is field-wise, so adding `prompt` to

--- a/src/agentMode/backends/opencode/descriptor.ts
+++ b/src/agentMode/backends/opencode/descriptor.ts
@@ -285,6 +285,7 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
         // shared conversions cache. vaultId/path derivation lives entirely in
         // conversionsLocation — this backend never duplicates it.
         getCacheRoot: () => cacheRoot(args.plugin.app),
+        getCopilotPlusCatalog: () => args.plugin.copilotPlusSync.getSnapshot(),
         getSelfHostWebSearchChannel: () => {
           // The native deny is safe only when this lifecycle can provide the
           // replacement route before OpenCode starts.

--- a/src/agentMode/backends/shared/copilotPlusUsage.test.ts
+++ b/src/agentMode/backends/shared/copilotPlusUsage.test.ts
@@ -1,8 +1,5 @@
-import {
-  CopilotPlusUsageReader,
-  parseContextLength,
-  planUsageFromCopilotPlusUsage,
-} from "./copilotPlusUsage";
+import { CopilotPlusUsageReader, planUsageFromCopilotPlusUsage } from "./copilotPlusUsage";
+import type { CopilotPlusCatalogSnapshot } from "@/modelManagement";
 
 jest.mock("@/logger", () => ({
   logInfo: jest.fn(),
@@ -11,12 +8,10 @@ jest.mock("@/logger", () => ({
 }));
 
 const mockGetUsage = jest.fn();
-const mockGetModels = jest.fn();
 jest.mock("@/LLMProviders/brevilabsClient", () => ({
   BrevilabsClient: {
     getInstance: () => ({
       getUsage: (...args: unknown[]) => mockGetUsage(...args),
-      getModels: (...args: unknown[]) => mockGetModels(...args),
     }),
   },
 }));
@@ -24,7 +19,6 @@ jest.mock("@/LLMProviders/brevilabsClient", () => ({
 describe("copilotPlusUsage", () => {
   beforeEach(() => {
     mockGetUsage.mockReset();
-    mockGetModels.mockReset();
   });
 
   describe("planUsageFromCopilotPlusUsage()", () => {
@@ -88,34 +82,11 @@ describe("copilotPlusUsage", () => {
     );
   });
 
-  describe("parseContextLength()", () => {
-    it.each([
-      ["1M", 1_048_576],
-      ["256K", 262_144],
-      ["192k", 196_608],
-      ["8192", 8_192],
-      [" 64 K ", 65_536],
-    ])("reads %s as %i tokens (binary suffixes, as published)", (display, tokens) => {
-      expect(parseContextLength(display)).toBe(tokens);
-    });
-
-    it.each([
-      ["an unknown suffix", "1G"],
-      ["prose", "one million"],
-      ["a zero", "0"],
-      ["a negative", "-5K"],
-      ["a non-string", 200_000],
-      ["undefined", undefined],
-    ])("returns null for %s", (_label, display) => {
-      expect(parseContextLength(display)).toBeNull();
-    });
-  });
-
   describe("CopilotPlusUsageReader", () => {
     it("reads plan usage through the Brevilabs client", async () => {
       mockGetUsage.mockResolvedValue({ used: { weekly: { usedPercent: 21 } } });
 
-      const reading = await new CopilotPlusUsageReader().readPlanUsage();
+      const reading = await new CopilotPlusUsageReader(() => undefined).readPlanUsage();
 
       expect(reading).toMatchObject({
         kind: "usage",
@@ -123,168 +94,39 @@ describe("copilotPlusUsage", () => {
       });
     });
 
-    it("answers context windows from one catalog fetch, shared across models and calls", async () => {
-      mockGetModels.mockResolvedValue({
-        data: [
-          { id: "gemini-3-pro", context_length: "1M" },
-          { id: "kimi-k2", context_length: "256K" },
-          { id: "no-window-published" },
+    it("answers context windows from the plugin lifecycle catalog (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", async () => {
+      const catalog: CopilotPlusCatalogSnapshot = {
+        status: "ready",
+        models: [
+          { id: "gemini-3-pro", displayName: "Gemini", limits: { context: 1_048_576 } },
+          { id: "kimi-k2", displayName: "Kimi", limits: { context: 262_144 } },
+          { id: "no-window-published", displayName: "No window" },
         ],
-      });
-      const reader = new CopilotPlusUsageReader();
+      };
+      const getCatalog = jest.fn(() => catalog);
+      const reader = new CopilotPlusUsageReader(getCatalog);
 
       await expect(reader.readContextWindow("gemini-3-pro")).resolves.toBe(1_048_576);
       await expect(reader.readContextWindow("kimi-k2")).resolves.toBe(262_144);
       await expect(reader.readContextWindow("no-window-published")).resolves.toBeNull();
       await expect(reader.readContextWindow("not-in-catalog")).resolves.toBeNull();
-      expect(mockGetModels).toHaveBeenCalledTimes(1);
+      expect(getCatalog).toHaveBeenCalledTimes(4);
     });
 
-    it("answers null for a null model id without touching the network", async () => {
+    it("answers null for a null model id without reading the catalog", async () => {
       // Null is the caller saying "not a Copilot Plus model" — its backend-specific
       // prefix did not match — so there is nothing to look up.
-      await expect(new CopilotPlusUsageReader().readContextWindow(null)).resolves.toBeNull();
-      expect(mockGetModels).not.toHaveBeenCalled();
-    });
-
-    it("shares one in-flight fetch between concurrent callers", async () => {
-      let release!: (value: { data: { id: string; context_length: string }[] }) => void;
-      mockGetModels.mockReturnValue(new Promise((resolve) => (release = resolve)));
-      const reader = new CopilotPlusUsageReader();
-
-      const first = reader.readContextWindow("gemini-3-pro");
-      const second = reader.readContextWindow("kimi-k2");
-      release({
-        data: [
-          { id: "gemini-3-pro", context_length: "1M" },
-          { id: "kimi-k2", context_length: "256K" },
-        ],
-      });
-
-      await expect(first).resolves.toBe(1_048_576);
-      await expect(second).resolves.toBe(262_144);
-      expect(mockGetModels).toHaveBeenCalledTimes(1);
-    });
-
-    it("answers the effort levels a model publishes, from the same catalog fetch", async () => {
-      mockGetModels.mockResolvedValue({
-        data: [
-          {
-            id: "reasons-three-ways",
-            context_length: "1M",
-            reasoning_efforts: ["none", "low", "max"],
-          },
-          { id: "honors-no-level", context_length: "1M", reasoning_efforts: [] },
-        ],
-      });
-      const reader = new CopilotPlusUsageReader();
-
-      await expect(reader.readReasoningEfforts("reasons-three-ways")).resolves.toEqual([
-        "none",
-        "low",
-        "max",
-      ]);
-      await expect(reader.readContextWindow("reasons-three-ways")).resolves.toBe(1_048_576);
-      expect(mockGetModels).toHaveBeenCalledTimes(1);
-    });
-
-    it("tells a model that honors no level apart from one that published none", async () => {
-      // An empty list means the model has no effort to vary and its caller should offer
-      // no control; an absent field means an older service that cannot say, where the
-      // caller must keep whatever menu it already had.
-      // https://github.com/logancyang/obsidian-copilot/issues/2917
-      mockGetModels.mockResolvedValue({
-        data: [
-          { id: "honors-no-level", reasoning_efforts: [] },
-          { id: "service-too-old", context_length: "1M" },
-        ],
-      });
-      const reader = new CopilotPlusUsageReader();
-
-      await expect(reader.readReasoningEfforts("honors-no-level")).resolves.toEqual([]);
-      await expect(reader.readReasoningEfforts("service-too-old")).resolves.toBeNull();
-      await expect(reader.readReasoningEfforts("not-in-catalog")).resolves.toBeNull();
-    });
-
-    it("treats an unusable effort list as unknown rather than as no levels", async () => {
-      // "No levels" removes the effort control. Doing that because the field arrived
-      // malformed would delete a working menu on the strength of garbage, so anything
-      // the caller cannot act on has to read the same as the field being absent.
-      mockGetModels.mockResolvedValue({
-        data: [
-          { id: "garbage-levels", reasoning_efforts: [7, "", null, "  "] },
-          { id: "wrong-type", reasoning_efforts: "high" },
-          { id: "partly-usable", reasoning_efforts: [" high ", 7] },
-        ],
-      });
-      const reader = new CopilotPlusUsageReader();
-
-      await expect(reader.readReasoningEfforts("garbage-levels")).resolves.toBeNull();
-      await expect(reader.readReasoningEfforts("wrong-type")).resolves.toBeNull();
-      await expect(reader.readReasoningEfforts("partly-usable")).resolves.toEqual(["high"]);
-    });
-
-    it("answers null for effort levels when the catalog cannot be read", async () => {
-      // Not "no levels": dropping a working effort control over one transient outage is
-      // worse than leaving the menu as it was.
-      mockGetModels.mockResolvedValue(null);
-
+      const getCatalog = jest.fn((): CopilotPlusCatalogSnapshot | undefined => undefined);
       await expect(
-        new CopilotPlusUsageReader().readReasoningEfforts("any-model")
+        new CopilotPlusUsageReader(getCatalog).readContextWindow(null)
       ).resolves.toBeNull();
+      expect(getCatalog).not.toHaveBeenCalled();
     });
 
-    it("gives up on a catalog read that never answers, so the agent still starts", async () => {
-      // The opencode spawn path waits on this read and the HTTP layer enforces no
-      // timeout, so an unreachable host would otherwise hold up starting the agent.
-      // https://github.com/logancyang/obsidian-copilot/issues/2917
-      jest.useFakeTimers();
-      try {
-        mockGetModels.mockReturnValue(new Promise(() => {}));
-        const reader = new CopilotPlusUsageReader();
-
-        const pending = reader.readReasoningEfforts("never-answers");
-        jest.advanceTimersByTime(3_000);
-
-        await expect(pending).resolves.toBeNull();
-      } finally {
-        jest.useRealTimers();
-      }
-    });
-
-    it("retries the catalog after a read times out instead of reusing the dead request (https://github.com/logancyang/obsidian-copilot/issues/2917)", async () => {
-      // Keeping the timed-out request as the shared one would make every later read wait
-      // out the same dead connection, so the menu would stay guessed even once the host
-      // came back.
-      jest.useFakeTimers();
-      try {
-        mockGetModels
-          .mockReturnValueOnce(new Promise(() => {}))
-          .mockResolvedValue({ data: [{ id: "gpt-5", reasoning_efforts: ["low", "high"] }] });
-        const reader = new CopilotPlusUsageReader();
-
-        const timedOut = reader.readReasoningEfforts("gpt-5");
-        jest.advanceTimersByTime(3_000);
-        await expect(timedOut).resolves.toBeNull();
-
-        await expect(reader.readReasoningEfforts("gpt-5")).resolves.toEqual(["low", "high"]);
-        expect(mockGetModels).toHaveBeenCalledTimes(2);
-      } finally {
-        jest.useRealTimers();
-      }
-    });
-
-    it("retries after a failed catalog fetch instead of caching the failure (https://github.com/logancyang/obsidian-copilot-preview/issues/193)", async () => {
-      // One transient outage at the wrong moment must not strand the context ring on a
-      // bare token count for the rest of the session.
-      mockGetModels
-        .mockResolvedValueOnce(null)
-        .mockResolvedValue({ data: [{ id: "gemini-3-pro", context_length: "1M" }] });
-      const reader = new CopilotPlusUsageReader();
+    it("answers null while the one lifecycle catalog is unavailable (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", async () => {
+      const reader = new CopilotPlusUsageReader(() => ({ status: "error", models: [] }));
 
       await expect(reader.readContextWindow("gemini-3-pro")).resolves.toBeNull();
-      await expect(reader.readContextWindow("gemini-3-pro")).resolves.toBe(1_048_576);
-      expect(mockGetModels).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/agentMode/backends/shared/copilotPlusUsage.ts
+++ b/src/agentMode/backends/shared/copilotPlusUsage.ts
@@ -1,7 +1,7 @@
 import type { PlanUsageReading, UsageWindow } from "@/agentMode/session/planUsage";
 import { planUsageReading, toUsagePercent } from "@/agentMode/session/planUsage";
 import { BrevilabsClient, type UsageResponse } from "@/LLMProviders/brevilabsClient";
-import { logInfo } from "@/logger";
+import type { CopilotPlusCatalogSnapshot } from "@/modelManagement";
 
 /**
  * Copilot Plus account caps and model context windows, read from the Brevilabs hosts.
@@ -58,95 +58,19 @@ export function planUsageFromCopilotPlusUsage(
 }
 
 /**
- * Token count from the display string the models endpoint publishes (`1M`, `256K`,
- * `192K`), or null when it is not a form we recognize.
- *
- * The suffixes are binary: `1M` is the 1,048,576-token Gemini window and `256K` the
- * 262,144-token Kimi one, both rounded for display. Reading them as powers of ten would
- * put every meter about 5% off — harmless for a gauge, but wrong for no reason.
- */
-export function parseContextLength(display: unknown): number | null {
-  if (typeof display !== "string") return null;
-  const match = /^\s*([\d.]+)\s*([KMkm])?\s*$/.exec(display);
-  if (!match) return null;
-
-  const value = Number(match[1]);
-  if (!Number.isFinite(value) || value <= 0) return null;
-
-  const unit = match[2]?.toUpperCase();
-  const multiplier = unit === "M" ? 1024 * 1024 : unit === "K" ? 1024 : 1;
-  return Math.round(value * multiplier);
-}
-
-/** What the published catalog says about one Copilot Plus model. */
-interface CatalogEntry {
-  /** Input context window in tokens, or null when the endpoint published none. */
-  contextWindow: number | null;
-  /**
-   * Thinking-effort levels this model distinguishes, or null when the endpoint did
-   * not publish any — an older service the caller must not read a menu into.
-   */
-  reasoningEfforts: readonly string[] | null;
-}
-
-/** A model that honors no effort level at all, shared so "empty" stays one value. */
-const NO_REASONING_EFFORTS: readonly string[] = Object.freeze([]);
-
-/**
- * Upper bound on one catalog read.
- *
- * The opencode spawn path waits on this to learn a model's effort levels, and
- * `requestUrl` enforces no timeout of its own, so an unreachable host would otherwise
- * hold up starting the agent for as long as the OS takes to give up on the connection.
- * Giving up early costs an accurate effort menu for that session; not giving up costs
- * the agent.
- */
-const CATALOG_TIMEOUT_MS = 3_000;
-
-/** Resolve with null if `promise` has not settled within `ms`. */
-function withDeadline<T>(promise: Promise<T | null>, ms: number): Promise<T | null> {
-  return new Promise((resolve) => {
-    const timer = window.setTimeout(() => resolve(null), ms);
-    const settle = (value: T | null) => {
-      window.clearTimeout(timer);
-      resolve(value);
-    };
-    promise.then(settle, () => settle(null));
-  });
-}
-
-/**
- * Levels a published list may contain, or null when the field is missing or unusable.
- *
- * An empty list is a real answer — the model honors no level and its caller should
- * offer no control — so it is kept distinct from the absent case. Anything the caller
- * cannot act on collapses into the absent case rather than into the empty one.
- */
-function parseReasoningEfforts(raw: unknown): readonly string[] | null {
-  if (!Array.isArray(raw)) return null;
-  if (raw.length === 0) return NO_REASONING_EFFORTS;
-  const levels = raw
-    .filter((level): level is string => typeof level === "string")
-    .map((level) => level.trim())
-    .filter((level) => level.length > 0);
-  // A list that arrived with entries but none usable is a malformed answer, not a model
-  // that honors no level. Reading it as the latter would delete a working effort menu on
-  // the strength of garbage.
-  return levels.length > 0 ? Object.freeze(levels) : null;
-}
-
-/**
- * Reads Copilot Plus caps and per-model capabilities on behalf of whichever backend is
- * serving those models, caching the published catalog for that backend's lifetime.
- *
- * The catalog changes when we publish a new model list, not while a vault is open, so it
- * is fetched at most once — but only a successful fetch is remembered. Caching a failure
- * would strand the context ring for the rest of the session after one transient outage
- * (https://github.com/logancyang/obsidian-copilot-preview/issues/193).
+ * Reads Copilot Plus caps and per-model context windows on behalf of a backend.
+ * Catalog metadata comes from the plugin lifecycle's one server request; this
+ * reader never starts a second model-list request.
  */
 export class CopilotPlusUsageReader {
-  private catalog: Map<string, CatalogEntry> | null = null;
-  private inFlight: Promise<Map<string, CatalogEntry> | null> | null = null;
+  private readonly getCatalog: () => CopilotPlusCatalogSnapshot | undefined;
+
+  /**
+   * @param getCatalog - Current plugin lifecycle's server-authoritative catalog snapshot.
+   */
+  constructor(getCatalog: () => CopilotPlusCatalogSnapshot | undefined) {
+    this.getCatalog = getCatalog;
+  }
 
   /** The account's cap utilization as the models host currently reports it. */
   async readPlanUsage(): Promise<PlanUsageReading> {
@@ -162,59 +86,8 @@ export class CopilotPlusUsageReader {
    */
   async readContextWindow(modelId: string | null): Promise<number | null> {
     if (!modelId) return null;
-    const catalog = await this.loadCatalog();
-    return catalog?.get(modelId)?.contextWindow ?? null;
-  }
-
-  /**
-   * Thinking-effort levels a Copilot Plus model distinguishes, as the service publishes
-   * them, or null when they cannot be read.
-   *
-   * The caller must not treat null as "no levels": an agent harness left without a
-   * published list falls back to guessing the menu from the model id, and dropping the
-   * control instead would remove a working one over a transient outage.
-   *
-   * @param modelId - Bare Copilot Plus model id, with any backend-specific wire prefix
-   *   already stripped by the caller. Null for a model this account does not serve.
-   */
-  async readReasoningEfforts(modelId: string | null): Promise<readonly string[] | null> {
-    if (!modelId) return null;
-    const catalog = await this.loadCatalog();
-    return catalog?.get(modelId)?.reasoningEfforts ?? null;
-  }
-
-  private async loadCatalog(): Promise<Map<string, CatalogEntry> | null> {
-    if (this.catalog) return this.catalog;
-    // Share one request between concurrent callers, but do not remember a failed one.
-    // The deadline belongs to the shared promise rather than to each await: a request
-    // that never settles would otherwise stay the shared one forever, so every later
-    // read would wait out the same dead connection and never retry once the host came
-    // back. The identity check keeps a timed-out request from clearing its successor.
-    const pending: Promise<Map<string, CatalogEntry> | null> = (this.inFlight ??= withDeadline(
-      this.fetchCatalog(),
-      CATALOG_TIMEOUT_MS
-    ).finally(() => {
-      if (this.inFlight === pending) this.inFlight = null;
-    }));
-    const catalog = await pending;
-    if (catalog) this.catalog = catalog;
-    return catalog;
-  }
-
-  private async fetchCatalog(): Promise<Map<string, CatalogEntry> | null> {
-    const response = await BrevilabsClient.getInstance().getModels();
-    if (!response?.data) {
-      logInfo("[AgentMode] Copilot Plus catalog unavailable; context ring will retry");
-      return null;
-    }
-    const catalog = new Map<string, CatalogEntry>();
-    for (const entry of response.data) {
-      if (!entry?.id) continue;
-      catalog.set(entry.id, {
-        contextWindow: parseContextLength(entry.context_length),
-        reasoningEfforts: parseReasoningEfforts(entry.reasoning_efforts),
-      });
-    }
-    return catalog;
+    const catalog = this.getCatalog();
+    if (catalog?.status !== "ready") return null;
+    return catalog.models.find((model) => model.id === modelId)?.limits?.context ?? null;
   }
 }

--- a/src/agentMode/index.ts
+++ b/src/agentMode/index.ts
@@ -16,6 +16,7 @@ import { AgentSessionIndex } from "./session/AgentSessionIndex";
 import { createNodeFileStorage } from "./session/nodeFileStorage";
 import { AgentSessionManager } from "./session/AgentSessionManager";
 import { seedCopilotDefaultModel } from "./session/copilotDefaultModel";
+import { preloadInitialModels } from "./session/initialModelPreload";
 import { SkillManager } from "./skills";
 import { planManagedBuiltins } from "./skills/builtin/builtinSkills";
 import { removeSeededBuiltin, seedBuiltinSkills } from "./skills/builtin/seedBuiltinSkills";
@@ -164,6 +165,9 @@ function backendEnvOverridesKey(settings: CopilotSettings, backendId: BackendId)
  *
  * `main.ts` calls this once on plugin load. To swap prompters, shut down
  * the existing manager and call this again.
+ *
+ * @param app - Obsidian app instance that owns this plugin lifecycle.
+ * @param plugin - Copilot plugin instance that owns model and backend state.
  */
 export function createAgentSessionManager(app: App, plugin: CopilotPlugin): AgentSessionManager {
   const os = requireNodeModule<typeof import("node:os")>("os");
@@ -455,7 +459,17 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
   // keeps them usable, so they load like any other.
   for (const descriptor of listBackendDescriptors()) {
     if (descriptor.getInstallState(settings).kind !== "ready") continue;
-    const promise = manager.preloadModels(descriptor.id);
+    // OpenCode's spawn config includes server-discovered Plus providers. Hold
+    // only its initial model probe until the one lifecycle catalog request has
+    // either reconciled or failed; other agents and plugin loading stay fully
+    // independent. Failure resolves this gate and starts OpenCode without Plus.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/319
+    const promise = preloadInitialModels(
+      manager,
+      descriptor.id,
+      plugin.copilotPlusSync,
+      settings.isPaidUser === true && !!settings.plusLicenseKey
+    );
     manager.registerPreload(
       descriptor.id,
       promise.catch((e) => {

--- a/src/agentMode/session/initialModelPreload.test.ts
+++ b/src/agentMode/session/initialModelPreload.test.ts
@@ -1,0 +1,53 @@
+import { preloadInitialModels } from "@/agentMode/session/initialModelPreload";
+import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
+import type { CopilotPlusSyncQueue } from "@/modelManagement";
+
+describe("initialModelPreload", () => {
+  describe("preloadInitialModels()", () => {
+    it("gates OpenCode but not Claude or Codex on Plus catalog settlement (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", async () => {
+      let settleCatalog: () => void = () => undefined;
+      const waitForSettled = jest.fn(
+        () =>
+          new Promise((resolve) => {
+            settleCatalog = () => resolve({ status: "ready", models: [] });
+          })
+      );
+      const preloadModels = jest.fn(async (_backendId: string) => undefined);
+      const manager = { preloadModels } as unknown as AgentSessionManager;
+      const plusSync = { waitForSettled } as unknown as CopilotPlusSyncQueue;
+
+      const opencode = preloadInitialModels(manager, "opencode", plusSync, true);
+      await preloadInitialModels(manager, "claude", plusSync, true);
+      await preloadInitialModels(manager, "codex", plusSync, true);
+
+      expect(preloadModels.mock.calls.map(([id]) => id)).toEqual(["claude", "codex"]);
+      settleCatalog();
+      await opencode;
+      expect(preloadModels).toHaveBeenLastCalledWith("opencode");
+    });
+
+    it("starts OpenCode after an unavailable catalog settles (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", async () => {
+      const preloadModels = jest.fn(async (_backendId: string) => undefined);
+      const manager = { preloadModels } as unknown as AgentSessionManager;
+      const plusSync = {
+        waitForSettled: async () => ({ status: "error", models: [] }),
+      } as unknown as CopilotPlusSyncQueue;
+
+      await preloadInitialModels(manager, "opencode", plusSync, true);
+
+      expect(preloadModels).toHaveBeenCalledWith("opencode");
+    });
+
+    it("does not gate an ineligible OpenCode user on the Plus catalog (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", async () => {
+      const waitForSettled = jest.fn(() => new Promise(() => undefined));
+      const preloadModels = jest.fn(async (_backendId: string) => undefined);
+      const manager = { preloadModels } as unknown as AgentSessionManager;
+      const plusSync = { waitForSettled } as unknown as CopilotPlusSyncQueue;
+
+      await preloadInitialModels(manager, "opencode", plusSync, false);
+
+      expect(waitForSettled).not.toHaveBeenCalled();
+      expect(preloadModels).toHaveBeenCalledWith("opencode");
+    });
+  });
+});

--- a/src/agentMode/session/initialModelPreload.ts
+++ b/src/agentMode/session/initialModelPreload.ts
@@ -1,0 +1,29 @@
+import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
+import type { BackendId } from "@/agentMode/session/types";
+
+interface CatalogSettlement {
+  waitForSettled(): Promise<unknown>;
+}
+
+/**
+ * Start a backend's plugin-load model probe after its required shared data is settled.
+ *
+ * @param manager - Agent lifecycle that owns the model preloader.
+ * @param backendId - Backend whose initial catalog should be probed.
+ * @param plusSync - Plugin-local Plus catalog lifecycle, when available.
+ * @param waitForPlusCatalog - Whether the current user can route Plus models through OpenCode.
+ */
+export async function preloadInitialModels(
+  manager: Pick<AgentSessionManager, "preloadModels">,
+  backendId: BackendId,
+  plusSync: CatalogSettlement | undefined,
+  waitForPlusCatalog: boolean
+): Promise<void> {
+  if (backendId === "opencode" && plusSync && waitForPlusCatalog) {
+    // Catalog errors are terminal snapshots, not rejected startup: OpenCode
+    // must still start with its own and BYOK models after the failed request.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/319
+    await plusSync.waitForSettled();
+  }
+  await manager.preloadModels(backendId);
+}

--- a/src/agentMode/ui/AgentModeChat.test.tsx
+++ b/src/agentMode/ui/AgentModeChat.test.tsx
@@ -10,6 +10,16 @@ import React from "react";
 // Readiness of the backend the pane would run, swapped per test. Declared with
 // the `mock` prefix so Jest allows the mock factory below to close over it.
 let mockInstallState: InstallState = { kind: "ready", source: "custom" };
+let mockBackendId: "claude" | "opencode" = "claude";
+let mockPlusEligible = false;
+
+jest.mock("@/settings/model", () => ({
+  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook
+  useSettingsValue: () => ({
+    isPaidUser: mockPlusEligible,
+    plusLicenseKey: mockPlusEligible ? "license" : "",
+  }),
+}));
 
 // Stub the descriptor hooks so the effect's `preloadReady`/install gates are
 // satisfied without the real backend registry / jotai atoms. The mock factory
@@ -17,7 +27,11 @@ let mockInstallState: InstallState = { kind: "ready", source: "custom" };
 // expected here.
 /* eslint-disable @eslint-react/hooks-extra/no-unnecessary-use-prefix */
 jest.mock("@/agentMode/ui/useBackendDescriptor", () => ({
-  useSessionBackendDescriptor: () => ({ id: "claude", openInstallUI: jest.fn() }),
+  useSessionBackendDescriptor: () => ({
+    id: mockBackendId,
+    displayName: mockBackendId,
+    openInstallUI: jest.fn(),
+  }),
   useBackendInstallState: () => mockInstallState,
 }));
 /* eslint-enable @eslint-react/hooks-extra/no-unnecessary-use-prefix */
@@ -43,6 +57,7 @@ interface ManagerStub {
   poolSessions: AgentSession[];
   lastError?: string | null;
   starting?: boolean;
+  preloadReady?: boolean;
 }
 
 function makeManager({
@@ -51,11 +66,12 @@ function makeManager({
   poolSessions,
   lastError = null,
   starting = false,
+  preloadReady = true,
 }: ManagerStub) {
   const getOrCreateActiveSession = jest.fn(async () => session("spawned"));
   const manager = {
     subscribe: jest.fn(() => () => {}),
-    isPreloadReady: jest.fn(() => true),
+    isPreloadReady: jest.fn(() => preloadReady),
     getSessions: jest.fn(() => poolSessions),
     getSessionsForScope: jest.fn(() => scopeSessions),
     getActiveProjectId: jest.fn(() => activeProjectId),
@@ -68,8 +84,19 @@ function makeManager({
   return { manager, getOrCreateActiveSession };
 }
 
-function renderChat(manager: AgentSessionManager) {
-  const plugin = { app: {}, agentSessionManager: manager } as unknown as CopilotPlugin;
+function renderChat(
+  manager: AgentSessionManager,
+  plusStatus: "loading" | "ready" | "error" = "error"
+) {
+  const plusSnapshot = { status: plusStatus, models: [] } as const;
+  const plugin = {
+    app: {},
+    agentSessionManager: manager,
+    copilotPlusSync: {
+      getSnapshot: () => plusSnapshot,
+      subscribe: () => () => undefined,
+    },
+  } as unknown as CopilotPlugin;
   return render(
     <AgentModeChat plugin={plugin} onSaveChat={() => {}} updateUserMessageHistory={() => {}} />
   );
@@ -91,6 +118,42 @@ function renderFallback(installState: InstallState, lastError: string | null, st
 describe("AgentModeChat", () => {
   afterEach(() => {
     mockInstallState = { kind: "ready", source: "custom" };
+    mockBackendId = "claude";
+    mockPlusEligible = false;
+  });
+
+  describe("startup progress", () => {
+    it("shows the Plus catalog wait and does not start OpenCode early (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", async () => {
+      mockBackendId = "opencode";
+      mockPlusEligible = true;
+      const { manager, getOrCreateActiveSession } = makeManager({
+        activeProjectId: GLOBAL_SCOPE,
+        scopeSessions: [],
+        poolSessions: [],
+        preloadReady: false,
+      });
+
+      renderChat(manager, "loading");
+
+      expect(screen.getByRole("status").textContent).toContain("Loading Plus catalog");
+      await waitFor(() => expect(manager.isPreloadReady).toHaveBeenCalled());
+      expect(getOrCreateActiveSession).not.toHaveBeenCalled();
+    });
+
+    it("shows that OpenCode continues without Plus after the catalog fails (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", () => {
+      mockBackendId = "opencode";
+      mockPlusEligible = true;
+      const { manager } = makeManager({
+        activeProjectId: GLOBAL_SCOPE,
+        scopeSessions: [],
+        poolSessions: [],
+        preloadReady: false,
+      });
+
+      renderChat(manager, "error");
+
+      expect(screen.getByRole("status").textContent).toContain("Starting opencode without Plus");
+    });
   });
 
   describe("auto-spawn guard (scope-aware)", () => {

--- a/src/agentMode/ui/AgentModeChat.tsx
+++ b/src/agentMode/ui/AgentModeChat.tsx
@@ -3,12 +3,15 @@ import { AgentHome } from "@/agentMode/ui/AgentHome";
 import { AgentModeStatus } from "@/agentMode/ui/AgentModeStatus";
 import { AgentSelectPanel } from "@/agentMode/ui/AgentSelectPanel";
 import { AgentSelectPane } from "@/agentMode/ui/AgentSelectPane";
+import { AgentStartupProgress, type AgentStartupStage } from "@/agentMode/ui/AgentStartupProgress";
 import {
   useBackendInstallState,
   useSessionBackendDescriptor,
 } from "@/agentMode/ui/useBackendDescriptor";
 import type CopilotPlugin from "@/main";
 import { logError } from "@/logger";
+import { useCopilotPlusCatalog } from "@/contexts/useCopilotPlusCatalog";
+import { useSettingsValue } from "@/settings/model";
 import React from "react";
 
 interface Props {
@@ -31,6 +34,8 @@ export const AgentModeChat: React.FC<Props> = ({
   const manager = plugin.agentSessionManager;
   const descriptor = useSessionBackendDescriptor(manager);
   const installState = useBackendInstallState(descriptor, plugin);
+  const copilotPlusCatalog = useCopilotPlusCatalog(plugin);
+  const settings = useSettingsValue();
   const [tick, setTick] = React.useState(0);
 
   React.useEffect(() => {
@@ -82,9 +87,17 @@ export const AgentModeChat: React.FC<Props> = ({
   // guarantees the picker (and effort dropdown) read from a populated
   // cache on first paint instead of flashing an empty list.
   if (!preloadReady) {
+    const waitsForPlus =
+      descriptor.id === "opencode" && settings.isPaidUser === true && !!settings.plusLicenseKey;
+    const startupStage: AgentStartupStage =
+      waitsForPlus && copilotPlusCatalog.status === "loading"
+        ? "plus-catalog"
+        : waitsForPlus && copilotPlusCatalog.status === "error"
+          ? "backend-without-plus"
+          : "backend";
     return (
       <div className="tw-flex tw-size-full tw-items-center tw-justify-center tw-text-muted">
-        Loading agent models…
+        <AgentStartupProgress stage={startupStage} agentName={descriptor.displayName} />
       </div>
     );
   }

--- a/src/agentMode/ui/AgentStartupProgress.stories.tsx
+++ b/src/agentMode/ui/AgentStartupProgress.stories.tsx
@@ -1,0 +1,24 @@
+import {
+  AgentStartupProgress,
+  type AgentStartupProgressProps,
+} from "@/agentMode/ui/AgentStartupProgress";
+import type { Meta, StoryObj } from "@/lib/story";
+
+const meta = {
+  title: "Agent Mode/Agent Startup Progress",
+  component: AgentStartupProgress,
+  parameters: { gallery: { host: "leaf", layout: "centered" } },
+} satisfies Meta<AgentStartupProgressProps>;
+export default meta;
+
+export const LoadingCopilotPlusModels: StoryObj<AgentStartupProgressProps> = {
+  args: { stage: "plus-catalog", agentName: "opencode" },
+};
+
+export const StartingOpenCode: StoryObj<AgentStartupProgressProps> = {
+  args: { stage: "backend", agentName: "opencode" },
+};
+
+export const ContinuingOffline: StoryObj<AgentStartupProgressProps> = {
+  args: { stage: "backend-without-plus", agentName: "opencode" },
+};

--- a/src/agentMode/ui/AgentStartupProgress.test.tsx
+++ b/src/agentMode/ui/AgentStartupProgress.test.tsx
@@ -1,0 +1,26 @@
+import {
+  AgentStartupProgress,
+  type AgentStartupProgressProps,
+} from "@/agentMode/ui/AgentStartupProgress";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+describe("AgentStartupProgress", () => {
+  describe("AgentStartupProgress()", () => {
+    function renderProgress(props: AgentStartupProgressProps) {
+      return render(<AgentStartupProgress {...props} />);
+    }
+
+    it("names the Plus catalog while OpenCode is gated (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", () => {
+      renderProgress({ stage: "plus-catalog", agentName: "opencode" });
+
+      expect(screen.getByRole("status").textContent).toContain("Loading Plus catalog");
+    });
+
+    it("explains that OpenCode continues without Plus after catalog failure (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", () => {
+      renderProgress({ stage: "backend-without-plus", agentName: "opencode" });
+
+      expect(screen.getByRole("status").textContent).toContain("Starting opencode without Plus");
+    });
+  });
+});

--- a/src/agentMode/ui/AgentStartupProgress.tsx
+++ b/src/agentMode/ui/AgentStartupProgress.tsx
@@ -1,0 +1,25 @@
+import { cn } from "@/lib/utils";
+import React from "react";
+
+export type AgentStartupStage = "plus-catalog" | "backend" | "backend-without-plus";
+
+export interface AgentStartupProgressProps {
+  stage: AgentStartupStage;
+  agentName: string;
+}
+
+/** Shows which external dependency currently owns an Agent Mode startup wait. */
+export const AgentStartupProgress: React.FC<AgentStartupProgressProps> = ({ stage, agentName }) => {
+  const message =
+    stage === "plus-catalog"
+      ? "Loading Plus catalog…"
+      : stage === "backend-without-plus"
+        ? `Starting ${agentName} without Plus…`
+        : `Starting ${agentName}…`;
+
+  return (
+    <div className={cn("tw-px-6 tw-text-center tw-text-sm tw-text-muted")} role="status">
+      {message}
+    </div>
+  );
+};

--- a/src/agentMode/ui/agentModelPickerHelpers.test.ts
+++ b/src/agentMode/ui/agentModelPickerHelpers.test.ts
@@ -297,6 +297,63 @@ describe("buildPickerEntries", () => {
     expect(entries.map((model) => model.name)).toEqual(["catalog-model"]);
   });
 
+  it("blocks switching from Claude to OpenCode until the Plus catalog settles (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", () => {
+    const claude = {
+      ...makeDescriptor("claude"),
+      getEnabledModelEntries: () => [
+        { baseModelId: "claude-sonnet", name: "Sonnet", credentialState: "ok" as const },
+      ],
+    } as unknown as BackendDescriptor;
+    const opencode = {
+      ...makeDescriptor("opencode"),
+      routesCopilotModels: true,
+      getEnabledModelEntries: () => [
+        {
+          baseModelId: "copilot-plus/cached-model",
+          name: "Cached Plus Model",
+          credentialState: "ok" as const,
+        },
+        { baseModelId: "opencode/free-model", name: "Free Model", credentialState: "ok" as const },
+      ],
+    } as unknown as BackendDescriptor;
+    const current = makeModelEntry("claude-sonnet", "Sonnet");
+    const manager = makeManager({
+      catalogById: {
+        claude: makeCatalog([current]),
+        opencode: makeCatalog([
+          makeModelEntry("copilot-plus/cached-model"),
+          makeModelEntry("opencode/free-model"),
+        ]),
+      },
+      preloadStatusById: { claude: "ready", opencode: "pending" },
+    });
+    const ctx: ModelActiveContext = {
+      activeSession: { backendId: "claude" } as unknown as AgentSession,
+      activeChatUIState: makeUIState({ canSwitchModel: true }),
+      activeBackendId: "claude",
+      activeDescriptor: claude,
+      activeSessionHasHistory: false,
+      activeModelState: makeModelState(current.baseModelId, [current]),
+      activeCurrentEntry: current,
+    };
+
+    const { entries } = buildPickerEntries(
+      manager,
+      [claude, opencode],
+      ctx,
+      { ...emptySettings, isPaidUser: true, plusLicenseKey: "license" },
+      [],
+      "loading"
+    );
+    const openCodeRows = entries.filter((entry) => entry._backendId === "opencode");
+
+    expect(openCodeRows).toHaveLength(1);
+    expect(openCodeRows[0]).toMatchObject({
+      displayName: "Loading models…",
+      _disabledReason: "Loading…",
+    });
+  });
+
   it("still shows a loading placeholder for a routing agent whose preload has not settled", () => {
     // The locked rows must not satisfy the "section produced nothing" check, or
     // an unlicensed user loses the per-agent loading row.

--- a/src/agentMode/ui/agentModelPickerHelpers.ts
+++ b/src/agentMode/ui/agentModelPickerHelpers.ts
@@ -1,6 +1,6 @@
 import { Notice } from "obsidian";
 import { logError } from "@/logger";
-import type { ModelCapability } from "@/constants";
+import { ChatModelProviders, type ModelCapability } from "@/constants";
 import type { ModelSelectorEntry } from "@/components/ui/ModelSelector";
 import {
   type CopilotPlusCatalogModel,
@@ -71,9 +71,15 @@ export function appendBackendSection(
     settings: CopilotSettings;
     /** Preload settled without a catalog, so persisted enabled models are the only recovery path. */
     useEnabledFallback?: boolean;
+    /** Optional current-lifecycle authorization check for persisted model rows. */
+    includeModel?: (baseModelId: string) => boolean;
   }
 ): void {
-  const enabledEntries = descriptor.getEnabledModelEntries?.(ctx.settings) ?? null;
+  const persistedEntries = descriptor.getEnabledModelEntries?.(ctx.settings) ?? null;
+  const enabledEntries =
+    persistedEntries && ctx.includeModel
+      ? persistedEntries.filter((entry) => ctx.includeModel?.(entry.baseModelId) === true)
+      : persistedEntries;
   if (!enabledEntries) return;
   if (!ctx.backendModels) {
     if (!ctx.useEnabledFallback) return;
@@ -318,7 +324,8 @@ export function buildPickerEntries(
   descriptors: BackendDescriptor[],
   ctx: ModelActiveContext,
   settings: CopilotSettings,
-  copilotPlusModels: readonly CopilotPlusCatalogModel[] = EMPTY_PLUS_MODELS
+  copilotPlusModels: readonly CopilotPlusCatalogModel[] = EMPTY_PLUS_MODELS,
+  copilotPlusStatus: "loading" | "ready" | "error" = "ready"
 ): { entries: ModelSelectorEntry[]; valueKey: string } {
   const entries: ModelSelectorEntry[] = [];
   for (const descriptor of descriptors) {
@@ -328,23 +335,40 @@ export function buildPickerEntries(
     const keepBaseModelId = isActiveBackend
       ? (ctx.activeModelState?.current.baseModelId ?? null)
       : (manager.getDefaultSelection(descriptor.id)?.baseModelId ?? null);
-    const backendModels = catalog?.availableModels ?? null;
+    const includeModel = (baseModelId: string): boolean => {
+      const prefix = `${ChatModelProviders.COPILOT_PLUS}/`;
+      if (!baseModelId.startsWith(prefix)) return true;
+      if (copilotPlusStatus !== "ready") return false;
+      const modelId = baseModelId.slice(prefix.length);
+      return copilotPlusModels.some((model) => model.id === modelId);
+    };
+    const backendModels =
+      catalog?.availableModels?.filter((model) => includeModel(model.baseModelId)) ?? null;
     const hasNoCatalog = catalog === null;
     const preloadStatus = manager.getPreloadStatus(descriptor.id);
     const sectionStart = entries.length;
-    appendBackendSection(entries, descriptor, {
-      backendModels,
-      keepBaseModelId,
-      settings,
-      useEnabledFallback: hasNoCatalog && (preloadStatus === "ready" || preloadStatus === "error"),
-    });
+    const plusGatePending =
+      descriptor.id === "opencode" &&
+      settings.isPaidUser === true &&
+      !!settings.plusLicenseKey &&
+      copilotPlusStatus === "loading";
+    if (!plusGatePending) {
+      appendBackendSection(entries, descriptor, {
+        backendModels,
+        keepBaseModelId,
+        settings,
+        useEnabledFallback:
+          hasNoCatalog && (preloadStatus === "ready" || preloadStatus === "error"),
+        includeModel,
+      });
+    }
     // No catalog discovered yet (distinct from a settled probe reporting no
     // model catalog). Show a per-backend loading / failure row so
     // the user can see every installed backend immediately — important
     // because the chat now unblocks on just the *active* backend's
     // preload, not the global preload.
-    if (hasNoCatalog && entries.length === sectionStart) {
-      if (preloadStatus === "pending") {
+    if ((hasNoCatalog || plusGatePending) && entries.length === sectionStart) {
+      if (preloadStatus === "pending" || plusGatePending) {
         entries.push(synthesizePreloadPlaceholder(descriptor, "pending"));
       } else if (preloadStatus === "ready" || preloadStatus === "error") {
         entries.push(synthesizePreloadPlaceholder(descriptor, "error"));
@@ -644,8 +668,15 @@ export function buildAgentModelPicker(args: {
   descriptors: BackendDescriptor[];
   settings: CopilotSettings;
   copilotPlusModels?: readonly CopilotPlusCatalogModel[];
+  copilotPlusStatus?: "loading" | "ready" | "error";
 }): AgentModelPickerOverride | null {
-  const { manager, descriptors, settings, copilotPlusModels = EMPTY_PLUS_MODELS } = args;
+  const {
+    manager,
+    descriptors,
+    settings,
+    copilotPlusModels = EMPTY_PLUS_MODELS,
+    copilotPlusStatus = "ready",
+  } = args;
   if (!manager) return null;
   const ctx = collectModelActiveContext(manager);
   const { entries, valueKey } = buildPickerEntries(
@@ -653,7 +684,8 @@ export function buildAgentModelPicker(args: {
     descriptors,
     ctx,
     settings,
-    copilotPlusModels
+    copilotPlusModels,
+    copilotPlusStatus
   );
   const onChange = buildModelOnChange(manager, ctx, entries);
   return {

--- a/src/agentMode/ui/useAgentModelPicker.ts
+++ b/src/agentMode/ui/useAgentModelPicker.ts
@@ -110,6 +110,7 @@ export function useAgentModelPicker(
       descriptors,
       settings,
       copilotPlusModels: copilotPlusCatalog.models,
+      copilotPlusStatus: copilotPlusCatalog.status,
     });
   }, [manager, descriptors, settings, signal, installStates, copilotPlusCatalog]);
 }


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#319

## Why

OpenCode could preload before the live Plus catalog settled. With a saved Plus default, that let its native fallback become active; restarting OpenCode after a late catalog response could then replace the Agent session.

## What

| State | Result |
| --- | --- |
| Eligible OpenCode startup while the catalog is loading | Agent Chat shows **Loading Plus catalog…** and waits before probing OpenCode |
| Claude or Codex is active while the catalog is loading | The active Agent remains usable; OpenCode stays unavailable in the cross-agent picker |
| The catalog succeeds | OpenCode starts once with only server-authorized Plus providers and reuses that snapshot for effort and context metadata |
| The catalog fails | OpenCode starts once without Plus and Agent Chat shows **Starting opencode without Plus…** |

No catalog-settlement path replaces an existing Agent session.

## Non goal

This does not retry a terminal catalog failure before plugin reload, and it does not yet keep an unavailable saved Plus default selected and prompt-blocked. The final PR owns that behavior.

## Screenshot

**Before: `origin/master` starts OpenCode on its native fallback while the Plus catalog is delayed.**

![Before: OpenCode native fallback is selected](https://github.com/user-attachments/assets/ef3c5045-484f-4e87-9ffd-f31448bae2f1)

**After: the exact PR branch renders the catalog wait in the isolated Obsidian component gallery.**

![After: Agent Chat waits for the Plus catalog](https://github.com/user-attachments/assets/3b497d11-544a-4fed-acec-16a818ac0473)

**Failure state: the exact PR branch explains that OpenCode continues without Plus.**

![After failure: OpenCode starts without Plus](https://github.com/user-attachments/assets/7dc73e85-bd11-44a6-bcb3-c7a62a5b3403)

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Preload, OpenCode config, picker readiness, usage metadata, and startup-state tests cover the changed behavior |
| A defect would fail CI or be obvious on first use | ✅ | Tests cover the gate and the startup status is visible immediately |
| A revert fully restores prior state, including persisted data | ✅ | This layer performs no migration or irreversible write |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Existing Plus credentials and entitlement checks are unchanged |
| No public API, plugin API, message, or on-disk contract changes | ✅ | OpenCode configuration remains an internal generated artifact |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | OpenCode preload now waits on catalog settlement before starting |
| No hot-path behavior lacks deterministic coverage | ✅ | Success, failure, non-OpenCode, and active-session variants are covered |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Visual regressions appear in Agent Chat during startup |

Review: inspect `preloadInitialModels()` in `src/agentMode/session/initialModelPreload.ts`, `buildOpencodeConfig()` in `src/agentMode/backends/opencode/OpencodeBackend.ts`, `AgentModeChat` in `src/agentMode/ui/AgentModeChat.tsx`, and `buildPickerEntries()` in `src/agentMode/ui/agentModelPickerHelpers.ts`; then run Verification steps 1-4, including the blocked-endpoint path.

## Verification

1. Sign in to Plus, install OpenCode, throttle the models endpoint, reload Copilot, and immediately open Agent Chat.
2. Confirm **Loading Plus catalog…** appears and OpenCode does not start until the request settles.
3. Start on Claude or Codex and repeat. Confirm the active Agent remains usable and no session identity changes when the catalog settles.
4. Block the models endpoint and reload. Confirm OpenCode starts once without Plus and the status changes to **Starting opencode without Plus…**.
