### PR TITLE
[Chinese localization] - Step 1: Add localization foundation

### DIFF
--- a/__mocks__/obsidian.js
+++ b/__mocks__/obsidian.js
@@ -13,6 +13,7 @@ let requestUrlImpl = jest.fn().mockResolvedValue({
 });
 
 module.exports = {
+  getLanguage: jest.fn().mockReturnValue("en"),
   moment: jest.requireActual("moment"),
   requestUrl: (...args) => requestUrlImpl(...args),
   __setRequestUrlImpl: (impl) => {

--- a/src/i18n/index.test.ts
+++ b/src/i18n/index.test.ts
@@ -1,0 +1,156 @@
+import { resolveLocale } from "@/i18n/locale";
+
+const ISSUE_URL = "https://github.com/Brevilabs/obsidian-copilot-private/issues/324";
+
+interface LoadedI18n {
+  formatDate: typeof import("@/i18n").formatDate;
+  formatNumber: typeof import("@/i18n").formatNumber;
+  initializeI18n: typeof import("@/i18n").initializeI18n;
+  registerCatalog: typeof import("@/i18n").registerCatalog;
+  t: typeof import("@/i18n").t;
+}
+
+function loadI18n(obsidianLocale: string): LoadedI18n {
+  jest.resetModules();
+  const obsidian = jest.requireActual<{
+    getLanguage: jest.MockedFunction<() => string>;
+  }>("obsidian");
+  obsidian.getLanguage.mockReturnValue(obsidianLocale);
+  return jest.requireActual<LoadedI18n>("@/i18n");
+}
+
+describe("i18n", () => {
+  describe("resolveLocale()", () => {
+    it(`maps Obsidian Simplified Chinese variants to zh-CN for ${ISSUE_URL}`, () => {
+      expect(resolveLocale("zh")).toBe("zh-CN");
+      expect(resolveLocale("zh-CN")).toBe("zh-CN");
+      expect(resolveLocale("zh-Hans")).toBe("zh-CN");
+    });
+
+    it(`maps Obsidian Traditional Chinese variants to zh-TW for ${ISSUE_URL}`, () => {
+      expect(resolveLocale("zh-TW")).toBe("zh-TW");
+      expect(resolveLocale("zh-Hant")).toBe("zh-TW");
+      expect(resolveLocale("zh-Hant-TW")).toBe("zh-TW");
+    });
+
+    it(`falls back to English for unsupported Obsidian locales for ${ISSUE_URL}`, () => {
+      expect(resolveLocale("fr")).toBe("en");
+      expect(resolveLocale("")).toBe("en");
+    });
+  });
+
+  describe("initializeI18n()", () => {
+    it(`reads Obsidian's language once when repeated initialization reuses the singleton for ${ISSUE_URL}`, () => {
+      const i18n = loadI18n("en");
+      const obsidian = jest.requireActual<{
+        getLanguage: jest.MockedFunction<() => string>;
+      }>("obsidian");
+
+      i18n.initializeI18n();
+      i18n.initializeI18n();
+
+      expect(obsidian.getLanguage).toHaveBeenCalledTimes(1);
+    });
+
+    it(`uses English until the requested catalog exists for ${ISSUE_URL}`, () => {
+      const i18n = loadI18n("zh");
+      i18n.registerCatalog("en", { variant: "English variant" });
+
+      i18n.initializeI18n();
+
+      expect(i18n.t("variant")).toBe("English variant");
+    });
+  });
+
+  describe("registerCatalog()", () => {
+    it(`activates a requested catalog registered after initialization for ${ISSUE_URL}`, () => {
+      const i18n = loadI18n("zh");
+      i18n.initializeI18n();
+
+      i18n.registerCatalog("zh-CN", { variant: "简体中文" });
+
+      expect(i18n.t("variant")).toBe("简体中文");
+    });
+  });
+
+  describe("t()", () => {
+    it(`falls back to the complete English message when a localized key is missing for ${ISSUE_URL}`, () => {
+      const i18n = loadI18n("zh");
+      i18n.registerCatalog("en", { fallbackOnly: "English fallback" });
+      i18n.registerCatalog("zh-CN", {});
+      i18n.initializeI18n();
+
+      expect(i18n.t("fallbackOnly")).toBe("English fallback");
+    });
+
+    it(`never falls through from Taiwan Traditional to a Simplified catalog for ${ISSUE_URL}`, () => {
+      const i18n = loadI18n("zh-TW");
+      i18n.registerCatalog("en", { variant: "English variant" });
+      i18n.registerCatalog("zh-CN", { variant: "简体中文" });
+      i18n.registerCatalog("zh-TW", {});
+      i18n.initializeI18n();
+
+      expect(i18n.t("variant")).toBe("English variant");
+    });
+
+    it(`interpolates named parameters into a complete message for ${ISSUE_URL}`, () => {
+      const i18n = loadI18n("en");
+      i18n.registerCatalog("en", { welcome: "Welcome, {{name}}!" });
+      i18n.initializeI18n();
+
+      expect(i18n.t("welcome", { name: "Ada" })).toBe("Welcome, Ada!");
+    });
+
+    it(`preserves an interpolation placeholder when its value is missing for ${ISSUE_URL}`, () => {
+      const i18n = loadI18n("en");
+      i18n.registerCatalog("en", { welcome: "Welcome, {{name}}!" });
+      i18n.initializeI18n();
+
+      expect(i18n.t("welcome")).toBe("Welcome, {{name}}!");
+    });
+
+    it(`selects locale plural forms and interpolates the count for ${ISSUE_URL}`, () => {
+      const i18n = loadI18n("en");
+      i18n.registerCatalog("en", {
+        item_one: "{{count}} item",
+        item_other: "{{count}} items",
+      });
+      i18n.initializeI18n();
+
+      expect(i18n.t("item", { count: 1 })).toBe("1 item");
+      expect(i18n.t("item", { count: 3 })).toBe("3 items");
+    });
+  });
+
+  describe("formatNumber()", () => {
+    it(`formats numbers with the active locale and caller options for ${ISSUE_URL}`, () => {
+      const i18n = loadI18n("zh");
+      i18n.registerCatalog("zh-CN", {});
+      i18n.initializeI18n();
+      const options: Intl.NumberFormatOptions = { style: "percent" };
+
+      expect(i18n.formatNumber(0.25, options)).toBe(
+        new Intl.NumberFormat("zh-CN", options).format(0.25)
+      );
+    });
+  });
+
+  describe("formatDate()", () => {
+    it(`formats dates with the active locale and caller options for ${ISSUE_URL}`, () => {
+      const i18n = loadI18n("zh-TW");
+      i18n.registerCatalog("zh-TW", {});
+      i18n.initializeI18n();
+      const value = new Date("2026-01-02T12:00:00Z");
+      const options: Intl.DateTimeFormatOptions = {
+        day: "numeric",
+        month: "long",
+        timeZone: "UTC",
+        year: "numeric",
+      };
+
+      expect(i18n.formatDate(value, options)).toBe(
+        new Intl.DateTimeFormat("zh-TW", options).format(value)
+      );
+    });
+  });
+});

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,78 @@
+import { DEFAULT_LOCALE, resolveLocale, type SupportedLocale } from "@/i18n/locale";
+import { ENGLISH_TRANSLATIONS } from "@/i18n/locales/en";
+import { getLanguage } from "obsidian";
+
+export { DEFAULT_LOCALE, SUPPORTED_LOCALES, resolveLocale } from "@/i18n/locale";
+export type { SupportedLocale } from "@/i18n/locale";
+
+export interface TranslationValues {
+  count?: number;
+  [name: string]: boolean | null | number | string | undefined;
+}
+
+export type TranslationCatalog = Readonly<Record<string, string>>;
+
+const catalogs: Partial<Record<SupportedLocale, TranslationCatalog>> = {
+  [DEFAULT_LOCALE]: ENGLISH_TRANSLATIONS,
+};
+let requestedLocale: SupportedLocale | undefined;
+let activeLocale: SupportedLocale = DEFAULT_LOCALE;
+
+/** Initialize the shared interface-localization runtime for the current plugin lifecycle. */
+export function initializeI18n(): void {
+  if (requestedLocale) return;
+  requestedLocale = resolveLocale(getLanguage());
+  // A supported locale without a shipped catalog must remain fully English.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/324
+  activeLocale = catalogs[requestedLocale] ? requestedLocale : DEFAULT_LOCALE;
+}
+
+/** Register one complete locale catalog before translating interface messages. */
+export function registerCatalog(locale: SupportedLocale, catalog: TranslationCatalog): void {
+  catalogs[locale] = catalog;
+  // Future catalogs may register after initialization without leaving the UI
+  // stuck on its temporary English fallback.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/324
+  if (requestedLocale === locale) activeLocale = locale;
+}
+
+function findMessage(
+  catalog: TranslationCatalog | undefined,
+  locale: SupportedLocale,
+  key: string,
+  count: number | undefined
+): string | undefined {
+  // A count selects the locale's CLDR plural form while ordinary messages
+  // keep their unsuffixed key.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/324
+  if (count === undefined) return catalog?.[key];
+  const category = new Intl.PluralRules(locale).select(count);
+  return catalog?.[`${key}_${category}`] ?? catalog?.[`${key}_other`] ?? catalog?.[key];
+}
+
+/** Translate one complete interface message through the shared locale and English fallback. */
+export function t(key: string, values: TranslationValues = {}): string {
+  // Traditional Chinese and every other locale fall directly back to English;
+  // no sibling-language catalog participates in lookup.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/324
+  const message =
+    findMessage(catalogs[activeLocale], activeLocale, key, values.count) ??
+    findMessage(catalogs[DEFAULT_LOCALE], DEFAULT_LOCALE, key, values.count) ??
+    key;
+  // An unresolved placeholder stays visible instead of silently deleting
+  // information from an incomplete translation call.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/324
+  return message.replace(/\{\{(\w+)\}\}/g, (placeholder, name: string) =>
+    values[name] === undefined ? placeholder : String(values[name])
+  );
+}
+
+/** Format a number with the active interface locale. */
+export function formatNumber(value: number, options?: Intl.NumberFormatOptions): string {
+  return new Intl.NumberFormat(activeLocale, options).format(value);
+}
+
+/** Format a date with the active interface locale. */
+export function formatDate(value: Date | number, options?: Intl.DateTimeFormatOptions): string {
+  return new Intl.DateTimeFormat(activeLocale, options).format(value);
+}

--- a/src/i18n/locale.ts
+++ b/src/i18n/locale.ts
@@ -1,0 +1,21 @@
+export const DEFAULT_LOCALE = "en";
+export const SUPPORTED_LOCALES = [DEFAULT_LOCALE, "zh-CN", "zh-TW"] as const;
+
+export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
+
+const OBSIDIAN_LOCALE_MAP: Readonly<Record<string, SupportedLocale>> = Object.freeze({
+  // Obsidian names Simplified Chinese `zh`; Copilot uses the explicit catalog
+  // id so Taiwan Traditional can never inherit Simplified messages.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/324
+  zh: "zh-CN",
+  "zh-cn": "zh-CN",
+  "zh-hans": "zh-CN",
+  "zh-hant": "zh-TW",
+  "zh-hant-tw": "zh-TW",
+  "zh-tw": "zh-TW",
+});
+
+/** Resolve an Obsidian interface language to a bundled Copilot catalog. */
+export function resolveLocale(obsidianLocale: string): SupportedLocale {
+  return OBSIDIAN_LOCALE_MAP[obsidianLocale.toLowerCase().replace("_", "-")] ?? DEFAULT_LOCALE;
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1,0 +1,2 @@
+/** English is the source catalog and final fallback for every interface locale. */
+export const ENGLISH_TRANSLATIONS = {} as const;

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,7 @@ import {
 } from "@/constants";
 import { ChatManager } from "@/core/ChatManager";
 import { MessageRepository } from "@/core/MessageRepository";
+import { initializeI18n } from "@/i18n";
 import { logError, logInfo, logWarn } from "@/logger";
 import { logFileManager } from "@/logFileManager";
 import {
@@ -196,6 +197,7 @@ export default class CopilotPlugin extends Plugin {
   private startupMigrationItems: StartupMigrationItem[] = [];
 
   async onload(): Promise<void> {
+    initializeI18n();
     // Patch Node's `events.setMaxListeners` so the Claude Agent SDK's call with
     // a web-realm AbortSignal stops throwing in Electron's renderer. No-ops on
     // mobile (no node:events / no SDK). Must run before any Agent Mode session;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,10 @@ import type { EditorView } from "@codemirror/view";
 import { type TFile } from "obsidian";
 
 declare module "obsidian" {
+  // `getLanguage` is public since Obsidian 1.8.7 and guaranteed by this
+  // plugin's minimum app version. The pinned development types predate it.
+  export function getLanguage(): string;
+
   interface MetadataCache {
     // Note that this API is considered internal and may work differently in the
     // future.


### PR DESCRIPTION
Fixes Brevilabs/obsidian-copilot-private#324

## Why

Copilot currently has no shared interface-localization contract. Before translated UI can ship, the plugin needs one authoritative language source and predictable English fallback without creating a second language preference that can disagree with Obsidian.

## What

Copilot now initializes interface localization from Obsidian's public language API before registering user-facing behavior.

| Obsidian language | Copilot locale | Current result |
| --- | --- | --- |
| English | `en` | English source catalog |
| Simplified Chinese | `zh-CN` | English until the Simplified catalog ships |
| Traditional Chinese | `zh-TW` | English until the Taiwan Traditional catalog ships |
| Unsupported language | `en` | English fallback |

Localized messages fall directly back to English when a key is missing. The shared contract also covers whole-message interpolation, plural forms, and locale-aware number and date formatting.

## Non goal

- Extracting the existing English UI strings.
- Shipping any non-English catalog.
- Adding a Copilot-specific language override.
- Translating AI responses, prompts, notes, provider output, or external documentation.
- Adding a hosted translation service.

## Screenshot

Not applicable. This PR adds the non-visual localization foundation and deliberately changes no rendered interface strings.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Deterministic tests cover locale selection, fallback, interpolation, plurals, and formatting |
| A defect would fail CI or be obvious on first use | ✅ | The localization contract and production bundle limit are enforced by automated tests and build checks |
| A revert fully restores prior state, including persisted data | ✅ | No settings or persisted data change |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Localization reads only Obsidian's public interface-language value |
| No public API, plugin API, message, or on-disk contract changes | ✅ | The new contract is internal and writes no external state |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Startup performs one synchronous language lookup |
| No hot-path behavior lacks deterministic coverage | ✅ | Every localization callable and fallback branch has unit coverage |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | No human-only behavior remains; this foundation is exercised deterministically |

Review: inspect `initializeI18n()`, `t()`, and the locale map in `src/i18n/index.ts` and `src/i18n/locale.ts`, then run both Verification steps.

## Verification

1. Run `npm test -- --runInBand src/i18n/index.test.ts`; all localization contract tests should pass.
2. Run `npm run build`; TypeScript, production bundling, and the unchanged Obsidian Sync size guard should pass.
