### PR TITLE
Use Miyo path filtering for current-vault search

### DIFF
--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -366,17 +366,19 @@ describe("builtinSkills", () => {
       expect(miyoScript(".cmd")).toContain("search %* -n 10 --json");
     });
 
-    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/121 passes the exact active-vault identity in Current vault mode on POSIX and Windows", () => {
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/121 passes the active-vault path prefix in Current vault mode on POSIX and Windows", () => {
       const sh = miyoScript(".sh");
       const cmd = miyoScript(".cmd");
 
       expect(sh).toContain('case "${COPILOT_MIYO_SEARCH_SCOPE:-current}"');
-      expect(sh).toContain('--folder "$COPILOT_MIYO_SEARCH_FOLDER"');
+      expect(sh).toContain('--path "$COPILOT_MIYO_SEARCH_FOLDER/"');
+      expect(sh).not.toContain("--folder");
       expect(cmd).toContain('if /I "%COPILOT_MIYO_SEARCH_SCOPE%"=="unrestricted"');
-      expect(cmd).toContain('--folder "%COPILOT_MIYO_SEARCH_FOLDER%"');
+      expect(cmd).toContain('--path "%COPILOT_MIYO_SEARCH_FOLDER%/"');
+      expect(cmd).not.toContain("--folder");
     });
 
-    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/121 omits the folder boundary only for explicit Unrestricted mode on POSIX and Windows", () => {
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/121 omits the vault path prefix only for explicit Unrestricted mode on POSIX and Windows", () => {
       const sh = miyoScript(".sh");
       const cmd = miyoScript(".cmd");
 

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -781,7 +781,7 @@ export const BUILTIN_SKILLS: readonly BuiltinSkill[] = [
   ...OBSIDIAN_SKILLS,
 ];
 
-const MIYO_SEARCH_VERSION = 3;
+const MIYO_SEARCH_VERSION = 4;
 const MIYO_PARSE_VERSION = 1;
 
 /** Shared by both Miyo wrappers; the host script must define `die` before it. */
@@ -826,8 +826,8 @@ QUERY="$*"
 
 ${MIYO_POSIX_RESOLVER}
 
-# Default closed: only the explicit Unrestricted value may omit Miyo's exact
-# pre-retrieval folder boundary.
+# Default closed: only the explicit Unrestricted value may omit the active
+# vault's Miyo path prefix.
 # https://github.com/Brevilabs/obsidian-copilot-private/issues/121
 case "\${${MIYO_SEARCH_SCOPE_ENV}:-current}" in
   unrestricted)
@@ -835,7 +835,7 @@ case "\${${MIYO_SEARCH_SCOPE_ENV}:-current}" in
     ;;
   current)
     [ -n "\${${MIYO_SEARCH_FOLDER_ENV}:-}" ] || die "Miyo search could not enforce Current vault scope because the active vault identity is missing. Do not retry or run an unrestricted search." 4
-    OUT=$("$MIYO" search "$QUERY" -n 10 --folder "$${MIYO_SEARCH_FOLDER_ENV}" --json 2>&1) || die "Miyo search could not enforce Current vault scope. Update Miyo, open it, and retry. Do not run an unrestricted search. Details: $OUT" 1
+    OUT=$("$MIYO" search "$QUERY" -n 10 --path "$${MIYO_SEARCH_FOLDER_ENV}/" --json 2>&1) || die "Miyo search could not enforce Current vault scope. Update Miyo, open it, and retry. Do not run an unrestricted search. Details: $OUT" 1
     ;;
   *)
     die "Miyo search received an invalid Search scope. Do not retry or run an unrestricted search." 4
@@ -858,8 +858,8 @@ if "%~1"=="" (
   exit /b 1
 )
 ${MIYO_WINDOWS_RESOLVER}
-rem Default closed: only the explicit Unrestricted value may omit Miyo's exact
-rem pre-retrieval folder boundary.
+rem Default closed: only the explicit Unrestricted value may omit the active
+rem vault's Miyo path prefix.
 rem https://github.com/Brevilabs/obsidian-copilot-private/issues/121
 if /I "%${MIYO_SEARCH_SCOPE_ENV}%"=="unrestricted" (
   "%MIYO%" search %* -n 10 --json
@@ -874,7 +874,7 @@ if not defined ${MIYO_SEARCH_FOLDER_ENV} (
   echo Miyo search could not enforce Current vault scope because the active vault identity is missing. Do not retry or run an unrestricted search. 1>&2
   exit /b 4
 )
-"%MIYO%" search %* -n 10 --folder "%${MIYO_SEARCH_FOLDER_ENV}%" --json
+"%MIYO%" search %* -n 10 --path "%${MIYO_SEARCH_FOLDER_ENV}%/" --json
 if errorlevel 1 (
   echo Miyo search could not enforce Current vault scope. Update Miyo, open it, and retry. Do not run an unrestricted search. 1>&2
   exit /b 1
@@ -972,8 +972,8 @@ script as your single search step; do not fall back to other search tools
 unless it reports that Miyo is unavailable. Read the JSON straight from stdout;
 do not pipe it through other tools (no \`jq\`, no \`|\`).
 
-Search scope comes from Copilot settings. **Current vault** applies Miyo's exact
-folder boundary for the active vault, including from Project chats.
+Search scope comes from Copilot settings. **Current vault** applies the active
+vault's Miyo path prefix, including from Project chats.
 **Unrestricted** searches every folder registered with Miyo.
 
 ## Reading the results


### PR DESCRIPTION
Fixes Brevilabs/obsidian-copilot-private#121

## Why

Current-vault Miyo searches in Agent Chat fail because the generated wrapper passes `--folder`, which the current Miyo CLI does not support. Obsidian already supplies the canonical active-vault name, so no additional vault discovery is needed.

## What

Current-vault searches now use Miyo's supported `--path "<vault-name>/"` filter on macOS, Linux, and Windows. Existing managed copies refresh automatically. Unrestricted searches still omit the filter, and missing Current-vault identity still fails closed.

## Non goal

- Supporting direct use of this vault-local skill from standalone Codex Desktop or another process not launched by Obsidian Copilot.
- Adding `--folder` to Miyo or waiting for a new Miyo release.
- Treating Current vault as a Miyo authorization boundary.
- Limiting Project chat search to only the files included in that Project.

## Screenshot

Not applicable. This changes a generated command-line wrapper and has no visual state.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Generated-wrapper tests cover Current vault, Unrestricted, and fail-closed behavior on POSIX and Windows |
| A defect would fail CI or be obvious on first use | ✅ | Wrapper assertions reject `--folder` and require the trailing-slash `--path` value |
| A revert fully restores prior state, including persisted data | ✅ | No persisted data or migration changes |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | The same protected active-vault value is passed to the supported filter flag |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Only Copilot's generated Miyo invocation changes |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Wrapper generation remains synchronous |
| No hot-path behavior lacks deterministic coverage | ✅ | Both shipped wrapper variants are asserted directly |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | The changed behavior is deterministic and an invalid command would fail on the first search |

Review: run Verification steps 1-3 and confirm CI is green.

## Verification

1. Run Miyo with the active vault and a second folder indexed, then select **Current vault** in Copilot's Miyo Search scope and reload the plugin.
2. In Agent Chat, search for content in the active vault. Confirm the search succeeds without an unknown `--folder` error and returned paths start with `<vault-name>/`.
3. Search for content unique to the second folder and confirm Current vault returns no path from it. Switch to **Unrestricted** and confirm the same search can return the second folder.
4. Repeat the Current-vault search in a Project chat and with each available Agent backend.
