### PR TITLE
Keep Agent Home rows clear of the scrollbar

### DIFF
--- a/src/agentMode/ui/AgentHomeSection.test.tsx
+++ b/src/agentMode/ui/AgentHomeSection.test.tsx
@@ -4,6 +4,17 @@ import React from "react";
 
 describe("AgentHomeSection", () => {
   describe("AgentHomePreviewList()", () => {
+    it("keeps preview row content clear of the overlaid scrollbar (https://github.com/logancyang/obsidian-copilot/issues/3017)", () => {
+      const { container } = render(
+        <AgentHomePreviewList hasMoreItems={false}>
+          <div>Preview rows</div>
+        </AgentHomePreviewList>
+      );
+      const viewport = container.querySelector<HTMLElement>("[data-radix-scroll-area-viewport]");
+
+      expect(viewport?.parentElement?.classList.contains("tw-pr-2.5")).toBe(true);
+    });
+
     it("shows the shared footer only when rows exceed the available height or preview limit (https://github.com/Brevilabs/obsidian-copilot-private/issues/169)", () => {
       const renderPreview = (hasMoreItems: boolean) => (
         <AgentHomePreviewList hasMoreItems={hasMoreItems} viewAll={<div>View all items</div>}>

--- a/src/agentMode/ui/AgentHomeSection.tsx
+++ b/src/agentMode/ui/AgentHomeSection.tsx
@@ -256,7 +256,10 @@ export function AgentHomePreviewList({
 
   return (
     <div className="tw-flex tw-min-h-0 tw-flex-1 tw-flex-col tw-divide-y tw-divide-border">
-      <ScrollArea ref={scrollRootRef} className="tw-min-h-0 tw-flex-1 tw-overflow-y-auto">
+      {/* Radix overlays its 10px scrollbar, so the matching gutter keeps every
+          Agent Home row's time and actions readable without narrowing all
+          ScrollArea consumers. https://github.com/logancyang/obsidian-copilot/issues/3017 */}
+      <ScrollArea ref={scrollRootRef} className="tw-min-h-0 tw-flex-1 tw-overflow-y-auto tw-pr-2.5">
         {children}
       </ScrollArea>
       {showViewAll && (


### PR DESCRIPTION
Fixes #3017

## Why

When an Agent Home shelf contains enough chats or projects to scroll, its scrollbar sits on top of each row's right-aligned relative time. The bar cuts off the last character on every visible row and can also cover the inline actions that replace the time on hover.

## What

Agent Home shelf rows now stop before the scrollbar's permanent strip. Relative times and hover actions remain fully visible in Recent Chats, Projects, and Project Chats, with no horizontal jump when overflow changes.

## Non goal

- Changing the scrollbar's width, color, or visibility behavior.
- Reserving a gutter in scrollable lists outside the Agent Home shelf.
- Changing the separate View all chats or View all projects popover lists.

## Screenshot

**Before**

![Agent Home relative times clipped beneath the scrollbar](https://github.com/user-attachments/assets/8c51c4f0-7a6e-48dc-a965-b22d16ad6d82)

**After**

![Agent Home relative times fully visible beside the scrollbar](https://github.com/user-attachments/assets/e74b7f23-0ff3-4a51-93a6-6e90b7cdd37b)

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | A component test verifies the permanent shared-shell gutter, and matched gallery images show the rendered result |
| A defect would fail CI or be obvious on first use | ✅ | The class contract runs in CI and overflow makes any overlap immediately visible |
| A revert fully restores prior state, including persisted data | ✅ | The change writes no data and a revert restores the prior layout |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Only spacing in the Agent Home list shell changes |
| No public API, plugin API, message, or on-disk contract changes | ✅ | The component interface and persisted state are unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Scroll measurement and list behavior are unchanged |
| No hot-path behavior lacks deterministic coverage | ✅ | The changed shared-shell class is covered directly |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | The effect is limited to Agent Home overflow lists and is visible as soon as the scrollbar appears |

Review: run Verification step 2 and confirm the full relative times and hover actions clear the scrollbar.

## Verification

1. Open Agent Home with enough recent chats to make the Recent Chats shelf scroll.
2. Show the scrollbar and confirm every relative time remains fully readable, then hover rows and confirm their inline actions remain fully visible and clickable.
3. Repeat the same check in Projects and in a project's Project Chats shelf.
