### PR TITLE
[Chinese localization] - Step 2: Create bundle headroom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,7 @@
         "stylelint-config-obsidianmd": "0.1.0",
         "tailwindcss": "^3.4.15",
         "tailwindcss-animate": "^1.0.7",
+        "terser": "5.51.2",
         "ts-jest": "^29.1.0",
         "tslib": "2.4.0",
         "typescript": "^5.7.2",
@@ -2561,6 +2562,17 @@
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -8570,6 +8582,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/compare-versions": {
       "version": "6.1.1",
@@ -17363,6 +17382,36 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.51.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.51.2.tgz",
+      "integrity": "sha512-bWnjSNscmuI+GJze6ZupnHP8G/cTcsJF+bXCeQknk2SHQsgbNJnLrqiH9jZ2W4STPVXH2mDKKRX3iwPhc9Cn/Q==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/test-exclude": {

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "stylelint-config-obsidianmd": "0.1.0",
     "tailwindcss": "^3.4.15",
     "tailwindcss-animate": "^1.0.7",
+    "terser": "5.51.2",
     "ts-jest": "^29.1.0",
     "tslib": "2.4.0",
     "typescript": "^5.7.2",

--- a/scripts/bundleSizeGuard.js
+++ b/scripts/bundleSizeGuard.js
@@ -2,6 +2,7 @@
 
 const fs = require("node:fs");
 const path = require("node:path");
+const { minify } = require("terser");
 const ts = require("typescript");
 
 const MAX_BUNDLE_BYTES = 5_000_000;
@@ -124,6 +125,21 @@ function assertBundleSize(source, maxBytes = MAX_BUNDLE_BYTES) {
   return bytes;
 }
 
+async function finalizeProductionBundle(source, maxBytes = MAX_BUNDLE_BYTES) {
+  const deduplicated = dedupeEsbuildLegalComments(source);
+  // Localization catalogs are static bundle data, so the final minifier must run before the
+  // release-size assertion. https://github.com/Brevilabs/obsidian-copilot-private/issues/325
+  const result = await minify(deduplicated, {
+    ecma: 2020,
+    compress: { passes: 3, toplevel: true },
+    mangle: { toplevel: true },
+    format: { comments: "some" },
+  });
+  const output = result.code;
+  assertBundleSize(output, maxBytes);
+  return output;
+}
+
 function createBundleSizeGuard({ production }) {
   return {
     name: "bundle-size-guard",
@@ -140,14 +156,13 @@ function createBundleSizeGuard({ production }) {
       // notice block and skip release-only enforcement for issue #94.
       // https://github.com/Brevilabs/obsidian-copilot-private/issues/94
       if (!production) return;
-      build.onEnd((result) => {
+      build.onEnd(async (result) => {
         if (result.errors.length > 0) return;
         const outfile = build.initialOptions.outfile;
         if (!outfile) throw new Error("[bundle-size-guard] expected an outfile");
 
         const source = fs.readFileSync(outfile, "utf8");
-        const output = dedupeEsbuildLegalComments(source);
-        assertBundleSize(output);
+        const output = await finalizeProductionBundle(source);
         fs.writeFileSync(outfile, output, "utf8");
       });
     },
@@ -158,5 +173,6 @@ module.exports = {
   assertBundleSize,
   createBundleSizeGuard,
   dedupeEsbuildLegalComments,
+  finalizeProductionBundle,
   rewriteExactZodImports,
 };

--- a/scripts/bundleSizeGuard.test.js
+++ b/scripts/bundleSizeGuard.test.js
@@ -4,6 +4,7 @@ const {
   assertBundleSize,
   createBundleSizeGuard,
   dedupeEsbuildLegalComments,
+  finalizeProductionBundle,
   rewriteExactZodImports,
 } = require("./bundleSizeGuard.js");
 
@@ -129,6 +130,54 @@ describe("bundleSizeGuard", () => {
     it("measures UTF-8 bytes and enforces a strict boundary for https://github.com/Brevilabs/obsidian-copilot-private/issues/94", () => {
       expect(assertBundleSize("é", 3)).toBe(2);
       expect(() => assertBundleSize("é", 2)).toThrow("strictly below 2 bytes");
+    });
+  });
+
+  describe("finalizeProductionBundle()", () => {
+    it("minifies representative code and preserves the deduplicated legal block for https://github.com/Brevilabs/obsidian-copilot-private/issues/325", async () => {
+      const notice = "  (** @license Example 1.0 *)";
+      const source = legalBundle(
+        legalEntry("first.js", notice),
+        legalEntry("second.js", notice)
+      ).replace(
+        "runtime();",
+        "function add(firstNumber, secondNumber) { return firstNumber + secondNumber; } add(1, 2);"
+      );
+
+      const output = await finalizeProductionBundle(source);
+
+      expect(Buffer.byteLength(output, "utf8")).toBeLessThan(Buffer.byteLength(source, "utf8"));
+      expect(output).toContain("/*! Bundled license information:");
+      expect(output).toContain("first.js (+1 identical notices)");
+      expect(output).toContain("@license Example 1.0");
+    });
+
+    it("removes unused top-level declarations to preserve localization headroom for https://github.com/Brevilabs/obsidian-copilot-private/issues/325", async () => {
+      const source = legalBundle(legalEntry("example.js", "  (** @license Example 1.0 *)")).replace(
+        "runtime();",
+        "const unusedLocalizationHeadroom = 'unused'; globalThis.keptValue = 'kept';"
+      );
+
+      const output = await finalizeProductionBundle(source);
+
+      expect(output).not.toContain("unusedLocalizationHeadroom");
+      expect(output).not.toContain("unused");
+      expect(output).toContain("kept");
+    });
+
+    it("enforces the strict size limit on the minified artifact for https://github.com/Brevilabs/obsidian-copilot-private/issues/325", async () => {
+      const source = legalBundle(legalEntry("example.js", "  (** @license Example 1.0 *)")).replace(
+        "runtime();",
+        "function identity(longArgumentName) { return longArgumentName; } identity(1);"
+      );
+      const finalized = await finalizeProductionBundle(source);
+      const finalizedBytes = Buffer.byteLength(finalized, "utf8");
+
+      expect(Buffer.byteLength(source, "utf8")).toBeGreaterThan(finalizedBytes + 1);
+      await expect(finalizeProductionBundle(source, finalizedBytes + 1)).resolves.toBe(finalized);
+      await expect(finalizeProductionBundle(source, finalizedBytes)).rejects.toThrow(
+        `strictly below ${finalizedBytes} bytes`
+      );
     });
   });
 });


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#325

## Why

The localization foundation leaves `main.js` only 2,514 bytes below Obsidian Sync's strict 5 MB limit. The agreed Simplified Chinese Settings and Agent Chat catalogs need substantially more space, so adding them directly would make the production build fail before any translated interface could ship.

## What

Production builds now apply a final minification pass before enforcing the unchanged 5 MB limit. The final artifact retains its bundled legal notices and has enough measured headroom for the first Chinese catalog slices. Development and watch builds behave as before.

## Non goal

This PR does not extract interface strings, add a locale catalog, translate any UI, change the 5 MB limit, or alter plugin runtime behavior.

## Screenshot

Not applicable. This PR changes the production build artifact only and has no rendered UI state.

## Risk

**Medium**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Deterministic guard tests cover final minification, legal-notice preservation, and final-size enforcement |
| A defect would fail CI or be obvious on first use | ✅ | Production build and mobile bundle evaluation exercise the generated artifact |
| A revert fully restores prior state, including persisted data | ✅ | The change affects only generated build output and has no persisted data |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | The plugin runtime and its inputs are unchanged |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Release artifact format and plugin interfaces are unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Only the build pipeline changes |
| No hot-path behavior lacks deterministic coverage | ✅ | No runtime hot path changes |
| No new dependency | ❌ | Terser is added as a pinned development-only build dependency |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Any artifact failure appears during production build or plugin load |

Review: inspect `finalizeProductionBundle` in `scripts/bundleSizeGuard.js` and its tests in `scripts/bundleSizeGuard.test.js`, then run Verification steps 1-3.

## Verification

1. Run `npm run build` and confirm the strict bundle-size guard succeeds.
2. Confirm `main.js` remains below 5,000,000 bytes and its bundled legal block is still present.
3. Run `npm run test:mobile-load` and confirm the production artifact evaluates successfully in the mobile runtime harness.
