### PR TITLE
[Live Plus catalog] - Step 2: Render models from the live catalog

### DIFF
--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -347,9 +347,8 @@ export default class ChatModelManager {
         // Reasoning is opt-in: forward the user's per-model effort pick only for
         // REASONING-capable models, and gate enableReasoning on an EXPLICIT effort.
         // Without an effort, ChatOpenRouter.invocationParams falls back to
-        // `reasoning: { max_tokens: 1024 }`, which would make the default-on
-        // copilot-plus-flash spend reasoning budget/latency despite being the fast
-        // default. So flash stays fast until the user picks an effort.
+        // `reasoning: { max_tokens: 1024 }`, which would spend reasoning
+        // budget/latency for a model the service published as fast by default.
         enableReasoning:
           (customModel.capabilities?.includes(ModelCapability.REASONING) ?? false) &&
           !!customModel.reasoningEffort,
@@ -691,9 +690,8 @@ export default class ChatModelManager {
     // lookup. Chat-backend (bridged) models live in the Provider/ConfiguredModel
     // registries and carry the full capability set derived from their
     // modalities/reasoning (`configuredModelToCustomModel`). A model whose wire id
-    // ALSO exists in legacy `settings.activeModels` — notably `copilot-plus-flash`,
-    // whose built-in entry advertises only VISION — would otherwise mask the
-    // bridged REASONING/VISION capabilities, so a capability check
+    // ALSO exists in legacy `settings.activeModels` would otherwise mask the
+    // bridged capability snapshot, so a capability check
     // (CopilotPlusChainRunner.hasCapability / isMultimodalModel) reads `false` and
     // reasoning/image content is dropped. The bridged model is the one actually
     // running, so it wins.

--- a/src/agentMode/ui/agentModelPickerHelpers.test.ts
+++ b/src/agentMode/ui/agentModelPickerHelpers.test.ts
@@ -215,7 +215,7 @@ function managerWithSonnet(): AgentSessionManager {
 // ---- buildPickerEntries ----
 
 describe("buildPickerEntries", () => {
-  it("previews the locked Copilot lineup above a routing agent's own models when unlicensed", () => {
+  it("previews the live locked Copilot lineup above a routing agent's own models when unlicensed (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", () => {
     const entry = makeModelEntry("catalog-model");
     const descriptor = {
       ...makeDescriptor("opencode"),
@@ -230,9 +230,13 @@ describe("buildPickerEntries", () => {
       getDefaultSelection: () => null,
     } as unknown as AgentSessionManager;
 
-    const { entries } = buildPickerEntries(manager, [descriptor], {} as ModelActiveContext, {
-      ...emptySettings,
-    });
+    const { entries } = buildPickerEntries(
+      manager,
+      [descriptor],
+      {} as ModelActiveContext,
+      { ...emptySettings },
+      [{ id: "tomorrow-model", displayName: "Tomorrow Model" }]
+    );
 
     const locked = entries.filter((model) => model._needsLicense);
     expect(locked.length).toBeGreaterThan(0);

--- a/src/agentMode/ui/agentModelPickerHelpers.ts
+++ b/src/agentMode/ui/agentModelPickerHelpers.ts
@@ -2,7 +2,11 @@ import { Notice } from "obsidian";
 import { logError } from "@/logger";
 import type { ModelCapability } from "@/constants";
 import type { ModelSelectorEntry } from "@/components/ui/ModelSelector";
-import { lockedCopilotEntries, shouldPreviewCopilotModels } from "@/lib/lockedCopilotEntries";
+import {
+  type CopilotPlusCatalogModel,
+  lockedCopilotEntries,
+  shouldPreviewCopilotModels,
+} from "@/lib/lockedCopilotEntries";
 import type { AgentSession } from "@/agentMode/session/AgentSession";
 import type { AgentChatUIState } from "@/agentMode/session/AgentChatUIState";
 import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
@@ -24,6 +28,7 @@ import type { AgentModelPickerOverride } from "./useAgentModelPicker";
 
 /** Frozen empty effort list — referential stability for the "no effort" case. */
 export const EMPTY_EFFORT_OPTIONS = Object.freeze([]) as unknown as EffortOption[];
+const EMPTY_PLUS_MODELS: readonly CopilotPlusCatalogModel[] = Object.freeze([]);
 
 /**
  * Right-side flag for an enabled model whose provider has no API key. Shared
@@ -312,7 +317,8 @@ export function buildPickerEntries(
   manager: AgentSessionManager,
   descriptors: BackendDescriptor[],
   ctx: ModelActiveContext,
-  settings: CopilotSettings
+  settings: CopilotSettings,
+  copilotPlusModels: readonly CopilotPlusCatalogModel[] = EMPTY_PLUS_MODELS
 ): { entries: ModelSelectorEntry[]; valueKey: string } {
   const entries: ModelSelectorEntry[] = [];
   for (const descriptor of descriptors) {
@@ -376,11 +382,15 @@ export function buildPickerEntries(
     // above so neither relabels these rows: an unset-up agent's readiness reason
     // would replace "Copilot license required" with the wrong fix, and the
     // emptiness check for the loading/error placeholder must not count them.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/319
     if (descriptor.routesCopilotModels && shouldPreviewCopilotModels(settings.providers)) {
       entries.splice(
         sectionStart,
         0,
-        ...lockedCopilotEntries({ group: descriptor.displayName, backendId: descriptor.id })
+        ...lockedCopilotEntries(copilotPlusModels, {
+          group: descriptor.displayName,
+          backendId: descriptor.id,
+        })
       );
     }
   }
@@ -633,11 +643,18 @@ export function buildAgentModelPicker(args: {
   manager: AgentSessionManager | null;
   descriptors: BackendDescriptor[];
   settings: CopilotSettings;
+  copilotPlusModels?: readonly CopilotPlusCatalogModel[];
 }): AgentModelPickerOverride | null {
-  const { manager, descriptors, settings } = args;
+  const { manager, descriptors, settings, copilotPlusModels = EMPTY_PLUS_MODELS } = args;
   if (!manager) return null;
   const ctx = collectModelActiveContext(manager);
-  const { entries, valueKey } = buildPickerEntries(manager, descriptors, ctx, settings);
+  const { entries, valueKey } = buildPickerEntries(
+    manager,
+    descriptors,
+    ctx,
+    settings,
+    copilotPlusModels
+  );
   const onChange = buildModelOnChange(manager, ctx, entries);
   return {
     models: entries,

--- a/src/agentMode/ui/useAgentModelPicker.ts
+++ b/src/agentMode/ui/useAgentModelPicker.ts
@@ -9,6 +9,7 @@ import { useBackendInstallStates } from "@/agentMode/ui/useBackendDescriptor";
 import { buildAgentModelPicker } from "./agentModelPickerHelpers";
 import { useManagerSubscribe } from "./useManagerSubscribe";
 import type CopilotPlugin from "@/main";
+import { useCopilotPlusCatalog } from "@/contexts/useCopilotPlusCatalog";
 
 export interface AgentModelPickerOverride {
   models: ModelSelectorEntry[];
@@ -97,12 +98,18 @@ export function useAgentModelPicker(
   // The registry is static, so the descriptor list is a stable module constant.
   const descriptors = useMemo(() => listBackendDescriptors(), []);
   const installStates = useBackendInstallStates(plugin);
+  const copilotPlusCatalog = useCopilotPlusCatalog(plugin);
   const signal = useAgentModelSignal(manager, descriptors);
   return useMemo(() => {
     // These are memo invalidators: the builder reads the manager and
     // descriptors directly after either external store reports a change.
     void signal;
     void installStates;
-    return buildAgentModelPicker({ manager, descriptors, settings });
-  }, [manager, descriptors, settings, signal, installStates]);
+    return buildAgentModelPicker({
+      manager,
+      descriptors,
+      settings,
+      copilotPlusModels: copilotPlusCatalog.models,
+    });
+  }, [manager, descriptors, settings, signal, installStates, copilotPlusCatalog]);
 }

--- a/src/components/chat-components/useChatModelPicker.ts
+++ b/src/components/chat-components/useChatModelPicker.ts
@@ -7,6 +7,8 @@ import {
 } from "@/modelManagement";
 import { getModelKeyFromModel, settingsStore, useSettingsValue } from "@/settings/model";
 import type { ModelSelectorEntry } from "@/components/ui/ModelSelector";
+import { usePlugin } from "@/contexts/PluginContext";
+import { useCopilotPlusCatalog } from "@/contexts/useCopilotPlusCatalog";
 import { lockedCopilotEntries, shouldPreviewCopilotModels } from "@/lib/lockedCopilotEntries";
 import { useAtomValue } from "jotai";
 import React from "react";
@@ -57,6 +59,8 @@ export function useChatModelPicker(params: {
   onChange: (configuredModelId: string) => void;
 }): ChatModelPickerOverride {
   const { value, onChange } = params;
+  const plugin = usePlugin();
+  const copilotPlusCatalog = useCopilotPlusCatalog(plugin);
   const entries = useAtomValue(backendPickerAtomFamily("chat"), { store: settingsStore });
   const settings = useSettingsValue();
 
@@ -64,8 +68,10 @@ export function useChatModelPicker(params: {
   // fallback, and the stored value can never resolve to one.
   const lockedRows = React.useMemo(
     () =>
-      shouldPreviewCopilotModels(settings.providers) ? lockedCopilotEntries() : EMPTY_LOCKED_ROWS,
-    [settings.providers]
+      shouldPreviewCopilotModels(settings.providers)
+        ? lockedCopilotEntries(copilotPlusCatalog.models)
+        : EMPTY_LOCKED_ROWS,
+    [settings.providers, copilotPlusCatalog.models]
   );
 
   const { models, byModelKey, idToModelKey } = React.useMemo(() => {
@@ -75,6 +81,15 @@ export function useChatModelPicker(params: {
     for (const entry of entries) {
       if (entry.state !== "ok") continue;
       const { configuredModel, provider, configuredModelId } = entry;
+      const isCurrentPlusModel =
+        provider.origin.kind !== "copilot-plus" ||
+        (copilotPlusCatalog.status === "ready" &&
+          copilotPlusCatalog.models.some((model) => model.id === configuredModel.info.id));
+      // A persisted Plus row can preserve the user's selected label offline,
+      // but it cannot declare current catalog membership. Hide every other
+      // stale row until this lifecycle's endpoint authorizes its exact id.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/319
+      if (!isCurrentPlusModel && configuredModelId !== value) continue;
       // Leave capabilities `undefined` when the snapshot carries no modality
       // data so unknown models stay unblocked; only a populated array (which may
       // be empty) asserts "known". See the image guard in `Chat.tsx`.
@@ -86,7 +101,13 @@ export function useChatModelPicker(params: {
         displayName: configuredModel.info.displayName || configuredModel.info.id,
         enabled: true,
         capabilities,
-        _disabledReason: needsKey ? "Add API key" : undefined,
+        _disabledReason: !isCurrentPlusModel
+          ? copilotPlusCatalog.status === "loading"
+            ? "Loading…"
+            : "Unavailable"
+          : needsKey
+            ? "Add API key"
+            : undefined,
         _needsSelfHostWarning: entry.needsSelfHostWarning,
       };
       const modelKey = getModelKeyFromModel(modelEntry);
@@ -95,7 +116,7 @@ export function useChatModelPicker(params: {
       idToModelKey.set(configuredModelId, modelKey);
     }
     return { models, byModelKey, idToModelKey };
-  }, [entries]);
+  }, [entries, value, copilotPlusCatalog]);
 
   const resolvedValue = React.useMemo(() => {
     const resolvedId = resolveChatModelSelectionId(entries, value);

--- a/src/components/modals/CopilotPlusWelcomeModal.stories.tsx
+++ b/src/components/modals/CopilotPlusWelcomeModal.stories.tsx
@@ -8,6 +8,7 @@ const meta = {
   title: "Modals/Copilot Welcome",
   component: CopilotPlusWelcomeModalContent,
   args: {
+    modelName: "Tomorrow Model",
     onConfirm: () => undefined,
     onCancel: () => undefined,
   },

--- a/src/components/modals/CopilotPlusWelcomeModal.test.tsx
+++ b/src/components/modals/CopilotPlusWelcomeModal.test.tsx
@@ -4,15 +4,24 @@ import React from "react";
 
 describe("CopilotPlusWelcomeModal", () => {
   describe("CopilotPlusWelcomeModalContent()", () => {
-    it("names the model it is offering to make the default", () => {
-      render(<CopilotPlusWelcomeModalContent onConfirm={jest.fn()} onCancel={jest.fn()} />);
+    const renderContent = (onConfirm = jest.fn(), onCancel = jest.fn()) =>
+      render(
+        <CopilotPlusWelcomeModalContent
+          modelName="Tomorrow Model"
+          onConfirm={onConfirm}
+          onCancel={onCancel}
+        />
+      );
 
-      expect(screen.getByText("copilot-plus-flash")).toBeTruthy();
+    it("names the server-selected model it is offering to make the default (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", () => {
+      renderContent();
+
+      expect(screen.getByText("Tomorrow Model")).toBeTruthy();
       expect(screen.getByText(/default model for chat and your agents/)).toBeTruthy();
     });
 
     it("names what the license includes, including the symposium link", () => {
-      render(<CopilotPlusWelcomeModalContent onConfirm={jest.fn()} onCancel={jest.fn()} />);
+      renderContent();
 
       const link = screen.getByRole("link", { name: "symposium.md" });
       expect(link.getAttribute("href")).toBe("https://symposium.md");
@@ -21,9 +30,7 @@ describe("CopilotPlusWelcomeModal", () => {
     });
 
     it("promises no capability a lower paid tier may not have", () => {
-      const { container } = render(
-        <CopilotPlusWelcomeModalContent onConfirm={jest.fn()} onCancel={jest.fn()} />
-      );
+      const { container } = renderContent();
 
       // Multi-agent is tier >= Plus (see `canUseMultiAgent`), so a Lite user
       // opening this modal must not be told they have it. Same for a blanket
@@ -32,9 +39,7 @@ describe("CopilotPlusWelcomeModal", () => {
     });
 
     it("offers to apply no mode, no embedding model, and no vault rebuild", () => {
-      const { container } = render(
-        <CopilotPlusWelcomeModalContent onConfirm={jest.fn()} onCancel={jest.fn()} />
-      );
+      const { container } = renderContent();
 
       // The settings this used to apply, by the labels it applied them under —
       // "embedding models" still appears in the feature list, which is true and
@@ -46,7 +51,7 @@ describe("CopilotPlusWelcomeModal", () => {
     it("confirms on Apply Now and declines on Apply Later, never both", () => {
       const onConfirm = jest.fn();
       const onCancel = jest.fn();
-      render(<CopilotPlusWelcomeModalContent onConfirm={onConfirm} onCancel={onCancel} />);
+      renderContent(onConfirm, onCancel);
 
       fireEvent.click(screen.getByRole("button", { name: "Apply Now" }));
       expect(onConfirm).toHaveBeenCalledTimes(1);

--- a/src/components/modals/CopilotPlusWelcomeModal.tsx
+++ b/src/components/modals/CopilotPlusWelcomeModal.tsx
@@ -4,17 +4,19 @@ import { Root } from "react-dom/client";
 import { Button } from "@/components/ui/button";
 import { createPluginRoot } from "@/utils/react/createPluginRoot";
 import { logError } from "@/logger";
-import { DEFAULT_COPILOT_PLUS_CHAT_MODEL, applyLicenseSettings } from "@/plusUtils";
+import { applyLicenseSettings } from "@/plusUtils";
 
 export interface CopilotPlusWelcomeModalContentProps {
   onConfirm: () => void;
   onCancel: () => void;
+  modelName: string;
 }
 
 /** Body of {@link CopilotPlusWelcomeModal}, exported prop-driven so the gallery can render it. */
 export function CopilotPlusWelcomeModalContent({
   onConfirm,
   onCancel,
+  modelName,
 }: CopilotPlusWelcomeModalContentProps) {
   return (
     <div className="tw-flex tw-flex-col tw-gap-4">
@@ -25,9 +27,8 @@ export function CopilotPlusWelcomeModalContent({
           much more!
         </p>
         <p>
-          Would you like to make <b className="tw-text-accent">{DEFAULT_COPILOT_PLUS_CHAT_MODEL}</b>{" "}
-          the default model for chat and your agents now? You can always change this later in
-          Settings.
+          Would you like to make <b className="tw-text-accent">{modelName}</b> the default model for
+          chat and your agents now? You can always change this later in Settings.
         </p>
       </div>
       <div className="tw-flex tw-w-full tw-justify-end tw-gap-2">
@@ -42,11 +43,16 @@ export function CopilotPlusWelcomeModalContent({
   );
 }
 
+/** Hosts the post-license default offer for one server-selected Plus model. */
 export class CopilotPlusWelcomeModal extends Modal {
   private root: Root;
+  private readonly modelId: string;
+  private readonly modelName: string;
 
-  constructor(app: App) {
+  constructor(app: App, modelId: string, modelName: string) {
     super(app);
+    this.modelId = modelId;
+    this.modelName = modelName;
     // https://docs.obsidian.md/Reference/TypeScript+API/Modal/setTitle
     // @ts-ignore
     this.setTitle("Welcome to Copilot 🚀");
@@ -57,7 +63,7 @@ export class CopilotPlusWelcomeModal extends Modal {
     this.root = createPluginRoot(contentEl, this.app);
 
     const handleConfirm = () => {
-      void applyLicenseSettings().catch((error) =>
+      void applyLicenseSettings(this.modelId).catch((error) =>
         logError("Failed to apply the licensed default model", error)
       );
       this.close();
@@ -68,7 +74,11 @@ export class CopilotPlusWelcomeModal extends Modal {
     };
 
     this.root.render(
-      <CopilotPlusWelcomeModalContent onConfirm={handleConfirm} onCancel={handleCancel} />
+      <CopilotPlusWelcomeModalContent
+        modelName={this.modelName}
+        onConfirm={handleConfirm}
+        onCancel={handleCancel}
+      />
     );
   }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -246,15 +246,6 @@ export const DEFAULT_MODEL_SETTING = {
 export const DEFAULT_OLLAMA_NUM_CTX = 131072;
 
 export enum ChatModels {
-  COPILOT_PLUS_FLASH = "copilot-plus-flash",
-  // Additional Copilot Plus relay models (served via the brevilabs proxy).
-  COPILOT_PLUS_KIMI_K2_6 = "kimi-k2.6",
-  COPILOT_PLUS_GLM_5_2 = "glm-5.2",
-  COPILOT_PLUS_KIMI_K2_7_CODE = "kimi-k2.7-code",
-  COPILOT_PLUS_DEEPSEEK_V4_PRO = "deepseek-v4-pro",
-  COPILOT_PLUS_DEEPSEEK_V4_FLASH_0731 = "deepseek-v4-flash-0731",
-  COPILOT_PLUS_MIMO_V2_5 = "mimo-v2.5",
-  COPILOT_PLUS_MINIMAX_M2_7 = "minimax-m2.7",
   GPT_5_5 = "gpt-5.5",
   GPT_5_4_mini = "gpt-5.4-mini",
   GPT_41 = "gpt-4.1",
@@ -316,15 +307,6 @@ export const MODEL_CAPABILITIES: Record<ModelCapability, string> = {
 
 export const BUILTIN_CHAT_MODELS: CustomModel[] = [
   // Enabled models first
-  {
-    name: ChatModels.COPILOT_PLUS_FLASH,
-    provider: ChatModelProviders.COPILOT_PLUS,
-    enabled: true,
-    isBuiltIn: true,
-    core: true,
-    plusExclusive: true,
-    capabilities: [ModelCapability.VISION],
-  },
   {
     name: ChatModels.OPENROUTER_GEMINI_2_5_FLASH,
     provider: ChatModelProviders.OPENROUTERAI,

--- a/src/contexts/useCopilotPlusCatalog.test.tsx
+++ b/src/contexts/useCopilotPlusCatalog.test.tsx
@@ -1,0 +1,45 @@
+import { act, renderHook } from "@testing-library/react";
+import type CopilotPlugin from "@/main";
+import type { CopilotPlusCatalogSnapshot, CopilotPlusSyncQueue } from "@/modelManagement";
+import { useCopilotPlusCatalog } from "@/contexts/useCopilotPlusCatalog";
+
+describe("useCopilotPlusCatalog", () => {
+  describe("useCopilotPlusCatalog()", () => {
+    it("rerenders when the current plugin lifecycle publishes its endpoint result (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", () => {
+      let snapshot: CopilotPlusCatalogSnapshot = { status: "loading", models: [] };
+      let listener: (() => void) | null = null;
+      const queue = Object.assign(jest.fn(), {
+        getSnapshot: () => snapshot,
+        subscribe: (next: () => void) => {
+          listener = next;
+          return () => {
+            listener = null;
+          };
+        },
+      }) as unknown as CopilotPlusSyncQueue;
+      const plugin = { copilotPlusSync: queue } as CopilotPlugin;
+
+      const { result } = renderHook(() => useCopilotPlusCatalog(plugin));
+      expect(result.current.status).toBe("loading");
+
+      snapshot = {
+        status: "ready",
+        models: [{ id: "tomorrow-model", displayName: "Tomorrow Model" }],
+      };
+      act(() => listener?.());
+
+      expect(result.current).toEqual(snapshot);
+    });
+
+    it("returns one stable unavailable snapshot when no lifecycle queue exists", () => {
+      const plugin = {} as CopilotPlugin;
+      const { result, rerender } = renderHook(() => useCopilotPlusCatalog(plugin));
+      const first = result.current;
+
+      rerender();
+
+      expect(result.current).toBe(first);
+      expect(result.current).toMatchObject({ status: "error", models: [] });
+    });
+  });
+});

--- a/src/contexts/useCopilotPlusCatalog.ts
+++ b/src/contexts/useCopilotPlusCatalog.ts
@@ -1,0 +1,27 @@
+import type CopilotPlugin from "@/main";
+import { useCallback, useSyncExternalStore } from "react";
+
+type CopilotPlusCatalogSnapshot = ReturnType<CopilotPlugin["copilotPlusSync"]["getSnapshot"]>;
+
+const EMPTY_MODELS = Object.freeze([]);
+const UNAVAILABLE_SNAPSHOT: CopilotPlusCatalogSnapshot = Object.freeze({
+  status: "error",
+  models: EMPTY_MODELS,
+});
+
+/**
+ * Subscribe React surfaces to the current plugin lifecycle's live Plus catalog.
+ * Tests and pre-onload renderers without a queue receive a stable unavailable
+ * snapshot instead of accidentally reading persisted models as live state.
+ *
+ * @param plugin - Plugin lifecycle that owns the catalog request queue.
+ */
+export function useCopilotPlusCatalog(plugin: CopilotPlugin): CopilotPlusCatalogSnapshot {
+  const queue = plugin.copilotPlusSync;
+  const subscribe = useCallback(
+    (listener: () => void) => queue?.subscribe(listener) ?? (() => undefined),
+    [queue]
+  );
+  const getSnapshot = useCallback(() => queue?.getSnapshot() ?? UNAVAILABLE_SNAPSHOT, [queue]);
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}

--- a/src/lib/lockedCopilotEntries.test.ts
+++ b/src/lib/lockedCopilotEntries.test.ts
@@ -1,5 +1,9 @@
-import { COPILOT_PLUS_DEFAULT_ENABLED_MODELS, COPILOT_PLUS_MODELS } from "@/modelManagement";
-import { lockedCopilotEntries, shouldPreviewCopilotModels } from "./lockedCopilotEntries";
+import type { ModelInfo } from "@/modelManagement";
+import {
+  findCopilotPlusModel,
+  lockedCopilotEntries,
+  shouldPreviewCopilotModels,
+} from "./lockedCopilotEntries";
 
 import type { CopilotSettings } from "@/settings/model";
 
@@ -7,7 +11,25 @@ function providerRows(providers: Record<string, unknown>): CopilotSettings["prov
   return providers as unknown as CopilotSettings["providers"];
 }
 
+const LIVE_MODELS: readonly ModelInfo[] = Object.freeze([
+  { id: "tomorrow-one", displayName: "Tomorrow One", description: "First live model" },
+  { id: "tomorrow-two", displayName: "Tomorrow Two", description: "Second live model" },
+  { id: "tomorrow-three", displayName: "Tomorrow Three" },
+  { id: "tomorrow-four", displayName: "Tomorrow Four" },
+]);
+
 describe("lockedCopilotEntries", () => {
+  describe("findCopilotPlusModel()", () => {
+    it("resolves raw and agent-routed Plus ids without matching unrelated models (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", () => {
+      expect(findCopilotPlusModel("tomorrow-one", LIVE_MODELS)?.displayName).toBe("Tomorrow One");
+      expect(findCopilotPlusModel("copilot-plus/tomorrow-one", LIVE_MODELS)?.displayName).toBe(
+        "Tomorrow One"
+      );
+      expect(findCopilotPlusModel("openai/tomorrow-one-like", LIVE_MODELS)).toBeUndefined();
+      expect(findCopilotPlusModel("openrouter/tomorrow-one", LIVE_MODELS)).toBeUndefined();
+    });
+  });
+
   describe("shouldPreviewCopilotModels()", () => {
     it("previews when no Copilot provider is registered", () => {
       expect(shouldPreviewCopilotModels(providerRows({}))).toBe(true);
@@ -30,21 +52,17 @@ describe("lockedCopilotEntries", () => {
   });
 
   describe("lockedCopilotEntries()", () => {
-    it("previews exactly the models a license switches on, in lineup order", () => {
-      const previewed = lockedCopilotEntries().map((entry) => entry.name);
+    it("previews the first three live endpoint models in server order (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", () => {
+      const previewed = lockedCopilotEntries(LIVE_MODELS).map((entry) => entry.name);
 
-      expect(previewed).toEqual(
-        COPILOT_PLUS_MODELS.filter((model) =>
-          COPILOT_PLUS_DEFAULT_ENABLED_MODELS.includes(model.id)
-        ).map((model) => model.id)
-      );
+      expect(previewed).toEqual(["tomorrow-one", "tomorrow-two", "tomorrow-three"]);
       // The cap is the point: a full lineup would push the user's own models
       // past the fold of a 288px picker.
-      expect(previewed.length).toBeLessThan(COPILOT_PLUS_MODELS.length);
+      expect(previewed.length).toBeLessThan(LIVE_MODELS.length);
     });
 
     it("marks every row as needing a license and as non-selectable", () => {
-      const entries = lockedCopilotEntries();
+      const entries = lockedCopilotEntries(LIVE_MODELS);
 
       expect(entries.length).toBeGreaterThan(0);
       for (const entry of entries) {
@@ -56,16 +74,19 @@ describe("lockedCopilotEntries", () => {
     });
 
     it("carries each model's display name and description so the row says what it is for", () => {
-      const flash = lockedCopilotEntries()[0];
-      const source = COPILOT_PLUS_MODELS.find((model) => model.id === flash.name);
+      const first = lockedCopilotEntries(LIVE_MODELS)[0];
+      const source = LIVE_MODELS.find((model) => model.id === first.name);
 
-      expect(flash.displayName).toBe(source?.displayName);
-      expect(flash._subtitle).toBe(source?.description);
+      expect(first.displayName).toBe(source?.displayName);
+      expect(first._subtitle).toBe(source?.description);
     });
 
     it("files rows under a group and backend when one is given, and leaves them flat otherwise", () => {
-      const grouped = lockedCopilotEntries({ group: "OpenCode", backendId: "opencode" });
-      const flat = lockedCopilotEntries();
+      const grouped = lockedCopilotEntries(LIVE_MODELS, {
+        group: "OpenCode",
+        backendId: "opencode",
+      });
+      const flat = lockedCopilotEntries(LIVE_MODELS);
 
       expect(grouped.every((entry) => entry._group === "OpenCode")).toBe(true);
       expect(grouped.every((entry) => entry._backendId === "opencode")).toBe(true);

--- a/src/lib/lockedCopilotEntries.ts
+++ b/src/lib/lockedCopilotEntries.ts
@@ -1,25 +1,33 @@
 import type { ModelSelectorEntry } from "@/components/ui/ModelSelector";
 import { ChatModelProviders } from "@/constants";
+import type { ModelInfo } from "@/modelManagement";
 import type { CopilotSettings } from "@/settings/model";
-import { COPILOT_PLUS_DEFAULT_ENABLED_MODELS, COPILOT_PLUS_MODELS } from "@/modelManagement";
 
 /** See AGENTS.md → "Referential stability". */
 const EMPTY_ENTRIES: readonly ModelSelectorEntry[] = Object.freeze([]);
 
 const LICENSE_REQUIRED = "Copilot license required";
+const MAX_PREVIEWED_MODELS = 3;
+
+/** Display metadata every live Plus picker surface consumes. */
+export type CopilotPlusCatalogModel = Pick<ModelInfo, "id" | "displayName" | "description">;
 
 /**
- * The lineup previewed to a user without a license: exactly the models a
- * license switches on, so the preview and the outcome match — activate, and
- * these three rows lose their locks in place rather than being replaced by a
- * different set.
+ * Resolve a Copilot Plus catalog row from either its raw id or an agent wire id.
+ * Returns the existing catalog object so callers do not allocate display
+ * metadata while rebuilding a picker.
  *
- * Showing all eight would bury the user's own models: the picker is 288px tall,
- * so a full lineup pushes the checkmark on their current model below the fold.
+ * @param wireModelId - Raw Plus id or an agent-prefixed wire id.
  */
-const PREVIEWED_MODELS = COPILOT_PLUS_MODELS.filter((model) =>
-  COPILOT_PLUS_DEFAULT_ENABLED_MODELS.includes(model.id)
-);
+export function findCopilotPlusModel(
+  wireModelId: string,
+  models: readonly CopilotPlusCatalogModel[]
+) {
+  return models.find(
+    (model) =>
+      wireModelId === model.id || wireModelId === `${ChatModelProviders.COPILOT_PLUS}/${model.id}`
+  );
+}
 
 /**
  * Whether a surface should advertise the lineup — true exactly when no Copilot
@@ -56,10 +64,13 @@ export function shouldPreviewCopilotModels(providers: CopilotSettings["providers
  *   keys distinct when several agents each preview the same model.
  */
 export function lockedCopilotEntries(
+  models: readonly CopilotPlusCatalogModel[],
   opts: { group?: string; backendId?: string } = {}
 ): readonly ModelSelectorEntry[] {
-  if (PREVIEWED_MODELS.length === 0) return EMPTY_ENTRIES;
-  return PREVIEWED_MODELS.map((model) => ({
+  if (models.length === 0) return EMPTY_ENTRIES;
+  // Keep the preview compact enough that a user's own current model stays in
+  // the 288px picker. The rows themselves always come from the live endpoint.
+  return models.slice(0, MAX_PREVIEWED_MODELS).map((model) => ({
     name: model.id,
     provider: ChatModelProviders.COPILOT_PLUS,
     displayName: model.displayName || model.id,

--- a/src/modelManagement/index.ts
+++ b/src/modelManagement/index.ts
@@ -90,12 +90,7 @@ export type {
 
 export { CopilotPlusSetupApi } from "./setup/CopilotPlusSetupApi";
 export type { PlusSetupResult, RegisterPlusProviderInput } from "./setup/CopilotPlusSetupApi";
-export {
-  COPILOT_PLUS_DEFAULT_ENABLED_MODELS,
-  COPILOT_PLUS_MODELS,
-  createCopilotPlusSyncQueue,
-  plusSyncNeeded,
-} from "./setup/copilotPlusSync";
+export { createCopilotPlusSyncQueue, plusSyncNeeded } from "./setup/copilotPlusSync";
 export type {
   CopilotPlusCatalogSnapshot,
   CopilotPlusCatalogStatus,

--- a/src/modelManagement/setup/copilotPlusSync.ts
+++ b/src/modelManagement/setup/copilotPlusSync.ts
@@ -11,7 +11,7 @@ import {
   type BrevilabsModelEntry,
   type BrevilabsModelsResponse,
 } from "@/LLMProviders/brevilabsClient";
-import { BREVILABS_MODELS_BASE_URL, ChatModels } from "@/constants";
+import { BREVILABS_MODELS_BASE_URL } from "@/constants";
 import { logError, logWarn } from "@/logger";
 import type { ModelManagementApi } from "@/modelManagement/createModelManagement";
 import { parseCopilotPlusContextLength } from "@/modelManagement/setup/copilotPlusCatalog";
@@ -21,78 +21,6 @@ import type { CopilotSettings } from "@/settings/model";
 const EMPTY_MODELS: readonly ModelInfo[] = Object.freeze([]);
 const EMPTY_REASONING_EFFORTS: readonly string[] = Object.freeze([]);
 const CATALOG_TIMEOUT_MS = 30_000;
-
-export const COPILOT_PLUS_MODELS: readonly ModelInfo[] = Object.freeze([
-  {
-    id: ChatModels.COPILOT_PLUS_FLASH,
-    displayName: "Copilot Plus Flash",
-    description: "The default model: fastest responses and the most quota.",
-    toolCall: true,
-    reasoning: true,
-    modalities: { input: ["text", "image"], output: ["text"] },
-  },
-  {
-    id: ChatModels.COPILOT_PLUS_KIMI_K2_6,
-    displayName: "Kimi K2.6",
-    description: "Good for long-running reasoning tasks.",
-    toolCall: true,
-    modalities: { input: ["text"], output: ["text"] },
-  },
-  {
-    id: ChatModels.COPILOT_PLUS_GLM_5_2,
-    displayName: "GLM-5.2",
-    description: "A long-horizon frontier open model that beats some of the best closed models.",
-    toolCall: true,
-    reasoning: true,
-    modalities: { input: ["text"], output: ["text"] },
-  },
-  {
-    id: ChatModels.COPILOT_PLUS_KIMI_K2_7_CODE,
-    displayName: "Kimi K2.7 Code",
-    description: "Optimized for coding tasks.",
-    toolCall: true,
-    reasoning: true,
-    modalities: { input: ["text", "image"], output: ["text"] },
-  },
-  {
-    id: ChatModels.COPILOT_PLUS_DEEPSEEK_V4_PRO,
-    displayName: "DeepSeek V4 Pro",
-    description: "A top-tier model for the hardest reasoning and agentic tasks.",
-    toolCall: true,
-    reasoning: true,
-    modalities: { input: ["text"], output: ["text"] },
-  },
-  {
-    id: ChatModels.COPILOT_PLUS_DEEPSEEK_V4_FLASH_0731,
-    displayName: "DeepSeek V4 Flash 0731",
-    description: "The newest DeepSeek V4 Flash snapshot: fast, cheap, and broadly capable.",
-    toolCall: true,
-    reasoning: true,
-    modalities: { input: ["text"], output: ["text"] },
-  },
-  {
-    id: ChatModels.COPILOT_PLUS_MIMO_V2_5,
-    displayName: "MiMo V2.5",
-    description: "Cost-effective and capable for everyday use.",
-    toolCall: true,
-    reasoning: true,
-    modalities: { input: ["text"], output: ["text"] },
-  },
-  {
-    id: ChatModels.COPILOT_PLUS_MINIMAX_M2_7,
-    displayName: "MiniMax M2.7",
-    description: "A compact, efficient model for lightweight tasks.",
-    toolCall: true,
-    reasoning: true,
-    modalities: { input: ["text"], output: ["text"] },
-  },
-]);
-
-export const COPILOT_PLUS_DEFAULT_ENABLED_MODELS: readonly string[] = Object.freeze([
-  ChatModels.COPILOT_PLUS_FLASH,
-  ChatModels.COPILOT_PLUS_DEEPSEEK_V4_PRO,
-  ChatModels.COPILOT_PLUS_GLM_5_2,
-]);
 
 export type CopilotPlusCatalogStatus = "loading" | "ready" | "error";
 

--- a/src/plusUtils.test.ts
+++ b/src/plusUtils.test.ts
@@ -207,7 +207,7 @@ describe("plusUtils", () => {
     it("makes the configured Copilot model the chat default", async () => {
       mockGetSettings.mockReturnValue(settingsWithFlashConfigured());
 
-      await applyLicenseSettings();
+      await applyLicenseSettings("copilot-plus-flash");
 
       expect(mockSetModelKey).toHaveBeenCalledWith(FLASH_CONFIGURED_ID);
       expect(mockSetSettings).toHaveBeenCalledWith({ defaultModelKey: FLASH_CONFIGURED_ID });
@@ -216,7 +216,7 @@ describe("plusUtils", () => {
     it("writes no chain type or embedding model — both belong to retired surfaces", async () => {
       mockGetSettings.mockReturnValue(settingsWithFlashConfigured());
 
-      await applyLicenseSettings();
+      await applyLicenseSettings("copilot-plus-flash");
 
       const written = mockSetSettings.mock.calls.flatMap((call) => Object.keys(call[0]));
       expect(written).toEqual(["defaultModelKey"]);
@@ -226,7 +226,7 @@ describe("plusUtils", () => {
       mockGetSettings.mockReturnValue(settingsWithFlashConfigured());
       mockApplyCopilotDefaultModel.mockReturnValue(["opencode"]);
 
-      await applyLicenseSettings();
+      await applyLicenseSettings("copilot-plus-flash");
 
       expect(mockApplyCopilotDefaultModel).toHaveBeenCalledWith(FLASH_CONFIGURED_ID);
     });
@@ -235,7 +235,7 @@ describe("plusUtils", () => {
       mockIsDesktopRuntime.mockReturnValue(false);
       mockGetSettings.mockReturnValue(settingsWithFlashConfigured());
 
-      await applyLicenseSettings();
+      await applyLicenseSettings("copilot-plus-flash");
 
       expect(mockSetSettings).toHaveBeenCalledWith({ defaultModelKey: FLASH_CONFIGURED_ID });
       expect(mockApplyCopilotDefaultModel).not.toHaveBeenCalled();
@@ -244,7 +244,7 @@ describe("plusUtils", () => {
     it("applies once provider sync enrolls the model, rather than no-opping on a click that beat it", async () => {
       mockGetSettings.mockReturnValue(buildSettings({}));
 
-      const applied = applyLicenseSettings();
+      const applied = applyLicenseSettings("copilot-plus-flash");
       // Mid-flight: the click landed before enrollment, so nothing is written yet.
       expect(mockSetSettings).not.toHaveBeenCalled();
 
@@ -259,7 +259,7 @@ describe("plusUtils", () => {
     it("ignores settings changes that still lack the model", async () => {
       mockGetSettings.mockReturnValue(buildSettings({}));
 
-      const applied = applyLicenseSettings();
+      const applied = applyLicenseSettings("copilot-plus-flash");
       emitSettings(buildSettings({ userId: "user-123" }));
       expect(mockSetSettings).not.toHaveBeenCalled();
 
@@ -274,7 +274,7 @@ describe("plusUtils", () => {
       try {
         mockGetSettings.mockReturnValue(buildSettings({}));
 
-        const applied = applyLicenseSettings();
+        const applied = applyLicenseSettings("copilot-plus-flash");
         jest.advanceTimersByTime(15_000);
         await applied;
 
@@ -290,7 +290,7 @@ describe("plusUtils", () => {
     it("leaves no settings listener behind once it settles", async () => {
       mockGetSettings.mockReturnValue(buildSettings({}));
 
-      const applied = applyLicenseSettings();
+      const applied = applyLicenseSettings("copilot-plus-flash");
       emitSettings(settingsWithFlashConfigured());
       await applied;
 
@@ -322,7 +322,7 @@ describe("plusUtils", () => {
 
       jest.useFakeTimers();
       try {
-        const applied = applyLicenseSettings();
+        const applied = applyLicenseSettings("copilot-plus-flash");
         jest.advanceTimersByTime(15_000);
         await applied;
       } finally {
@@ -338,7 +338,7 @@ describe("plusUtils", () => {
         throw new Error("registry unavailable");
       });
 
-      await expect(applyLicenseSettings()).resolves.toBeUndefined();
+      await expect(applyLicenseSettings("copilot-plus-flash")).resolves.toBeUndefined();
       expect(mockSetSettings).toHaveBeenCalledWith({ defaultModelKey: FLASH_CONFIGURED_ID });
     });
   });

--- a/src/plusUtils.ts
+++ b/src/plusUtils.ts
@@ -2,7 +2,6 @@ import { setModelKey } from "@/aiParams";
 import { CopilotPlusExpiredModal } from "@/components/modals/CopilotPlusExpiredModal";
 import {
   ChatModelProviders,
-  ChatModels,
   EmbeddingModelProviders,
   PLUS_UTM_MEDIUMS,
   PlusUtmMedium,
@@ -21,8 +20,6 @@ import {
 import { isDesktopRuntime } from "@/utils/desktopRuntime";
 import { App, Notice } from "obsidian";
 import React from "react";
-
-export const DEFAULT_COPILOT_PLUS_CHAT_MODEL = ChatModels.COPILOT_PLUS_FLASH;
 
 /**
  * How often a running session re-validates its license. Well inside the token's
@@ -57,24 +54,6 @@ export function isPlusModel(modelKey: string): boolean {
 }
 
 /**
- * Every wire form a Copilot chat model can take in a backend's stored default:
- * bare, and prefixed with the Copilot provider as opencode records it. Matching
- * these exactly, rather than searching for the model id inside the stored value,
- * is what keeps a BYOK model of a similar name (`openrouter/copilot-plus-flash`,
- * `copilot-plus-flash-v2`) from being mistaken for the licensed one.
- *
- * The prefix is `ChatModelProviders.COPILOT_PLUS` rather than opencode's own
- * copy of it, which lives behind the desktop-only Agent Mode barrel; a test in
- * `opencodeModelResolve.test.ts` pins the two together.
- */
-const LICENSED_DEFAULT_WIRE_IDS: ReadonlySet<string> = Object.freeze(
-  new Set([
-    DEFAULT_COPILOT_PLUS_CHAT_MODEL as string,
-    `${ChatModelProviders.COPILOT_PLUS}/${DEFAULT_COPILOT_PLUS_CHAT_MODEL}`,
-  ])
-);
-
-/**
  * Whether any default a license installed still points at a Copilot model — the
  * chat default, or an agent's stored default from {@link applyLicenseSettings}.
  * Both matter on expiry: a user can move chat onto their own model and leave an
@@ -88,7 +67,7 @@ export function isUsingLicensedModels(settings: CopilotSettings): boolean {
   if (isPlusModel(settings.defaultModelKey)) return true;
   return Object.values(settings.agentMode?.backends ?? {}).some((backend) => {
     const baseModelId = backend?.defaultModel?.baseModelId;
-    return baseModelId !== undefined && LICENSED_DEFAULT_WIRE_IDS.has(baseModelId);
+    return baseModelId?.startsWith(`${ChatModelProviders.COPILOT_PLUS}/`) === true;
   });
 }
 
@@ -423,17 +402,18 @@ export function useIsSelfHostEligible(): boolean | undefined {
  */
 const CONFIGURED_MODEL_WAIT_MS = 15_000;
 
-/** The configured Copilot chat model in `settings`, or `undefined` if the provider sync has not enrolled it. */
-function findLicensedChatModelId(settings: CopilotSettings): string | undefined {
+/** The requested server-published Copilot model in settings, once provider sync enrolls it. */
+function findLicensedChatModelId(
+  settings: CopilotSettings,
+  serverModelId: string
+): string | undefined {
   const plusProviderIds = new Set(
     Object.values(settings.providers)
       .filter((provider) => provider.origin.kind === "copilot-plus")
       .map((provider) => provider.providerId)
   );
   return settings.configuredModels.find(
-    (model) =>
-      plusProviderIds.has(model.providerId) &&
-      model.info.id === (DEFAULT_COPILOT_PLUS_CHAT_MODEL as string)
+    (model) => plusProviderIds.has(model.providerId) && model.info.id === serverModelId
   )?.configuredModelId;
 }
 
@@ -447,8 +427,8 @@ function findLicensedChatModelId(settings: CopilotSettings): string | undefined 
  * that persists the same change. Reading the configured set once would let a
  * user who clicks Apply Now inside that window apply nothing at all.
  */
-function waitForLicensedChatModelId(): Promise<string | undefined> {
-  const present = findLicensedChatModelId(getSettings());
+function waitForLicensedChatModelId(serverModelId: string): Promise<string | undefined> {
+  const present = findLicensedChatModelId(getSettings(), serverModelId);
   if (present) return Promise.resolve(present);
   return new Promise((resolve) => {
     let settled = false;
@@ -460,20 +440,20 @@ function waitForLicensedChatModelId(): Promise<string | undefined> {
       resolve(id);
     };
     const unsubscribe = subscribeToSettingsChange((_prev, next) => {
-      const id = findLicensedChatModelId(next);
+      const id = findLicensedChatModelId(next, serverModelId);
       if (id) settle(id);
     });
     const timer = window.setTimeout(() => settle(undefined), CONFIGURED_MODEL_WAIT_MS);
     // Enrollment can land between the check above and this subscription, which
     // would otherwise leave nothing left to notify us.
-    const raced = findLicensedChatModelId(getSettings());
+    const raced = findLicensedChatModelId(getSettings(), serverModelId);
     if (raced) settle(raced);
   });
 }
 
 /**
- * Install the licensed default model — Copilot Plus Flash — everywhere the
- * user will meet a model picker: chat, and every agent that can route it.
+ * Install the server-selected licensed default everywhere the user will meet a
+ * model picker: chat, and every agent that can route it.
  *
  * License activation already registers the Copilot provider and enrolls its
  * models; this is the opinionated half, choosing which of them a licensed user
@@ -483,13 +463,13 @@ function waitForLicensedChatModelId(): Promise<string | undefined> {
  * Applies nothing if the model never arrives, rather than storing a key no
  * picker can resolve — and says so, since by then the modal has closed and
  * silence would look like success.
+ *
+ * @param serverModelId - First model id from the current lifecycle's ordered server catalog.
  */
-export async function applyLicenseSettings(): Promise<void> {
-  const configuredModelId = await waitForLicensedChatModelId();
+export async function applyLicenseSettings(serverModelId: string): Promise<void> {
+  const configuredModelId = await waitForLicensedChatModelId(serverModelId);
   if (!configuredModelId) {
-    logWarn(
-      `applyLicenseSettings: ${DEFAULT_COPILOT_PLUS_CHAT_MODEL} was never configured, nothing to apply`
-    );
+    logWarn(`applyLicenseSettings: ${serverModelId} was never configured, nothing to apply`);
     new Notice(
       "Copilot could not set a default model. Pick one under Settings → Basic → Agents once your license is active."
     );

--- a/src/settings/v2/components/ConfiguredModelEnableList.tsx
+++ b/src/settings/v2/components/ConfiguredModelEnableList.tsx
@@ -5,6 +5,8 @@ import {
   type ModelEnableGroup,
 } from "@/agentMode";
 import { logError } from "@/logger";
+import { usePlugin } from "@/contexts/PluginContext";
+import { useCopilotPlusCatalog } from "@/contexts/useCopilotPlusCatalog";
 import {
   backendsAtom,
   configuredModelsAtom,
@@ -43,7 +45,9 @@ const isOpencodeRoutableProvider = (
 export const ConfiguredModelEnableList: React.FC<ConfiguredModelEnableListProps> = ({
   descriptor,
 }) => {
+  const plugin = usePlugin();
   const api = useModelManagement();
+  const copilotPlusCatalog = useCopilotPlusCatalog(plugin);
   // A backend's id doubles as its model-management AgentType.
   const agentType = descriptor.id as AgentType;
 
@@ -60,17 +64,34 @@ export const ConfiguredModelEnableList: React.FC<ConfiguredModelEnableListProps>
 
   const isOpencode = descriptor.id === "opencode";
 
+  const currentConfiguredModels = React.useMemo(
+    () =>
+      configuredModels.filter((model) => {
+        const provider = providers[model.providerId];
+        if (provider?.origin.kind !== "copilot-plus") return true;
+        // Persisted rows remain available for offline selection recovery, but
+        // the settings catalog lists only ids authorized by this lifecycle's
+        // successful server response.
+        // https://github.com/Brevilabs/obsidian-copilot-private/issues/319
+        return (
+          copilotPlusCatalog.status === "ready" &&
+          copilotPlusCatalog.models.some((liveModel) => liveModel.id === model.info.id)
+        );
+      }),
+    [configuredModels, providers, copilotPlusCatalog]
+  );
+
   const partition = React.useMemo(
     () =>
       partitionCandidates(
-        configuredModels,
+        currentConfiguredModels,
         providers,
         enabledIds,
         agentType,
         isOpencode,
         isOpencodeRoutableProvider
       ),
-    [configuredModels, providers, enabledIds, agentType, isOpencode]
+    [currentConfiguredModels, providers, enabledIds, agentType, isOpencode]
   );
 
   // Ask the provider rows, as both pickers do, rather than letting the grouping
@@ -81,8 +102,15 @@ export const ConfiguredModelEnableList: React.FC<ConfiguredModelEnableListProps>
   const copilotProviderMissing = shouldPreviewCopilotModels(providers);
 
   const groups = React.useMemo<ModelEnableGroup[]>(
-    () => buildModelEnableGroups(partition, isOpencode, query, copilotProviderMissing),
-    [partition, isOpencode, query, copilotProviderMissing]
+    () =>
+      buildModelEnableGroups(
+        partition,
+        isOpencode,
+        query,
+        copilotProviderMissing,
+        copilotPlusCatalog.models
+      ),
+    [partition, isOpencode, query, copilotProviderMissing, copilotPlusCatalog.models]
   );
 
   const handleToggle = React.useCallback(

--- a/src/settings/v2/components/PlusSettings.test.tsx
+++ b/src/settings/v2/components/PlusSettings.test.tsx
@@ -4,6 +4,11 @@ import React from "react";
 
 const updateSetting = jest.fn<void, unknown[]>();
 const mockApp = {};
+const mockWaitForSettled = jest.fn(async () => ({
+  status: "ready" as const,
+  models: [{ id: "tomorrow-model", displayName: "Tomorrow Model" }],
+}));
+const mockWelcomeConstructor = jest.fn();
 let currentSettings = { ...DEFAULT_SETTINGS };
 jest.mock("@/settings/model", () => ({
   updateSetting: (...a: unknown[]) => updateSetting(...a),
@@ -31,8 +36,16 @@ jest.mock("@/context", () => ({
   useApp: () => mockApp,
 }));
 
+jest.mock("@/contexts/PluginContext", () => ({
+  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook
+  usePlugin: () => ({ copilotPlusSync: { waitForSettled: mockWaitForSettled } }),
+}));
+
 jest.mock("@/components/modals/CopilotPlusWelcomeModal", () => ({
   CopilotPlusWelcomeModal: class {
+    constructor(...args: unknown[]) {
+      mockWelcomeConstructor(...args);
+    }
     open() {}
   },
 }));
@@ -103,6 +116,22 @@ describe("PlusSettings", () => {
       });
 
       expect(screen.getByText("Inactive")).toBeTruthy();
+    });
+
+    it("offers the first model in the server catalog rather than a client-declared default (https://github.com/Brevilabs/obsidian-copilot-private/issues/319)", async () => {
+      checkIsPaidUser.mockResolvedValue(true);
+
+      render(<PlusSettings />);
+      await act(async () => {
+        screen.getByRole("button", { name: "Apply" }).click();
+      });
+
+      expect(mockWaitForSettled).toHaveBeenCalledTimes(1);
+      expect(mockWelcomeConstructor).toHaveBeenCalledWith(
+        mockApp,
+        "tomorrow-model",
+        "Tomorrow Model"
+      );
     });
   });
 });

--- a/src/settings/v2/components/PlusSettings.tsx
+++ b/src/settings/v2/components/PlusSettings.tsx
@@ -1,5 +1,6 @@
 import { CopilotPlusWelcomeModal } from "@/components/modals/CopilotPlusWelcomeModal";
 import { useApp } from "@/context";
+import { usePlugin } from "@/contexts/PluginContext";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { PasswordInput } from "@/components/ui/password-input";
@@ -15,6 +16,7 @@ import { updateSetting, useSettingsValue } from "@/settings/model";
 import { ExternalLink, Loader2 } from "lucide-react";
 import React, { useState } from "react";
 import { safeAsyncHandler } from "@/utils/safeAsyncHandler";
+import { Notice } from "obsidian";
 
 /**
  * B3 placeholder: mock Plus usage data until the real API is available.
@@ -35,6 +37,7 @@ const LIFETIME_PLAN = "believer";
 
 export function PlusSettings() {
   const app = useApp();
+  const plugin = usePlugin();
   const settings = useSettingsValue();
   const [error, setError] = useState<string | null>(null);
   const [isChecking, setIsChecking] = useState(false);
@@ -135,7 +138,19 @@ export function PlusSettings() {
               setError("Invalid license key");
             } else {
               setError(null);
-              new CopilotPlusWelcomeModal(app).open();
+              const catalog = await plugin.copilotPlusSync.waitForSettled();
+              const defaultModel = catalog.status === "ready" ? catalog.models[0] : undefined;
+              if (defaultModel) {
+                new CopilotPlusWelcomeModal(
+                  app,
+                  defaultModel.id,
+                  defaultModel.displayName || defaultModel.id
+                ).open();
+              } else {
+                new Notice(
+                  "Your license is active, but Copilot Plus models could not be loaded. Reload while online to choose a Plus model."
+                );
+              }
             }
           })}
           className="tw-min-w-10 tw-text-xs md:tw-text-sm"

--- a/src/settings/v2/components/configuredModelGrouping.test.ts
+++ b/src/settings/v2/components/configuredModelGrouping.test.ts
@@ -6,8 +6,12 @@ import {
   toRow,
   type Candidate,
 } from "./configuredModelGrouping";
-import type { ConfiguredModel, Provider } from "@/modelManagement";
+import type { ConfiguredModel, ModelInfo, Provider } from "@/modelManagement";
 import { ModelCapability } from "@/constants";
+
+const LIVE_PLUS_MODELS: readonly ModelInfo[] = Object.freeze([
+  { id: "tomorrow-flash", displayName: "Tomorrow Flash", description: "From the endpoint" },
+]);
 
 function byokProvider(id: string, displayName: string): Provider {
   return {
@@ -417,7 +421,7 @@ describe("buildModelEnableGroups", () => {
       agentOriginCandidates: [],
     };
 
-    const groups = buildModelEnableGroups(partition, true, "", true);
+    const groups = buildModelEnableGroups(partition, true, "", true, LIVE_PLUS_MODELS);
 
     // Same position, badge, and tooltip a licensed user's group gets — only the
     // rows differ, and only by being unusable.
@@ -485,8 +489,8 @@ describe("buildModelEnableGroups", () => {
   it("filters the locked rows by the search query like any others", () => {
     const empty = { byokPlusCandidates: [], agentOriginCandidates: [] };
 
-    const matching = buildModelEnableGroups(empty, true, "flash", true);
-    const missing = buildModelEnableGroups(empty, true, "no-such-model", true);
+    const matching = buildModelEnableGroups(empty, true, "flash", true, LIVE_PLUS_MODELS);
+    const missing = buildModelEnableGroups(empty, true, "no-such-model", true, LIVE_PLUS_MODELS);
 
     expect(matching[0].rows.length).toBeGreaterThan(0);
     expect(matching[0].rows.every((row) => /flash/i.test(row.label + row.wireId))).toBe(true);

--- a/src/settings/v2/components/configuredModelGrouping.ts
+++ b/src/settings/v2/components/configuredModelGrouping.ts
@@ -2,11 +2,14 @@
 
 import { isOpencodeZenWireId, type ModelEnableGroup, type ModelEnableRow } from "@/agentMode";
 import {
-  COPILOT_PLUS_MODELS,
   capabilitiesFromConfiguredInfo,
   type ConfiguredModel,
+  type ModelInfo,
   type Provider,
 } from "@/modelManagement";
+
+/** See AGENTS.md → "Referential stability". */
+const EMPTY_MODELS: readonly ModelInfo[] = Object.freeze([]);
 
 /** One candidate model joined to its provider, plus current enabled state. */
 export interface Candidate {
@@ -180,7 +183,8 @@ export function buildModelEnableGroups(
   partition: CandidatePartition,
   isOpencode: boolean,
   query: string,
-  copilotProviderMissing: boolean
+  copilotProviderMissing: boolean,
+  copilotPlusModels: readonly ModelInfo[] = EMPTY_MODELS
 ): ModelEnableGroup[] {
   const q = query.trim().toLowerCase();
   const out: OriginGroup[] = [];
@@ -228,16 +232,18 @@ export function buildModelEnableGroups(
   // ability to act on it. Only opencode can route these models, and only its
   // list mixes in non-agent providers at all.
   if (isOpencode && copilotProviderMissing) {
-    const rows = COPILOT_PLUS_MODELS.map(
-      (model): ModelEnableRow => ({
-        id: `__locked_copilot__${model.id}`,
-        label: model.displayName || model.id,
-        description: model.description,
-        wireId: model.id,
-        enabled: false,
-        locked: true,
-      })
-    ).filter((row) => rowMatches(row, q));
+    const rows = copilotPlusModels
+      .map(
+        (model): ModelEnableRow => ({
+          id: `__locked_copilot__${model.id}`,
+          label: model.displayName || model.id,
+          description: model.description,
+          wireId: model.id,
+          enabled: false,
+          locked: true,
+        })
+      )
+      .filter((row) => rowMatches(row, q));
     if (rows.length > 0) {
       out.push({
         group: { key: "locked:copilot-plus", label: "Copilot", rows },


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#319

## Why

Even with one live catalog lifecycle, Chat, Agent Mode, Plus settings, and onboarding still rendered the client-declared Plus lineup. Users could therefore see models that the current server response had not authorized.

## What

The live snapshot now supplies Plus rows across Chat model selection, Agent Mode model selection, Plus settings, and the welcome flow. Loading and failed snapshots no longer fall back to the hardcoded lineup, and server-provided labels, descriptions, capabilities, and limits remain consistent across those surfaces.

## Non goal

This does not delay OpenCode startup, change its generated provider configuration, or preserve an unavailable saved Plus default as the selected Agent model.

## Screenshot

Not included because this PR changes which server-provided rows appear, not their layout or visual treatment. Verification compares the endpoint response with the rendered lineups on each affected surface.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Picker, settings, welcome-flow, hook-subscription, and locked-row tests cover live, loading, and error snapshots |
| A defect would fail CI or be obvious on first use | ✅ | The affected rendered lineups are covered by deterministic tests and visible immediately |
| A revert fully restores prior state, including persisted data | ✅ | This layer changes catalog reads only and performs no migration |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Existing entitlement and credential checks are unchanged |
| No public API, plugin API, message, or on-disk contract changes | ✅ | The shared internal snapshot is consumed without changing external contracts |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | This layer subscribes to the existing lifecycle without adding a new one |
| No hot-path behavior lacks deterministic coverage | ✅ | Every changed catalog status has deterministic surface coverage |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | A wrong lineup is visible as soon as any affected picker or settings panel opens |

Review: run Verification steps 1-3 and confirm the same endpoint IDs appear on every named surface.

## Verification

1. Return a distinctive Plus lineup from the models endpoint, reload Copilot, and open Chat model selection, Agent Mode model selection, Plus settings, and the welcome flow.
2. Confirm each surface shows only the returned IDs with the same labels and capabilities.
3. Repeat while the endpoint is loading and after it fails. Confirm none of the surfaces resurrects the old client-declared lineup.
