### PR TITLE
[Live Plus catalog] - Step 1: Load one catalog per plugin lifecycle

### DIFF
--- a/src/LLMProviders/brevilabsClient.ts
+++ b/src/LLMProviders/brevilabsClient.ts
@@ -193,8 +193,11 @@ export interface UsageResponse {
 export interface BrevilabsModelEntry {
   id?: string;
   label?: string;
+  description?: string;
   /** Input context window as a display string: `1M`, `256K`. */
   context_length?: string;
+  supports_images?: boolean;
+  supports_reasoning?: boolean;
   /**
    * Thinking-effort levels this model distinguishes, ascending. Empty means the model
    * honors none of them. Absent from services older than the field, which is why the
@@ -485,11 +488,11 @@ export class BrevilabsClient {
   }
 
   /**
-   * The models host's public catalog. Unauthenticated, and the only place the context
-   * window of a Copilot Plus model is published, so the usage meter can size its ring.
+   * The models host's public catalog. Unauthenticated and authoritative for the
+   * current Plus lineup; it also supplies usage-meter capability metadata.
    *
-   * Returns null rather than throwing, for the same reason as {@link getUsage}: this
-   * feeds a gauge, and a gauge that cannot be drawn is not an error worth raising.
+   * Returns null rather than throwing so callers can represent network failure
+   * without turning it into plugin-startup failure.
    */
   async getModels(): Promise<BrevilabsModelsResponse | null> {
     try {

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -58,6 +58,11 @@ import { resetMiyoMutations } from "@/miyo/miyoResync";
 import { flushPersistence } from "@/services/settingsPersistence";
 import { isDesktopRuntime } from "@/utils/desktopRuntime";
 import { disposeNotificationSound } from "@/utils/notificationSound";
+import { KeychainService } from "@/services/keychainService";
+import { BrevilabsClient } from "@/LLMProviders/brevilabsClient";
+import * as modelManagement from "@/modelManagement";
+import * as settingsMigrations from "@/settings/migrations";
+import * as settingsModel from "@/settings/model";
 
 /**
  * Build a plugin instance without running Obsidian's `Plugin` constructor or
@@ -97,6 +102,66 @@ async function flushTeardown(): Promise<void> {
 
 describe("main", () => {
   describe("CopilotPlugin", () => {
+    describe("onload()", () => {
+      afterEach(() => {
+        jest.restoreAllMocks();
+      });
+
+      it("continues plugin startup while initial Plus registration runs in the background (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", async () => {
+        const plugin = Object.create(CopilotPlugin.prototype) as CopilotPlugin;
+        Object.assign(plugin, {
+          app: {},
+          manifest: { version: "test" },
+          loadSettings: jest.fn(async () => undefined),
+        });
+        let finishRegistration: () => void = () => undefined;
+        const registerPlusProvider = jest.fn(
+          () =>
+            new Promise((resolve) => {
+              finishRegistration = () =>
+                resolve({ providerId: "plus-1", configuredModelIds: [] as string[] });
+            })
+        );
+        const api = {
+          setup: {
+            copilotPlus: {
+              registerPlusProvider,
+              unregisterPlusProvider: jest.fn(async () => undefined),
+            },
+          },
+        } as unknown as modelManagement.ModelManagementApi;
+        jest.spyOn(KeychainService, "resetInstance").mockImplementation(() => undefined);
+        jest.spyOn(KeychainService, "getInstance").mockReturnValue({} as KeychainService);
+        jest.spyOn(BrevilabsClient, "getInstance").mockReturnValue({
+          setPluginVersion: jest.fn(),
+          getModels: jest.fn(async () => ({
+            data: [{ id: "live-plus", label: "Live Plus" }],
+          })),
+        } as unknown as BrevilabsClient);
+        jest.spyOn(modelManagement, "createModelManagement").mockReturnValue(api);
+        jest.spyOn(settingsModel, "getSettings").mockReturnValue({
+          isPaidUser: true,
+          plusLicenseKey: "hydrated-token",
+        } as ReturnType<typeof settingsModel.getSettings>);
+        jest.spyOn(settingsModel, "subscribeToSettingsChange").mockReturnValue(() => undefined);
+        const stopAfterSync = new Error("stop after startup continues");
+        const runMigrations = jest
+          .spyOn(settingsMigrations, "runSettingsMigrations")
+          .mockRejectedValue(stopAfterSync);
+
+        const loading = plugin.onload();
+        const startupResult = loading.catch((error: unknown) => error);
+        await new Promise((resolve) => window.setTimeout(resolve, 0));
+
+        expect(registerPlusProvider).toHaveBeenCalledTimes(1);
+        expect(runMigrations).toHaveBeenCalledWith(api);
+        await expect(startupResult).resolves.toBe(stopAfterSync);
+
+        finishRegistration();
+        await Promise.resolve();
+      });
+    });
+
     describe("onunload()", () => {
       beforeEach(() => {
         jest.clearAllMocks();

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,9 +35,10 @@ import { MessageRepository } from "@/core/MessageRepository";
 import { logError, logInfo, logWarn } from "@/logger";
 import { logFileManager } from "@/logFileManager";
 import {
+  createCopilotPlusSyncQueue,
   createModelManagement,
   plusSyncNeeded,
-  syncCopilotPlusProvider,
+  type CopilotPlusSyncQueue,
   type ModelManagementApi,
 } from "@/modelManagement";
 import { KeychainService } from "@/services/keychainService";
@@ -157,6 +158,8 @@ export default class CopilotPlugin extends Plugin {
   private planPreviewViewType?: typeof import("@/agentMode").PLAN_PREVIEW_VIEW_TYPE;
   private agentModelDiscoveryUnsubscriber?: () => void;
   modelManagement!: ModelManagementApi;
+  /** Live Plus catalog request queue owned by this plugin lifecycle. */
+  copilotPlusSync!: CopilotPlusSyncQueue;
   /** Frozen path-only facade available to Agent Mode's Obsidian CLI bridge. */
   symposiumAgentBridge?: Readonly<SymposiumAgentBridge>;
   /** Provider-credential-free channel available to the managed Agent Chat search skill. */
@@ -215,25 +218,22 @@ export default class CopilotPlugin extends Plugin {
     KeychainService.resetInstance();
     KeychainService.getInstance(this.app);
     await this.loadSettings();
+    // Initialize before the catalog queue starts so even its first background
+    // request carries the current plugin version.
+    this.brevilabsClient = BrevilabsClient.getInstance();
+    this.brevilabsClient.setPluginVersion(this.manifest.version);
     this.modelManagement = createModelManagement({
       app: this.app,
     });
     // Register/unregister the Copilot Plus provider (and its models) to match
     // Plus state, so Plus models surface in the chat + opencode pickers. The
     // license key is already hydrated from Keychain by the settings boundary.
-    // Idempotent, so the redundant initial call below + per-change calls are
-    // safe. Serialized through `plusSyncChain` so a fast
-    // sign-out→sign-in (each its own settings change) settles in issue order,
-    // not in whichever overlapping reconcile happens to finish last.
-    let plusSyncChain: Promise<void> = Promise.resolve();
-    const syncPlus = (isPaidUser: boolean | undefined, licenseKey: string): void => {
-      plusSyncChain = plusSyncChain.then(() =>
-        syncCopilotPlusProvider(this.modelManagement, !!isPaidUser, licenseKey)
-      );
-    };
-    // Initial reconcile: an already-signed-in user's `isPaidUser` is restored
-    // from disk without firing the subscription, so register on load.
-    syncPlus(getSettings().isPaidUser, getSettings().plusLicenseKey);
+    // The public catalog request runs once per plugin lifecycle. Later license
+    // changes reuse that result while provider writes follow the newest state,
+    // so a fast sign-out→sign-in cannot settle out of order.
+    const syncPlus = (this.copilotPlusSync = createCopilotPlusSyncQueue(this.modelManagement, () =>
+      this.brevilabsClient.getModels()
+    ));
     this.settingsUnsubscriber = subscribeToSettingsChange((prev, next) => {
       void (async () => {
         try {
@@ -250,10 +250,19 @@ export default class CopilotPlugin extends Plugin {
         }
         // Sign-in / sign-out (isPaidUser flip) or key rotation while signed in.
         if (plusSyncNeeded(prev, next)) {
-          syncPlus(next.isPaidUser, next.plusLicenseKey);
+          void syncPlus(!!next.isPaidUser, next.plusLicenseKey);
         }
       })();
     });
+    // Initial reconcile: an already-signed-in user's `isPaidUser` is restored
+    // from disk without firing the subscription. Start it before Agent Mode so
+    // a missing saved Plus model is identifiable as registration in progress.
+    // Plugin loading and non-OpenCode agents do not await this request; eligible
+    // OpenCode startup consumes the same promise through its preload gate.
+    // Keep the persistence subscriber above this call so first-time enrollment
+    // writes reach data.json.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/319
+    void syncPlus(!!getSettings().isPaidUser, getSettings().plusLicenseKey);
     // One-time settings migrations. Runs after the persist subscriber is wired
     // (so every mutation is saved) and after createModelManagement, and before
     // agent/model-discovery init below — so migrated BYOK providers are present
@@ -274,9 +283,6 @@ export default class CopilotPlugin extends Plugin {
     CustomCommandManager.getInstance(this.app);
     logFileManager.setApp(this.app);
 
-    // Initialize BrevilabsClient
-    this.brevilabsClient = BrevilabsClient.getInstance();
-    this.brevilabsClient.setPluginVersion(this.manifest.version);
     // Re-verify the cached entitlement token offline so the strict Plus and
     // self-host gates fail closed against an edited data.json until the
     // signature re-proves itself. The network re-validation below overrides

--- a/src/modelManagement/index.ts
+++ b/src/modelManagement/index.ts
@@ -93,8 +93,13 @@ export type { PlusSetupResult, RegisterPlusProviderInput } from "./setup/Copilot
 export {
   COPILOT_PLUS_DEFAULT_ENABLED_MODELS,
   COPILOT_PLUS_MODELS,
+  createCopilotPlusSyncQueue,
   plusSyncNeeded,
-  syncCopilotPlusProvider,
+} from "./setup/copilotPlusSync";
+export type {
+  CopilotPlusCatalogSnapshot,
+  CopilotPlusCatalogStatus,
+  CopilotPlusSyncQueue,
 } from "./setup/copilotPlusSync";
 
 // ---------------------------------------------------------------------------

--- a/src/modelManagement/setup/CopilotPlusSetupApi.test.ts
+++ b/src/modelManagement/setup/CopilotPlusSetupApi.test.ts
@@ -391,7 +391,7 @@ describe("CopilotPlusSetupApi.registerPlusProvider", () => {
     expect(row.info.displayName).toBe("Copilot Plus Flash 2");
   });
 
-  it("refreshes drifted capability fields (reasoning/modalities/toolCall) in place", async () => {
+  it("refreshes drifted capability fields in place (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", async () => {
     const h = makeHarness();
     // Existing model registered WITHOUT reasoning/modalities (an older snapshot).
     const first = await register(h, [{ id: "glm-5.2", displayName: "GLM-5.2", toolCall: false }]);
@@ -405,6 +405,7 @@ describe("CopilotPlusSetupApi.registerPlusProvider", () => {
         displayName: "GLM-5.2",
         toolCall: true,
         reasoning: true,
+        reasoningEfforts: ["low", "high"],
         modalities: { input: ["text"], output: ["text"] },
       },
     ]);
@@ -412,6 +413,7 @@ describe("CopilotPlusSetupApi.registerPlusProvider", () => {
     const row = h.models.getByWireId(first.providerId, "glm-5.2")!;
     expect(row.configuredModelId).toBe(idBefore); // no churn
     expect(row.info.reasoning).toBe(true);
+    expect(row.info.reasoningEfforts).toEqual(["low", "high"]);
     expect(row.info.toolCall).toBe(true);
     expect(row.info.modalities).toEqual({ input: ["text"], output: ["text"] });
   });

--- a/src/modelManagement/setup/CopilotPlusSetupApi.ts
+++ b/src/modelManagement/setup/CopilotPlusSetupApi.ts
@@ -12,10 +12,8 @@
  * `ModelManagementCoordinator`.
  *
  * Auto-enrollment targets the BYOK backends (`BYOK_DEFAULT_AUTO_ENROLL`:
- * Simple Chat + the OpenCode agent picker). `autoEnrollModelIds` narrows
- * *which* models enroll on first add: Plus passes just the default-on
- * subset (the flash model), so the rest of the lineup is created and shown
- * in the pickers but left off for the user to toggle on.
+ * Simple Chat + the OpenCode agent picker). Callers may use
+ * `autoEnrollModelIds` to narrow which newly discovered models enroll.
  */
 
 import type { ModelManagementCoordinator } from "@/modelManagement/createModelManagement";
@@ -45,9 +43,7 @@ export interface RegisterPlusProviderInput {
   /** Wire ids (`ModelInfo.id`) eligible for default auto-enrollment. When
    *  provided, only newly-added models whose id is in this set get enrolled
    *  into `autoEnrollIn`; the rest are added available-but-off. When omitted,
-   *  every newly-added (non-embedding) model is enrolled — the prior behavior.
-   *  Lets Plus curate a default-on subset (just the flash model today) while
-   *  still surfacing the full lineup in the pickers. */
+   *  every newly-added (non-embedding) model is enrolled. */
   autoEnrollModelIds?: readonly string[];
 }
 
@@ -202,11 +198,13 @@ export class CopilotPlusSetupApi {
       // re-synced too, otherwise an existing user keeps a stale snapshot and never
       // picks up newly-advertised capabilities (e.g. reasoning effort) on re-sign-in.
       // Plus models are server-curated, so there are no user overrides to clobber.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/319
       if (
         current.info.displayName !== info.displayName ||
         current.info.description !== info.description ||
         current.info.toolCall !== info.toolCall ||
         current.info.reasoning !== info.reasoning ||
+        JSON.stringify(current.info.reasoningEfforts) !== JSON.stringify(info.reasoningEfforts) ||
         JSON.stringify(current.info.modalities) !== JSON.stringify(info.modalities)
       ) {
         await this.#models.update(current.configuredModelId, {
@@ -215,6 +213,7 @@ export class CopilotPlusSetupApi {
             description: info.description,
             toolCall: info.toolCall,
             reasoning: info.reasoning,
+            reasoningEfforts: info.reasoningEfforts,
             modalities: info.modalities,
           },
         });

--- a/src/modelManagement/setup/copilotPlusCatalog.test.ts
+++ b/src/modelManagement/setup/copilotPlusCatalog.test.ts
@@ -1,0 +1,32 @@
+import { parseCopilotPlusContextLength } from "@/modelManagement/setup/copilotPlusCatalog";
+
+describe("copilotPlusCatalog", () => {
+  describe("parseCopilotPlusContextLength()", () => {
+    it.each([
+      ["1M", 1_048_576],
+      ["256K", 262_144],
+      ["192k", 196_608],
+      ["8192", 8_192],
+      [" 64 K ", 65_536],
+    ])(
+      "reads %s as %i tokens from the single server catalog (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)",
+      (display, tokens) => {
+        expect(parseCopilotPlusContextLength(display)).toBe(tokens);
+      }
+    );
+
+    it.each([
+      ["an unknown suffix", "1G"],
+      ["prose", "one million"],
+      ["a zero", "0"],
+      ["a negative", "-5K"],
+      ["a non-string", 200_000],
+      ["undefined", undefined],
+    ])(
+      "returns null for %s (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)",
+      (_label, display) => {
+        expect(parseCopilotPlusContextLength(display)).toBeNull();
+      }
+    );
+  });
+});

--- a/src/modelManagement/setup/copilotPlusCatalog.ts
+++ b/src/modelManagement/setup/copilotPlusCatalog.ts
@@ -1,0 +1,19 @@
+/**
+ * Parse the context-window label published by the Copilot Plus catalog.
+ *
+ * https://github.com/Brevilabs/obsidian-copilot-private/issues/319
+ *
+ * @param display - Server-provided token count such as `1M`, `256K`, or `8192`.
+ */
+export function parseCopilotPlusContextLength(display: unknown): number | null {
+  if (typeof display !== "string") return null;
+  const match = /^\s*([\d.]+)\s*([KMkm])?\s*$/.exec(display);
+  if (!match) return null;
+
+  const value = Number(match[1]);
+  if (!Number.isFinite(value) || value <= 0) return null;
+
+  const unit = match[2]?.toUpperCase();
+  const multiplier = unit === "M" ? 1024 * 1024 : unit === "K" ? 1024 : 1;
+  return Math.round(value * multiplier);
+}

--- a/src/modelManagement/setup/copilotPlusSync.test.ts
+++ b/src/modelManagement/setup/copilotPlusSync.test.ts
@@ -1,10 +1,9 @@
+import type { BrevilabsModelsResponse } from "@/LLMProviders/brevilabsClient";
 import type { ModelManagementApi } from "@/modelManagement/createModelManagement";
 import type { RegisterPlusProviderInput } from "@/modelManagement/setup/CopilotPlusSetupApi";
 import {
-  COPILOT_PLUS_DEFAULT_ENABLED_MODELS,
-  COPILOT_PLUS_MODELS,
+  createCopilotPlusSyncQueue,
   plusSyncNeeded,
-  syncCopilotPlusProvider,
 } from "@/modelManagement/setup/copilotPlusSync";
 
 jest.mock("@/logger", () => ({
@@ -25,37 +24,29 @@ function makeApi() {
   return { api, registerPlusProvider, unregisterPlusProvider };
 }
 
-describe("copilotPlusSync", () => {
-  it("defines the curated lineup and default-enabled models", () => {
-    expect(COPILOT_PLUS_MODELS.map((model) => model.id)).toEqual([
-      "copilot-plus-flash",
-      "kimi-k2.6",
-      "glm-5.2",
-      "kimi-k2.7-code",
-      "deepseek-v4-pro",
-      "deepseek-v4-flash-0731",
-      "mimo-v2.5",
-      "minimax-m2.7",
-    ]);
-    expect(COPILOT_PLUS_DEFAULT_ENABLED_MODELS).toEqual([
-      "copilot-plus-flash",
-      "deepseek-v4-pro",
-      "glm-5.2",
-    ]);
-  });
+const LIVE_RESPONSE: BrevilabsModelsResponse = {
+  data: [
+    {
+      id: "tomorrow-model",
+      label: "Tomorrow Model",
+      description: "Published by the live catalog.",
+      supports_images: true,
+      supports_reasoning: true,
+      reasoning_efforts: ["low", "high"],
+      context_length: "256K",
+    },
+  ],
+};
 
+describe("copilotPlusSync", () => {
   describe("plusSyncNeeded()", () => {
     const signedIn = { isPaidUser: true, plusLicenseKey: "lic-1" };
 
     it("stays false when a signed-in user's Reset Settings preserves the paid state (https://github.com/logancyang/obsidian-copilot-preview/issues/259)", () => {
-      // The reset write changes almost every field, but preserves both values
-      // this predicate reads — so the destructive unregister cascade (provider
-      // row, configured models, backend refs, provider keychain entry) must
-      // not fire.
       expect(plusSyncNeeded(signedIn, { ...signedIn })).toBe(false);
     });
 
-    it("fires on a genuine sign-out or sign-in (isPaidUser flip)", () => {
+    it("fires on a genuine sign-out or sign-in", () => {
       expect(plusSyncNeeded(signedIn, { isPaidUser: false, plusLicenseKey: "lic-1" })).toBe(true);
       expect(plusSyncNeeded({ isPaidUser: false, plusLicenseKey: "" }, signedIn)).toBe(true);
     });
@@ -71,58 +62,178 @@ describe("copilotPlusSync", () => {
     });
   });
 
-  describe("syncCopilotPlusProvider()", () => {
-    it("registers with the Keychain-hydrated token when signed in", async () => {
-      const { api, registerPlusProvider, unregisterPlusProvider } = makeApi();
-
-      await syncCopilotPlusProvider(api, true, "hydrated-token");
-
-      expect(unregisterPlusProvider).not.toHaveBeenCalled();
-      expect(registerPlusProvider).toHaveBeenCalledWith(
-        expect.objectContaining({
-          apiKey: "hydrated-token",
-          models: COPILOT_PLUS_MODELS,
-          autoEnrollModelIds: COPILOT_PLUS_DEFAULT_ENABLED_MODELS,
-        })
+  describe("createCopilotPlusSyncQueue()", () => {
+    it("publishes loading before the endpoint settles without blocking the caller (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", async () => {
+      const { api, registerPlusProvider } = makeApi();
+      let finishFetch: (response: BrevilabsModelsResponse | null) => void = () => undefined;
+      const fetchModels = jest.fn(
+        () =>
+          new Promise<BrevilabsModelsResponse | null>((resolve) => {
+            finishFetch = resolve;
+          })
       );
-    });
+      const syncPlus = createCopilotPlusSyncQueue(api, fetchModels);
+      const statuses: string[] = [];
+      syncPlus.subscribe(() => statuses.push(syncPlus.getSnapshot().status));
 
-    it("marks reasoning support for the models that expose an effort picker", () => {
-      const reasoningById = Object.fromEntries(
-        COPILOT_PLUS_MODELS.map((model) => [model.id, model.reasoning === true])
-      );
-      expect(reasoningById).toEqual({
-        "copilot-plus-flash": true,
-        "kimi-k2.6": false,
-        "glm-5.2": true,
-        "kimi-k2.7-code": true,
-        "deepseek-v4-pro": true,
-        "deepseek-v4-flash-0731": true,
-        "mimo-v2.5": true,
-        "minimax-m2.7": true,
+      const startup = syncPlus(true, "hydrated-token");
+
+      expect(syncPlus.getSnapshot()).toMatchObject({ status: "loading", models: [] });
+      expect(registerPlusProvider).not.toHaveBeenCalled();
+
+      await Promise.resolve();
+      finishFetch(LIVE_RESPONSE);
+      await startup;
+
+      expect(syncPlus.getSnapshot()).toEqual({
+        status: "ready",
+        models: [
+          {
+            id: "tomorrow-model",
+            displayName: "Tomorrow Model",
+            description: "Published by the live catalog.",
+            reasoning: true,
+            reasoningEfforts: ["low", "high"],
+            modalities: { input: ["text", "image"], output: ["text"] },
+            limits: { context: 262_144 },
+          },
+        ],
       });
+      expect(statuses).toEqual(["loading", "ready"]);
     });
 
-    it.each([
-      { isPaidUser: false, licenseKey: "hydrated-token" },
-      { isPaidUser: true, licenseKey: "" },
-    ])(
-      "unregisters when paid state or credential is missing",
-      async ({ isPaidUser, licenseKey }) => {
-        const { api, registerPlusProvider, unregisterPlusProvider } = makeApi();
+    it("publishes unavailable state when the endpoint cannot be reached (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", async () => {
+      const { api } = makeApi();
+      const syncPlus = createCopilotPlusSyncQueue(api, async () => null);
 
-        await syncCopilotPlusProvider(api, isPaidUser, licenseKey);
+      await syncPlus(true, "hydrated-token");
 
+      expect(syncPlus.getSnapshot()).toMatchObject({ status: "error", models: [] });
+    });
+
+    it("preserves an explicit empty effort list in the cached catalog (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", async () => {
+      const { api } = makeApi();
+      const syncPlus = createCopilotPlusSyncQueue(api, async () => ({
+        data: [
+          {
+            id: "no-effort-model",
+            label: "No Effort Model",
+            supports_reasoning: true,
+            reasoning_efforts: [],
+          },
+        ],
+      }));
+
+      await syncPlus(true, "hydrated-token");
+
+      expect(syncPlus.getSnapshot().models).toEqual([
+        expect.objectContaining({ reasoningEfforts: [] }),
+      ]);
+    });
+
+    it("leaves loading for unavailable after a bounded endpoint wait (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", async () => {
+      jest.useFakeTimers();
+      try {
+        const { api, registerPlusProvider } = makeApi();
+        const syncPlus = createCopilotPlusSyncQueue(api, () => new Promise(() => undefined));
+
+        const startup = syncPlus(true, "hydrated-token");
+        await jest.advanceTimersByTimeAsync(30_000);
+
+        await startup;
+        expect(syncPlus.getSnapshot()).toMatchObject({ status: "error", models: [] });
         expect(registerPlusProvider).not.toHaveBeenCalled();
-        expect(unregisterPlusProvider).toHaveBeenCalledTimes(1);
+      } finally {
+        jest.useRealTimers();
       }
-    );
+    });
 
-    it("contains background reconciliation failures", async () => {
+    it("rejects a malformed response without deleting cached models (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", async () => {
+      const { api, registerPlusProvider, unregisterPlusProvider } = makeApi();
+      const syncPlus = createCopilotPlusSyncQueue(api, async () => ({
+        data: [LIVE_RESPONSE.data![0], { label: "Missing id" }],
+      }));
+
+      await syncPlus(true, "hydrated-token");
+
+      expect(registerPlusProvider).not.toHaveBeenCalled();
+      expect(unregisterPlusProvider).not.toHaveBeenCalled();
+      expect(syncPlus.getSnapshot()).toMatchObject({ status: "error", models: [] });
+    });
+
+    it("contains provider reconciliation failures (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", async () => {
       const { api, registerPlusProvider } = makeApi();
       registerPlusProvider.mockRejectedValueOnce(new Error("boom"));
+      const syncPlus = createCopilotPlusSyncQueue(api, async () => LIVE_RESPONSE);
 
-      await expect(syncCopilotPlusProvider(api, true, "hydrated-token")).resolves.toBeUndefined();
+      await expect(syncPlus(true, "hydrated-token")).resolves.toBeUndefined();
+
+      expect(syncPlus.getSnapshot()).toMatchObject({ status: "error", models: [] });
+    });
+
+    it("fetches the server catalog once across lifecycle reconciliation changes (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", async () => {
+      const { api, registerPlusProvider, unregisterPlusProvider } = makeApi();
+      const fetchModels = jest.fn(async () => LIVE_RESPONSE);
+      const syncPlus = createCopilotPlusSyncQueue(api, fetchModels);
+
+      await syncPlus(true, "first-token");
+      await syncPlus(false, "");
+      await syncPlus(true, "rotated-token");
+
+      expect(fetchModels).toHaveBeenCalledTimes(1);
+      expect(unregisterPlusProvider).toHaveBeenCalledTimes(1);
+      expect(registerPlusProvider).toHaveBeenLastCalledWith(
+        expect.objectContaining({ apiKey: "rotated-token" })
+      );
+      expect(syncPlus.getSnapshot().status).toBe("ready");
+    });
+
+    it("waits for the newest reconciliation and resolves on catalog failure (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", async () => {
+      const { api } = makeApi();
+      let finishFetch: (response: BrevilabsModelsResponse | null) => void = () => undefined;
+      const syncPlus = createCopilotPlusSyncQueue(
+        api,
+        () =>
+          new Promise((resolve) => {
+            finishFetch = resolve;
+          })
+      );
+
+      void syncPlus(true, "first-token");
+      void syncPlus(true, "rotated-token");
+      const settled = syncPlus.waitForSettled();
+      await Promise.resolve();
+      finishFetch(null);
+
+      await expect(settled).resolves.toMatchObject({ status: "error", models: [] });
+    });
+
+    it("preserves lifecycle order and publishes only the newest queued request (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", async () => {
+      const { api, unregisterPlusProvider } = makeApi();
+      let finishFirst: (response: BrevilabsModelsResponse | null) => void = () => undefined;
+      const fetchModels = jest
+        .fn<Promise<BrevilabsModelsResponse | null>, []>()
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              finishFirst = resolve;
+            })
+        )
+        .mockResolvedValueOnce(LIVE_RESPONSE);
+      const syncPlus = createCopilotPlusSyncQueue(api, fetchModels);
+
+      const signIn = syncPlus(true, "hydrated-token");
+      const signOut = syncPlus(false, "");
+      await Promise.resolve();
+      finishFirst(LIVE_RESPONSE);
+      await signIn;
+
+      expect(syncPlus.getSnapshot().status).toBe("ready");
+      await signOut;
+
+      expect(unregisterPlusProvider).toHaveBeenCalledTimes(1);
+      expect(fetchModels).toHaveBeenCalledTimes(1);
+      expect(syncPlus.getSnapshot().status).toBe("ready");
     });
   });
 });

--- a/src/modelManagement/setup/copilotPlusSync.ts
+++ b/src/modelManagement/setup/copilotPlusSync.ts
@@ -1,37 +1,27 @@
 /**
- * Reconciles the Copilot Plus provider with the user's current Plus state.
+ * Keeps the Copilot Plus provider synchronized with the models service.
  *
- * Plus has no model-list endpoint, so the model set is a hardcoded snapshot
- * (`COPILOT_PLUS_MODELS`). `syncCopilotPlusProvider` is the single bridge the
- * plugin host calls on Plus sign-in / sign-out (and once on load): it
- * registers the Plus provider when signed in (with a key) and unregisters it
- * otherwise. Both `register`/`unregister` are idempotent, so calling this on
- * every relevant settings change is safe.
+ * The public `GET /models` response is the only catalog authority. Persisted
+ * configured-model rows are a cache used to build provider configuration; they
+ * are not evidence that a Plus model still exists on the relay.
  */
 
+import {
+  BrevilabsClient,
+  type BrevilabsModelEntry,
+  type BrevilabsModelsResponse,
+} from "@/LLMProviders/brevilabsClient";
 import { BREVILABS_MODELS_BASE_URL, ChatModels } from "@/constants";
-import { logError } from "@/logger";
+import { logError, logWarn } from "@/logger";
 import type { ModelManagementApi } from "@/modelManagement/createModelManagement";
+import { parseCopilotPlusContextLength } from "@/modelManagement/setup/copilotPlusCatalog";
 import type { ModelInfo } from "@/modelManagement/types/catalog";
 import type { CopilotSettings } from "@/settings/model";
 
-/**
- * The Copilot Plus models the brevilabs relay exposes. Hardcoded — there's no
- * relay catalog to fetch, so this mirrors the curated public lineup served by
- * `models.brevilabs.com/v1/models`. Wire ids must match what the relay accepts;
- * opencode routes them as `copilot-plus/<id>` (see `mapProviderToOpencodeId`).
- *
- * `COPILOT_PLUS_DEFAULT_ENABLED_MODELS` names the few enabled by default; the
- * rest ship available-but-off in the chat + opencode pickers for the user to
- * toggle on.
- *
- * `reasoning: true` marks the models the relay accepts an effort level for (it
- * matches the models service's `supports_reasoning`). The chat + agent pickers
- * read this (via `configuredModelToCustomModel` → `ModelCapability.REASONING`)
- * to surface the effort selector. These models do NOT reason unless the user
- * picks an effort, so flash stays fast by default. Kimi K2.6 (Azure) is the one
- * model without effort support, so it's left unflagged.
- */
+const EMPTY_MODELS: readonly ModelInfo[] = Object.freeze([]);
+const EMPTY_REASONING_EFFORTS: readonly string[] = Object.freeze([]);
+const CATALOG_TIMEOUT_MS = 30_000;
+
 export const COPILOT_PLUS_MODELS: readonly ModelInfo[] = Object.freeze([
   {
     id: ChatModels.COPILOT_PLUS_FLASH,
@@ -98,33 +88,112 @@ export const COPILOT_PLUS_MODELS: readonly ModelInfo[] = Object.freeze([
   },
 ]);
 
-/**
- * Wire ids auto-enrolled (toggled on) by default when the Plus provider is
- * registered. Everything else in `COPILOT_PLUS_MODELS` is added but left
- * unenrolled, so users opt into the extra models themselves. Passed to
- * `registerPlusProvider` as `autoEnrollModelIds`.
- *
- * Three models are enabled by default to give users immediate access to
- * representative capabilities: fastest responses (Flash), top-tier reasoning
- * (DeepSeek V4 Pro), and long-horizon frontier open model (GLM-5.2).
- */
 export const COPILOT_PLUS_DEFAULT_ENABLED_MODELS: readonly string[] = Object.freeze([
   ChatModels.COPILOT_PLUS_FLASH,
   ChatModels.COPILOT_PLUS_DEEPSEEK_V4_PRO,
   ChatModels.COPILOT_PLUS_GLM_5_2,
 ]);
 
+export type CopilotPlusCatalogStatus = "loading" | "ready" | "error";
+
+/** Immutable live-catalog state shared with picker and session consumers. */
+export interface CopilotPlusCatalogSnapshot {
+  status: CopilotPlusCatalogStatus;
+  models: readonly ModelInfo[];
+}
+
+export interface CopilotPlusSyncResult {
+  status: "ready" | "error";
+  models: readonly ModelInfo[];
+}
+
+export type CopilotPlusModelsFetcher = () => Promise<BrevilabsModelsResponse | null>;
+
+const LOADING_SNAPSHOT: CopilotPlusCatalogSnapshot = Object.freeze({
+  status: "loading",
+  models: EMPTY_MODELS,
+});
+const ERROR_RESULT: CopilotPlusSyncResult = Object.freeze({
+  status: "error",
+  models: EMPTY_MODELS,
+});
+
+function toModelInfo(entry: BrevilabsModelEntry): ModelInfo | null {
+  const id = entry.id?.trim();
+  if (!id) return null;
+
+  const model: ModelInfo = {
+    id,
+    displayName: entry.label?.trim() || id,
+    description: entry.description?.trim() || undefined,
+  };
+  if (typeof entry.supports_reasoning === "boolean") {
+    model.reasoning = entry.supports_reasoning;
+  }
+  // Keep the endpoint's ordered effort contract with the synchronized model,
+  // including an explicit empty list, so Agent startup never has to refetch it.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/319
+  if (Array.isArray(entry.reasoning_efforts)) {
+    const efforts = entry.reasoning_efforts
+      .filter((effort): effort is string => typeof effort === "string")
+      .map((effort) => effort.trim())
+      .filter((effort) => effort.length > 0);
+    if (entry.reasoning_efforts.length === 0) {
+      model.reasoningEfforts = EMPTY_REASONING_EFFORTS;
+    } else if (efforts.length > 0) {
+      model.reasoningEfforts = Object.freeze(efforts);
+    }
+  }
+  if (typeof entry.supports_images === "boolean") {
+    model.modalities = {
+      input: entry.supports_images === true ? ["text", "image"] : ["text"],
+      output: ["text"],
+    };
+  }
+  const context = parseCopilotPlusContextLength(entry.context_length);
+  // Context meters consume this same snapshot so they never start a second
+  // models-endpoint request after OpenCode starts.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/319
+  if (context !== null) model.limits = { context };
+  return model;
+}
+
+function readLiveModels(response: BrevilabsModelsResponse | null): readonly ModelInfo[] | null {
+  if (!Array.isArray(response?.data)) return null;
+  const models: ModelInfo[] = [];
+  const modelIds = new Set<string>();
+  for (const entry of response.data) {
+    const model = entry && typeof entry === "object" ? toModelInfo(entry) : null;
+    if (!model || modelIds.has(model.id)) return null;
+    modelIds.add(model.id);
+    models.push(model);
+  }
+  // An empty or malformed success must not erase cached provider rows. The
+  // next successful refresh can safely reconcile the authoritative catalog.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/319
+  if (models.length === 0) return null;
+  return Object.freeze(models);
+}
+
+async function fetchModelsWithDeadline(
+  fetchModels: CopilotPlusModelsFetcher
+): Promise<BrevilabsModelsResponse | null> {
+  // A request that never settles must become an actionable unavailable state,
+  // not leave a saved model disabled as Loading forever.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/319
+  let timeoutId: number | undefined;
+  const timeout = new Promise<null>((resolve) => {
+    timeoutId = window.setTimeout(() => resolve(null), CATALOG_TIMEOUT_MS);
+  });
+  try {
+    return await Promise.race([fetchModels(), timeout]);
+  } finally {
+    if (timeoutId !== undefined) window.clearTimeout(timeoutId);
+  }
+}
+
 /**
- * Whether a settings change requires re-reconciling the Plus provider:
- * a sign-in / sign-out (`isPaidUser` flip) or a key rotation while signed in.
- *
- * This is the settings subscriber's trigger, extracted so the one settings
- * write that must NOT read as sign-out is testable: Reset Settings preserves
- * `isPaidUser` alongside the license key, and this predicate staying false is
- * what keeps the destructive `unregisterPlusProvider` cascade (provider row,
- * configured models, backend refs, provider keychain entry) from firing on a
- * signed-in user's reset.
- * https://github.com/logancyang/obsidian-copilot-preview/issues/259
+ * Whether a settings change requires re-reconciling the Plus provider.
  *
  * @param prev - Settings before the change.
  * @param next - Settings after the change.
@@ -139,33 +208,121 @@ export function plusSyncNeeded(
   );
 }
 
+/** Callable serialized sync queue and observable live-catalog store. */
+export interface CopilotPlusSyncQueue {
+  (isPaidUser: boolean, licenseKey: string | undefined): Promise<void>;
+  getSnapshot(): CopilotPlusCatalogSnapshot;
+  subscribe(listener: () => void): () => void;
+  /** Wait for the newest provider reconciliation without rejecting on catalog failure. */
+  waitForSettled(): Promise<CopilotPlusCatalogSnapshot>;
+}
+
 /**
- * Register or unregister the Plus provider to match Plus state. Best-effort:
- * a failure is logged, not thrown, since this runs as background reconciliation
- * off a settings change.
+ * Build a per-plugin queue so Plus lifecycle changes reconcile in settings order.
  *
- * `licenseKey` is already hydrated from Obsidian Keychain by the settings
- * persistence boundary.
+ * @param api - Model-management instance owned by the current plugin lifecycle.
+ * @param fetchModels - Public models-endpoint reader.
  */
-export async function syncCopilotPlusProvider(
+export function createCopilotPlusSyncQueue(
   api: ModelManagementApi,
-  isPaidUser: boolean,
-  licenseKey: string | undefined
-): Promise<void> {
-  try {
-    if (isPaidUser && licenseKey) {
-      await api.setup.copilotPlus.registerPlusProvider({
-        providerType: "openai-compatible",
-        displayName: "Copilot",
-        baseUrl: BREVILABS_MODELS_BASE_URL,
-        apiKey: licenseKey,
-        models: COPILOT_PLUS_MODELS,
-        autoEnrollModelIds: COPILOT_PLUS_DEFAULT_ENABLED_MODELS,
-      });
-    } else {
-      await api.setup.copilotPlus.unregisterPlusProvider();
+  fetchModels: CopilotPlusModelsFetcher = () => BrevilabsClient.getInstance().getModels()
+): CopilotPlusSyncQueue {
+  let latestRequest = 0;
+  let snapshot: CopilotPlusCatalogSnapshot = LOADING_SNAPSHOT;
+  let catalogPromise: Promise<CopilotPlusSyncResult> | null = null;
+  let latestSync: Promise<void> = Promise.resolve();
+  const listeners = new Set<() => void>();
+
+  const publish = (next: CopilotPlusCatalogSnapshot): void => {
+    snapshot = next;
+    for (const listener of listeners) listener();
+  };
+
+  const loadCatalog = (): Promise<CopilotPlusSyncResult> => {
+    if (!catalogPromise) {
+      catalogPromise = fetchModelsWithDeadline(fetchModels)
+        .then((response) => {
+          const models = readLiveModels(response);
+          if (!models) {
+            logWarn("[modelManagement] Copilot Plus catalog unavailable");
+            return ERROR_RESULT;
+          }
+          return Object.freeze({ status: "ready" as const, models });
+        })
+        .catch((error) => {
+          logError("[modelManagement] Copilot Plus catalog fetch failed", error);
+          return ERROR_RESULT;
+        });
     }
-  } catch (err) {
-    logError("[modelManagement] Copilot Plus provider sync failed", err);
-  }
+    return catalogPromise;
+  };
+
+  const enqueue: CopilotPlusSyncQueue = (isPaidUser, licenseKey) => {
+    const request = ++latestRequest;
+    const isFirstRequest = catalogPromise === null;
+    const catalog = loadCatalog();
+    if (isFirstRequest) publish(LOADING_SNAPSHOT);
+    const previousSync = latestSync;
+
+    // Revocation cannot wait for the public catalog. Invalidating the request
+    // first also prevents an older sign-in, still waiting on the endpoint, from
+    // registering credentials after this sign-out.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/319
+    if (!isPaidUser || !licenseKey) {
+      latestSync = (async () => {
+        try {
+          await api.setup.copilotPlus.unregisterPlusProvider();
+          const result = await catalog;
+          if (request === latestRequest) publish(result);
+        } catch (error) {
+          logError("[modelManagement] Copilot Plus provider sync failed", error);
+          if (request === latestRequest) publish(ERROR_RESULT);
+        }
+      })();
+      return latestSync;
+    }
+
+    latestSync = (async () => {
+      // A preceding sign-out must finish before a newer key is registered. An
+      // older sign-in becomes a no-op after the request-number check below.
+      await previousSync.catch(() => undefined);
+      const result = await catalog;
+      if (request !== latestRequest) return;
+      if (result.status === "error") {
+        publish(result);
+        return;
+      }
+      try {
+        await api.setup.copilotPlus.registerPlusProvider({
+          providerType: "openai-compatible",
+          displayName: "Copilot",
+          baseUrl: BREVILABS_MODELS_BASE_URL,
+          apiKey: licenseKey,
+          models: result.models,
+        });
+        if (request === latestRequest) publish(result);
+      } catch (error) {
+        logError("[modelManagement] Copilot Plus provider sync failed", error);
+        if (request === latestRequest) publish(ERROR_RESULT);
+      }
+    })();
+    return latestSync;
+  };
+  enqueue.getSnapshot = () => snapshot;
+  enqueue.subscribe = (listener) => {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  };
+  enqueue.waitForSettled = async () => {
+    // Settings can change while the endpoint is pending. Follow the newest
+    // reconciliation so OpenCode never starts between an obsolete result and
+    // the current provider write.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/319
+    while (true) {
+      const pending = latestSync;
+      await pending.catch(() => undefined);
+      if (pending === latestSync) return snapshot;
+    }
+  };
+  return enqueue;
 }

--- a/src/modelManagement/types/catalog.ts
+++ b/src/modelManagement/types/catalog.ts
@@ -53,6 +53,8 @@ export interface ModelInfo {
   modalities?: { input?: string[]; output?: string[] };
   limits?: { context?: number; output?: number; input?: number };
   reasoning?: boolean;
+  /** Ordered reasoning-effort levels published by this model's catalog. */
+  reasoningEfforts?: readonly string[];
   toolCall?: boolean;
   /** True when the catalog `family` marks this as an embedding model. */
   isEmbedding?: boolean;


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#319

## Why

Copilot Plus model availability was split between a hardcoded client list, persisted configured-model rows, and ad hoc models-endpoint reads. A stale row could therefore survive after the service removed a model, while separate consumers could disagree about the current lineup.

## What

Each plugin lifecycle now owns one models-endpoint request and one observable catalog snapshot. A successful response reconciles the Plus provider and its persisted model metadata; malformed, empty, timed-out, or failed responses publish an error snapshot without erasing the last saved rows. Sign-in and sign-out writes remain serialized, and a plugin reload is the retry boundary.

## Non goal

This does not switch Chat, Settings, or Agent Mode pickers to the live snapshot, and it does not gate OpenCode startup. Those behaviors belong to later PRs in this stack.

## Screenshot

Not applicable. This PR establishes the catalog lifecycle and persistence boundary without changing rendered UI.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Catalog, reconciliation, timeout, malformed-response, and rapid license-change tests cover the new behavior |
| A defect would fail CI or be obvious on first use | ✅ | The deterministic lifecycle tests run in CI |
| A revert fully restores prior state, including persisted data | ❌ | A successful authoritative reconciliation can remove saved rows for models the server removed |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | License validation and credential destinations are unchanged; the catalog request is public |
| No public API, plugin API, message, or on-disk contract changes | ❌ | Persisted Plus model metadata now carries server-provided reasoning efforts and limits |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Plugin startup now owns a serialized one-shot catalog lifecycle |
| No hot-path behavior lacks deterministic coverage | ✅ | Success, timeout, malformed data, failure, and overlapping settings changes are covered |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | No behavior in this layer depends only on human verification |

Review: inspect `CopilotPlugin.onload()` in `src/main.ts`, `createCopilotPlusSyncQueue()` and `readLiveModels()` in `src/modelManagement/setup/copilotPlusSync.ts`, and Plus reconciliation in `CopilotPlusSetupApi` in `src/modelManagement/setup/CopilotPlusSetupApi.ts`; then run Verification steps 1-3, including the failed-response variant.

## Verification

1. Sign in to Plus, reload Copilot, and confirm the public models endpoint is requested once.
2. Change Plus settings and visit model-related surfaces without reloading. Confirm no second catalog request starts during the same plugin lifecycle.
3. Repeat with the endpoint blocked or returning malformed data. Confirm saved Plus rows are not erased and reloading the plugin starts a new request.
