### PR TITLE
Remove the redundant View all chats expansion

### DIFF
--- a/designdocs/AGENT_HOME_ARCHITECTURE.md
+++ b/designdocs/AGENT_HOME_ARCHITECTURE.md
@@ -25,7 +25,7 @@ and are not covered here.
 | AgentHome layout shell, persistent (no `key` remount)     | ✅ build (no-project state)                | + project state                         |
 | No-project landing (centered composer → pin to bottom)    | ✅                                         | —                                       |
 | Multi-session tabs (`AgentTabStrip`)                      | ✅ reuse, global                           | project-scoped                          |
-| Recent Chats section                                      | ✅ inline 3 + `ChatHistoryPopover`         | per-scope                               |
+| Recent Chats section                                      | ✅ searchable scrolling list               | per-scope                               |
 | Per-session compose drafts                                | ✅ queue survives switch, foreground flush | session-layer auto-flush still deferred |
 | Projects section                                          | ✅ read-only list + picker                 | real entry + CRUD                       |
 | Enter a project (header + per-project sessions + Context) | ❌ coming-soon `Notice`                    | ✅                                      |
@@ -152,12 +152,11 @@ strand it; the replacement session inherits the replaced session's `projectId`
 
 The landing's two shelves sit at different capability levels on purpose: in PR1
 Projects was read-only (a coming-soon `Notice`) because real project management
-is backend work, while Recent Chats was fully manageable by reusing the existing
-`ChatHistoryPopover` (search / rename / delete / open-source). The shared shelf
-building blocks live in `AgentHomeSection.tsx` (`AgentHomeSection` /
-`AgentHomeListRow` / generic `AgentHomeViewAll<TItem>` with lazy
-`IntersectionObserver` paging), kept generic so PR2's project-scoped shelves
-reuse them.
+is backend work, while Recent Chats was fully manageable in place (search /
+rename / delete / open-source). The chat list scrolls inside the shelf and keeps
+all results on that one surface. The shared shelf building blocks live in
+`AgentHomeSection.tsx`; Projects additionally use the generic
+`AgentHomeViewAll<TItem>` with lazy `IntersectionObserver` paging.
 
 The reuse rule of thumb: **a pure function, read-only selector, or side-effect-free
 hook is reused; a controller component or a hook that writes global state is

--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -92,7 +92,7 @@ Agent Chat keeps each conversation separate:
 
 - Select **+** for another session. Each tab keeps its own history, draft, attachments, and queued follow-ups.
 - Select **New Chat** to reset the current tab.
-- Use **Recent Chats** from the Agent Chat home screen, or **Chat History** inside a conversation, to resume saved work.
+- Use **Recent Chats** from the Agent Chat home screen, or **Chat History** inside a conversation, to resume saved work. The **Recent Chats** list can be scrolled or searched.
 - Add the active note, selected text, other notes, folders, a Copilot Web Viewer tab, or supported images. You can also mention a note with `[[Note title]]`.
 - Hover the context ring beside the send controls to see how much of the model's context window is in use. If the connected account reports usage limits, the same panel shows the available limit and reset time.
 

--- a/src/agentMode/ui/AgentHome.tsx
+++ b/src/agentMode/ui/AgentHome.tsx
@@ -473,9 +473,9 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
   //   previous visit (e.g. "New chat" right after a project's first
   //   conversation), so a refresh that finds chats corrects the layout — that
   //   flip lands within the visit's first moments, while the reverse
-  //   (shelf→standalone, e.g. deleting the last chat from the View-all popover
-  //   mid-visit) would yank the card out from under an open popover. The shelf
-  //   just shows the project empty copy until the next visit re-decides.
+  //   (shelf→standalone, e.g. deleting the last chat mid-visit) would yank the
+  //   card out from under the user. The shelf just shows the project empty copy
+  //   until the next visit re-decides.
   //
   // Written during render — the same derive-from-props pattern as the header
   // latch above.

--- a/src/agentMode/ui/AgentHome.tsx
+++ b/src/agentMode/ui/AgentHome.tsx
@@ -562,6 +562,7 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
             runningChatIds={runningChatIds}
             attentionChatIds={attentionChatIds}
             projectNamesById={projectNamesById}
+            sortStrategy={settings.chatHistorySortStrategy}
           />
         ),
       },
@@ -617,6 +618,7 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
       attentionChatIds,
       isRelevantNotesPaneOpen,
       plugin,
+      settings.chatHistorySortStrategy,
     ]
   );
 
@@ -649,6 +651,7 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
             onLoadHistory={handleLoadChatHistorySafely}
             runningChatIds={runningChatIds}
             attentionChatIds={attentionChatIds}
+            sortStrategy={settings.chatHistorySortStrategy}
           />
         ),
       },
@@ -675,6 +678,7 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
       handleLoadChatHistorySafely,
       runningChatIds,
       attentionChatIds,
+      settings.chatHistorySortStrategy,
     ]
   );
 

--- a/src/agentMode/ui/AgentHomeSection.tsx
+++ b/src/agentMode/ui/AgentHomeSection.tsx
@@ -17,11 +17,9 @@ import React, {
 
 /**
  * Shared building blocks for the Agent Home landing section bodies (Projects,
- * Recent Chats): a few inline rows plus a "View all" popover with search. That
- * structure lives here once so each section supplies only its data and row click
- * behavior. The section title/count/collapse now live in the shelf chip above
- * the panel (see {@link AgentHomeShelf}); this file is just the row and view-all
- * primitives.
+ * Recent Chats): rows, a bounded scroll region, and the Projects "View all"
+ * popover. The section title/count/collapse live in the shelf chip above the
+ * panel (see {@link AgentHomeShelf}).
  */
 
 /**

--- a/src/agentMode/ui/AgentLandingStack.stories.tsx
+++ b/src/agentMode/ui/AgentLandingStack.stories.tsx
@@ -31,7 +31,6 @@ const sections: AgentHomeShelfSection[] = [
               {row}
             </div>
           ))}
-          <div className="tw-px-2 tw-py-1.5 tw-text-xs tw-text-accent">View all chats</div>
         </div>
       </div>
     ),

--- a/src/agentMode/ui/GlobalRecentChatsSection.stories.tsx
+++ b/src/agentMode/ui/GlobalRecentChatsSection.stories.tsx
@@ -9,7 +9,7 @@ type GlobalRecentChatsSectionProps = React.ComponentProps<typeof GlobalRecentCha
 const noop = async () => {};
 const noopSync = () => {};
 
-const items: GlobalRecentChatsSectionProps["items"] = Array.from({ length: 14 }, (_, index) => ({
+const items: GlobalRecentChatsSectionProps["items"] = Array.from({ length: 60 }, (_, index) => ({
   id: `recent-chat-${index + 1}`,
   title:
     index === 3

--- a/src/agentMode/ui/GlobalRecentChatsSection.stories.tsx
+++ b/src/agentMode/ui/GlobalRecentChatsSection.stories.tsx
@@ -50,11 +50,11 @@ function renderShelf(args: Partial<GlobalRecentChatsSectionProps>) {
   return <AgentHomeShelf sections={sections} />;
 }
 
-export const FitsWithoutFooter: StoryObj<GlobalRecentChatsSectionProps> = {
+export const ShortList: StoryObj<GlobalRecentChatsSectionProps> = {
   args: { items: items.slice(0, 5) },
   render: renderShelf,
 };
 
-export const Overflow: StoryObj<GlobalRecentChatsSectionProps> = {
+export const ScrollableList: StoryObj<GlobalRecentChatsSectionProps> = {
   render: renderShelf,
 };

--- a/src/agentMode/ui/GlobalRecentChatsSection.test.tsx
+++ b/src/agentMode/ui/GlobalRecentChatsSection.test.tsx
@@ -16,6 +16,7 @@ function renderSection(props: Partial<React.ComponentProps<typeof GlobalRecentCh
       runningChatIds={props.runningChatIds}
       attentionChatIds={props.attentionChatIds}
       projectNamesById={props.projectNamesById}
+      sortStrategy={props.sortStrategy}
       onLoadChat={noop}
       onUpdateTitle={noop}
       onDeleteChat={noop}
@@ -228,6 +229,34 @@ describe("GlobalRecentChatsSection", () => {
       } finally {
         observer.restore();
       }
+    });
+
+    it("https://github.com/logancyang/obsidian-copilot/issues/3040 honors the saved name and created chat-history sort strategies", () => {
+      const items = [
+        makeItem("alpha", {
+          title: "Alpha",
+          createdAt: new Date("2026-01-01T00:00:00Z"),
+          lastAccessedAt: new Date("2026-01-03T00:00:00Z"),
+        }),
+        makeItem("zulu", {
+          title: "Zulu",
+          createdAt: new Date("2026-01-02T00:00:00Z"),
+          lastAccessedAt: new Date("2026-01-01T00:00:00Z"),
+        }),
+      ];
+
+      const { unmount } = renderSection({ items, sortStrategy: "name" });
+      expect(screen.getAllByText(/^(Alpha|Zulu)$/).map((element) => element.textContent)).toEqual([
+        "Alpha",
+        "Zulu",
+      ]);
+      unmount();
+
+      renderSection({ items, sortStrategy: "created" });
+      expect(screen.getAllByText(/^(Alpha|Zulu)$/).map((element) => element.textContent)).toEqual([
+        "Zulu",
+        "Alpha",
+      ]);
     });
 
     it("https://github.com/logancyang/obsidian-copilot/issues/3040 renders at most 50 chats before the user scrolls", () => {

--- a/src/agentMode/ui/GlobalRecentChatsSection.test.tsx
+++ b/src/agentMode/ui/GlobalRecentChatsSection.test.tsx
@@ -5,21 +5,6 @@ import { safeAsyncHandler } from "@/utils/safeAsyncHandler";
 
 type SectionItems = React.ComponentProps<typeof GlobalRecentChatsSection>["items"];
 
-// jsdom lacks Obsidian's portal document and the observer used to page the open
-// View-all popover, so supply inert browser equivalents for that interaction.
-beforeAll(() => {
-  (window as unknown as { activeDocument: Document }).activeDocument = window.document;
-  window.IntersectionObserver = class implements IntersectionObserver {
-    readonly root = null;
-    readonly rootMargin = "";
-    readonly thresholds = [];
-    disconnect = jest.fn();
-    observe = jest.fn();
-    takeRecords = jest.fn(() => []);
-    unobserve = jest.fn();
-  };
-});
-
 const noop = async () => {};
 
 function renderSection(props: Partial<React.ComponentProps<typeof GlobalRecentChatsSection>> = {}) {
@@ -151,11 +136,11 @@ describe("GlobalRecentChatsSection", () => {
       expect(titleElement.getAttribute("title")).toBe(title);
     });
 
-    it("caps the inline preview at 10 chats and offers a View-all trigger on overflow", () => {
+    it("renders every chat in the existing scroll region without a View-all trigger", () => {
       const items = Array.from({ length: 12 }, (_, i) => makeItem(`overflow-${i}`));
       const { container } = renderSection({ items });
-      expect(screen.getAllByText(/^Chat overflow-/)).toHaveLength(10);
-      expect(screen.getByText("View all chats")).toBeTruthy();
+      expect(screen.getAllByText(/^Chat overflow-/)).toHaveLength(12);
+      expect(screen.queryByText("View all chats")).toBeNull();
 
       const scrollRegion = container.querySelector(
         "[data-radix-scroll-area-viewport]"
@@ -166,7 +151,7 @@ describe("GlobalRecentChatsSection", () => {
       expect(scrollRegion?.parentElement?.classList.contains("tw-flex-1")).toBe(true);
     });
 
-    it("renders project badges in the View-all popover from the global landing", () => {
+    it("renders project badges for every chat in the global scroll region", () => {
       const items = Array.from({ length: 11 }, (_, i) =>
         makeItem(`project-overflow-${i}`, { projectId: "project-1" })
       );
@@ -175,19 +160,16 @@ describe("GlobalRecentChatsSection", () => {
         projectNamesById: { "project-1": "Product research" },
       });
 
-      expect(screen.getAllByLabelText("Project: Product research")).toHaveLength(10);
-      fireEvent.click(screen.getByText("View all chats"));
-      expect(screen.getAllByLabelText("Project: Product research")).toHaveLength(21);
+      expect(screen.getAllByLabelText("Project: Product research")).toHaveLength(11);
     });
 
-    it("shows every match (no cap, no View-all) while searching", () => {
+    it("filters the full scrollable list while searching", () => {
       const items = Array.from({ length: 7 }, (_, i) => makeItem(`search-${i}`));
       renderSection({ items });
       fireEvent.change(screen.getByPlaceholderText("Search chats..."), {
         target: { value: "Chat search" },
       });
       expect(screen.getAllByText(/^Chat search-/)).toHaveLength(7);
-      expect(screen.queryByText("View all chats")).toBeNull();
     });
 
     it("refreshes once when the parent re-renders with the items that refresh produced", () => {

--- a/src/agentMode/ui/GlobalRecentChatsSection.test.tsx
+++ b/src/agentMode/ui/GlobalRecentChatsSection.test.tsx
@@ -17,10 +17,10 @@ function renderSection(props: Partial<React.ComponentProps<typeof GlobalRecentCh
       attentionChatIds={props.attentionChatIds}
       projectNamesById={props.projectNamesById}
       sortStrategy={props.sortStrategy}
-      onLoadChat={noop}
-      onUpdateTitle={noop}
-      onDeleteChat={noop}
-      onOpenSourceFile={noop}
+      onLoadChat={props.onLoadChat ?? noop}
+      onUpdateTitle={props.onUpdateTitle ?? noop}
+      onDeleteChat={props.onDeleteChat ?? noop}
+      onOpenSourceFile={props.onOpenSourceFile ?? noop}
     />
   );
 }
@@ -304,6 +304,38 @@ describe("GlobalRecentChatsSection", () => {
       } finally {
         observer.restore();
       }
+    });
+
+    it("https://github.com/logancyang/obsidian-copilot/issues/3040 keeps a rename draft when updating the title fails", async () => {
+      const onUpdateTitle = jest.fn(async () => {
+        throw new Error("rename failed");
+      });
+      renderSection({ items: [makeItem("rename-failure")], onUpdateTitle });
+
+      fireEvent.click(screen.getByTitle("Rename"));
+      const input = screen.getByDisplayValue("Chat rename-failure");
+      fireEvent.change(input, { target: { value: "Retained draft" } });
+      await act(async () => {
+        fireEvent.keyDown(input, { key: "Enter" });
+      });
+
+      expect(onUpdateTitle).toHaveBeenCalledWith("rename-failure", "Retained draft");
+      expect(screen.getByDisplayValue("Retained draft")).toBeTruthy();
+    });
+
+    it("https://github.com/logancyang/obsidian-copilot/issues/3040 keeps delete confirmation available when deletion fails", async () => {
+      const onDeleteChat = jest.fn(async () => {
+        throw new Error("delete failed");
+      });
+      renderSection({ items: [makeItem("delete-failure")], onDeleteChat });
+
+      fireEvent.click(screen.getByTitle("Delete"));
+      await act(async () => {
+        fireEvent.click(screen.getByTitle("Confirm delete"));
+      });
+
+      expect(onDeleteChat).toHaveBeenCalledWith("delete-failure");
+      expect(screen.getByTitle("Confirm delete")).toBeTruthy();
     });
 
     it("refreshes once when the parent re-renders with the items that refresh produced", () => {

--- a/src/agentMode/ui/GlobalRecentChatsSection.test.tsx
+++ b/src/agentMode/ui/GlobalRecentChatsSection.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { GlobalRecentChatsSection } from "@/agentMode/ui/GlobalRecentChatsSection";
 import { safeAsyncHandler } from "@/utils/safeAsyncHandler";
 
@@ -42,6 +42,56 @@ function makeItem(
     createdAt: new Date(),
     lastAccessedAt: new Date(),
     ...overrides,
+  };
+}
+
+function makeRecentItems(prefix: string, count: number): SectionItems {
+  const now = Date.now();
+  return Array.from({ length: count }, (_, index) =>
+    makeItem(`${prefix}-${index}`, {
+      createdAt: new Date(now - index),
+      lastAccessedAt: new Date(now - index),
+    })
+  );
+}
+
+function installIntersectionObserverMock(): {
+  intersect: () => void;
+  restore: () => void;
+} {
+  const original = window.IntersectionObserver;
+  let callback: IntersectionObserverCallback | undefined;
+  const observer = {
+    disconnect: jest.fn(),
+    observe: jest.fn(),
+    takeRecords: jest.fn(() => []),
+    unobserve: jest.fn(),
+    root: null,
+    rootMargin: "0px",
+    thresholds: [0.1],
+  } satisfies IntersectionObserver;
+
+  Object.defineProperty(window, "IntersectionObserver", {
+    configurable: true,
+    writable: true,
+    value: jest.fn((nextCallback: IntersectionObserverCallback) => {
+      callback = nextCallback;
+      return observer;
+    }),
+  });
+
+  return {
+    intersect: () => {
+      if (!callback) throw new Error("IntersectionObserver was not created");
+      callback([{ isIntersecting: true } as IntersectionObserverEntry], observer);
+    },
+    restore: () => {
+      Object.defineProperty(window, "IntersectionObserver", {
+        configurable: true,
+        writable: true,
+        value: original,
+      });
+    },
   };
 }
 
@@ -163,13 +213,68 @@ describe("GlobalRecentChatsSection", () => {
       expect(screen.getAllByLabelText("Project: Product research")).toHaveLength(11);
     });
 
-    it("filters the full scrollable list while searching", () => {
-      const items = Array.from({ length: 7 }, (_, i) => makeItem(`search-${i}`));
-      renderSection({ items });
-      fireEvent.change(screen.getByPlaceholderText("Search chats..."), {
-        target: { value: "Chat search" },
-      });
-      expect(screen.getAllByText(/^Chat search-/)).toHaveLength(7);
+    it("https://github.com/logancyang/obsidian-copilot/issues/3040 finds an older chat beyond the initial rendered batch", () => {
+      const observer = installIntersectionObserverMock();
+      try {
+        const items = makeRecentItems("search", 120);
+        renderSection({ items });
+        expect(screen.queryByText("Chat search-100")).toBeNull();
+
+        fireEvent.change(screen.getByPlaceholderText("Search chats..."), {
+          target: { value: "Chat search-100" },
+        });
+
+        expect(screen.getByText("Chat search-100")).toBeTruthy();
+      } finally {
+        observer.restore();
+      }
+    });
+
+    it("https://github.com/logancyang/obsidian-copilot/issues/3040 renders at most 50 chats before the user scrolls", () => {
+      const observer = installIntersectionObserverMock();
+      try {
+        const items = makeRecentItems("paged", 120);
+        renderSection({ items });
+
+        expect(screen.getAllByText(/^Chat paged-/)).toHaveLength(50);
+        expect(screen.queryByText("Chat paged-50")).toBeNull();
+      } finally {
+        observer.restore();
+      }
+    });
+
+    it("https://github.com/logancyang/obsidian-copilot/issues/3040 appends 50 chats when the scroll sentinel enters view", () => {
+      const observer = installIntersectionObserverMock();
+      try {
+        const items = makeRecentItems("paged", 120);
+        renderSection({ items });
+
+        act(() => observer.intersect());
+
+        expect(screen.getAllByText(/^Chat paged-/)).toHaveLength(100);
+        expect(screen.getByText("Chat paged-50")).toBeTruthy();
+        expect(screen.queryByText("Chat paged-100")).toBeNull();
+      } finally {
+        observer.restore();
+      }
+    });
+
+    it("https://github.com/logancyang/obsidian-copilot/issues/3040 resets a new search to the first 50 matching chats", () => {
+      const observer = installIntersectionObserverMock();
+      try {
+        const items = makeRecentItems("search-page", 120);
+        renderSection({ items });
+        act(() => observer.intersect());
+        expect(screen.getAllByText(/^Chat search-page-/)).toHaveLength(100);
+
+        fireEvent.change(screen.getByPlaceholderText("Search chats..."), {
+          target: { value: "Chat search-page" },
+        });
+
+        expect(screen.getAllByText(/^Chat search-page-/)).toHaveLength(50);
+      } finally {
+        observer.restore();
+      }
     });
 
     it("refreshes once when the parent re-renders with the items that refresh produced", () => {

--- a/src/agentMode/ui/GlobalRecentChatsSection.tsx
+++ b/src/agentMode/ui/GlobalRecentChatsSection.tsx
@@ -1,17 +1,10 @@
 import { backendRegistry } from "@/agentMode/backends/registry";
-import {
-  AgentHomePreviewList,
-  AgentHomeViewAllTrigger,
-  INLINE_LIMIT,
-} from "@/agentMode/ui/AgentHomeSection";
+import { AgentHomePreviewList } from "@/agentMode/ui/AgentHomeSection";
 import { RecentChatProjectBadge, RecentChatTitle } from "@/agentMode/ui/RecentChatTitle";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { SearchBar } from "@/components/ui/SearchBar";
-import {
-  ChatHistoryItem,
-  ChatHistoryPopover,
-} from "@/components/chat-components/ChatHistoryPopover";
+import { type ChatHistoryItem } from "@/components/chat-components/ChatHistoryPopover";
 import { ChatIconWithAttention } from "@/components/chat-components/ChatIconWithAttention";
 import { cn } from "@/lib/utils";
 import { isNativeChatId } from "@/utils/nativeChatId";
@@ -330,12 +323,11 @@ const RecentChatRow = memo(function RecentChatRow({
  * "Recent Chats" section for the Agent Home landing. A searchable list whose
  * rows manage chats in place — open, rename, delete, and (for markdown-saved
  * chats only) open the source note — the same affordances as the chat history
- * popover. The inline preview caps at {@link INLINE_LIMIT}; overflow lives
- * behind a "View all chats" trigger that opens the full
- * {@link ChatHistoryPopover}, while searching surfaces every match. Native
- * (autosave-off) sessions appear here too; they just have no source note. The
- * per-project landing reuses it (`variant="project"`) with scoped items and
- * project empty copy — identical rows, no extra chrome.
+ * popover. Every chat stays in this section's scrollable list, and search
+ * filters that same list without opening a second surface. Native (autosave-off)
+ * sessions appear here too; they just have no source note. The per-project
+ * landing reuses it (`variant="project"`) with scoped items and project empty
+ * copy — identical rows, no extra chrome.
  */
 export const GlobalRecentChatsSection = memo(function GlobalRecentChatsSection({
   items,
@@ -356,31 +348,19 @@ export const GlobalRecentChatsSection = memo(function GlobalRecentChatsSection({
   const [editingTitle, setEditingTitle] = useState("");
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
 
-  // Refresh once when the section first mounts (i.e. the user opened the
-  // Recent Chats tab), mirroring the old popover's refresh-on-open.
+  // Refresh once when the section first mounts so opening Recent Chats does
+  // not rely on a stale history snapshot.
   useEffect(() => {
     onLoadHistory?.();
   }, [onLoadHistory]);
 
-  // Sort once for the inline preview (fixed recent-first, like the rest of the
-  // landing); the View-all popover re-sorts the full list by the user's
-  // configured chatHistorySortStrategy — the same management surface as the
-  // control bar's History button — so it reads raw `items` directly below.
+  // Sort once for the landing's fixed recent-first order.
   const sortedItems = useMemo(() => sortChatsByRecent(items), [items]);
-  const isSearching = query.trim().length > 0;
   const filteredItems = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return sortedItems;
     return sortedItems.filter((item) => item.title.toLowerCase().includes(q));
   }, [sortedItems, query]);
-  // Inline preview caps at INLINE_LIMIT; a search shows every match (the cap
-  // would hide exactly what the user is looking for).
-  const visibleItems = useMemo(
-    () => (isSearching ? filteredItems : filteredItems.slice(0, INLINE_LIMIT)),
-    [filteredItems, isSearching]
-  );
-  const hasMoreItems = !isSearching && filteredItems.length > visibleItems.length;
-
   const handleStartEdit = useCallback((id: string, title: string) => {
     setConfirmDeleteId(null);
     setEditingId(id);
@@ -425,14 +405,6 @@ export const GlobalRecentChatsSection = memo(function GlobalRecentChatsSection({
       variant === "global" && item.projectId ? projectNamesById?.[item.projectId] : undefined,
     [projectNamesById, variant]
   );
-  const renderProjectBadge = useCallback(
-    (item: ChatHistoryItem): React.ReactNode => {
-      const projectName = getProjectName(item);
-      return projectName ? <RecentChatProjectBadge name={projectName} /> : null;
-    },
-    [getProjectName]
-  );
-
   return (
     <div
       role={title ? "group" : undefined}
@@ -463,52 +435,9 @@ export const GlobalRecentChatsSection = memo(function GlobalRecentChatsSection({
               : "No recent chats"}
         </div>
       ) : (
-        <AgentHomePreviewList
-          hasMoreItems={hasMoreItems}
-          viewAll={
-            !isSearching ? (
-              <ChatHistoryPopover
-                chatHistory={items}
-                onUpdateTitle={onUpdateTitle}
-                onDeleteChat={onDeleteChat}
-                onLoadChat={onLoadChat}
-                onOpenSourceFile={onOpenSourceFile}
-                getIcon={resolveChatIcon}
-                getBadge={renderProjectBadge}
-                // Full-width row near the pane's lower half: open downward like
-                // an accordion. Radix flips to "top" if the area below is tight.
-                side="bottom"
-                align="start"
-              >
-                {/* DESIGN NOTE: unlike these inline rows, the popover's rows show
-                  the open-source-note action for native (autosave-off) chats
-                  too — pre-existing shared ChatHistoryPopover behavior (same
-                  exposure as the control bar's History button; the click
-                  degrades to a "no saved note" notice). Hiding it would mean a
-                  per-row visibility prop on the shared popover — tracked as
-                  shared-popover debt, not worth an entry-point hack here.
-
-                  Radix merges its toggle onClick onto this child; Enter/Space
-                  dispatch a click so the popover opens for keyboard users
-                  without this row owning the popover's open state.
-
-                  DESIGN NOTE: onLoadHistory runs on every toggle (open *and*
-                  close), because Radix fires the merged onClick both ways and
-                  this row can't see the popover's open state. That's an
-                  intentional, harmless refresh — the same pattern the
-                  conversation control bar uses on its History button
-                  (AgentChatControls). loadChatHistory is mounted-guarded and
-                  self-correcting, so a fast open/close race only momentarily
-                  shows near-identical data. A "refresh only on open" fix would
-                  need ChatHistoryPopover to expose onOpenChange — not worth
-                  touching the shared base for this. */}
-                <AgentHomeViewAllTrigger label="chats" onClick={() => onLoadHistory?.()} />
-              </ChatHistoryPopover>
-            ) : undefined
-          }
-        >
+        <AgentHomePreviewList hasMoreItems={false}>
           <div className="tw-flex tw-flex-col tw-divide-y tw-divide-border">
-            {visibleItems.map((item) => (
+            {filteredItems.map((item) => (
               <RecentChatRow
                 key={item.id}
                 item={item}

--- a/src/agentMode/ui/GlobalRecentChatsSection.tsx
+++ b/src/agentMode/ui/GlobalRecentChatsSection.tsx
@@ -9,7 +9,7 @@ import { ChatIconWithAttention } from "@/components/chat-components/ChatIconWith
 import { cn } from "@/lib/utils";
 import { isNativeChatId } from "@/utils/nativeChatId";
 import { formatCompactRelativeTime } from "@/utils/formatRelativeTime";
-import { sortByStrategy } from "@/utils/recentUsageManager";
+import { sortByStrategy, type SortStrategy } from "@/utils/recentUsageManager";
 import { ArrowUpRight, Check, Edit2, LoaderCircle, MessageCircle, Trash2, X } from "lucide-react";
 import React, {
   memo,
@@ -81,6 +81,8 @@ interface GlobalRecentChatsSectionProps {
   attentionChatIds?: ReadonlySet<string>;
   /** Current project names keyed by id. Used only by the global variant. */
   projectNamesById?: Readonly<Record<string, string>>;
+  /** Saved ordering used by the complete chat-history surface. */
+  sortStrategy?: SortStrategy;
   className?: string;
 }
 
@@ -95,11 +97,12 @@ function resolveChatIcon(
   return item.backendId ? backendRegistry[item.backendId]?.Icon : undefined;
 }
 
-// Most-recent-first, matching the rest of the landing (last-used desc, falling
-// back to created; ties broken by name then created). Upstream
-// `getChatHistoryItems()` returns vault-scan order, so the sort lives here.
-function sortChatsByRecent(items: ChatHistoryItem[]): ChatHistoryItem[] {
-  return sortByStrategy(items, "recent", {
+// Upstream `getChatHistoryItems()` returns vault-scan order. Apply the saved
+// history ordering here so removing the duplicate history surface does not
+// silently discard a user's preference.
+// https://github.com/logancyang/obsidian-copilot/issues/3040
+function sortChats(items: ChatHistoryItem[], strategy: SortStrategy): ChatHistoryItem[] {
+  return sortByStrategy(items, strategy, {
     getName: (item) => item.title,
     getCreatedAtMs: (item) => item.createdAt.getTime(),
     getLastUsedAtMs: (item) => item.lastAccessedAt.getTime(),
@@ -358,6 +361,7 @@ export const GlobalRecentChatsSection = memo(function GlobalRecentChatsSection({
   runningChatIds,
   attentionChatIds,
   projectNamesById,
+  sortStrategy = "recent",
   className,
 }: GlobalRecentChatsSectionProps): React.ReactElement {
   const [query, setQuery] = useState("");
@@ -373,8 +377,7 @@ export const GlobalRecentChatsSection = memo(function GlobalRecentChatsSection({
     onLoadHistory?.();
   }, [onLoadHistory]);
 
-  // Sort once for the landing's fixed recent-first order.
-  const sortedItems = useMemo(() => sortChatsByRecent(items), [items]);
+  const sortedItems = useMemo(() => sortChats(items, sortStrategy), [items, sortStrategy]);
   const filteredItems = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return sortedItems;

--- a/src/agentMode/ui/GlobalRecentChatsSection.tsx
+++ b/src/agentMode/ui/GlobalRecentChatsSection.tsx
@@ -6,6 +6,7 @@ import { Input } from "@/components/ui/input";
 import { SearchBar } from "@/components/ui/SearchBar";
 import { type ChatHistoryItem } from "@/components/chat-components/ChatHistoryPopover";
 import { ChatIconWithAttention } from "@/components/chat-components/ChatIconWithAttention";
+import { logError } from "@/logger";
 import { cn } from "@/lib/utils";
 import { isNativeChatId } from "@/utils/nativeChatId";
 import { formatCompactRelativeTime } from "@/utils/formatRelativeTime";
@@ -422,21 +423,40 @@ export const GlobalRecentChatsSection = memo(function GlobalRecentChatsSection({
     setEditingTitle(title);
   }, []);
 
-  const handleSaveEdit = useCallback(() => {
+  const handleSaveEdit = useCallback(async () => {
     const trimmed = editingTitle.trim();
     const id = editingId;
-    setEditingId(null);
-    if (!id || !trimmed) return;
-    void onUpdateTitle(id, trimmed);
+    if (!id || !trimmed) {
+      setEditingId(null);
+      return;
+    }
+
+    try {
+      await onUpdateTitle(id, trimmed);
+      setEditingId(null);
+    } catch (error) {
+      // Keep the draft editable when the underlying vault operation fails.
+      // https://github.com/logancyang/obsidian-copilot/issues/3040
+      logError("Error updating title:", error);
+    }
   }, [editingId, editingTitle, onUpdateTitle]);
 
   const handleConfirmDelete = useCallback(
-    (id: string) => {
-      setConfirmDeleteId(null);
-      void onDeleteChat(id);
+    async (id: string) => {
+      try {
+        await onDeleteChat(id);
+        setConfirmDeleteId(null);
+      } catch (error) {
+        // Keep confirmation available so the user can retry the failed delete.
+        // https://github.com/logancyang/obsidian-copilot/issues/3040
+        logError("Error deleting chat:", error);
+      }
     },
     [onDeleteChat]
   );
+
+  const handleSaveEditSafely = safeAsyncHandler(handleSaveEdit);
+  const handleConfirmDeleteSafely = safeAsyncHandler(handleConfirmDelete);
 
   const handleOpenSourceFile = useCallback(
     (id: string) => {
@@ -509,10 +529,10 @@ export const GlobalRecentChatsSection = memo(function GlobalRecentChatsSection({
                 // Only the editing row needs the live save handler (it changes
                 // per keystroke via editingTitle); the rest get a stable noop so
                 // their memo isn't defeated mid-rename.
-                onSaveEdit={editingId === item.id ? handleSaveEdit : NOOP_SAVE}
+                onSaveEdit={editingId === item.id ? handleSaveEditSafely : NOOP_SAVE}
                 onCancelEdit={handleCancelEdit}
                 onStartDelete={setConfirmDeleteId}
-                onConfirmDelete={handleConfirmDelete}
+                onConfirmDelete={handleConfirmDeleteSafely}
                 onCancelDelete={handleCancelDelete}
                 canOpenSourceFile={!isNativeChatId(item.id)}
                 onOpenSourceFile={handleOpenSourceFile}

--- a/src/agentMode/ui/GlobalRecentChatsSection.tsx
+++ b/src/agentMode/ui/GlobalRecentChatsSection.tsx
@@ -11,11 +11,26 @@ import { isNativeChatId } from "@/utils/nativeChatId";
 import { formatCompactRelativeTime } from "@/utils/formatRelativeTime";
 import { sortByStrategy } from "@/utils/recentUsageManager";
 import { ArrowUpRight, Check, Edit2, LoaderCircle, MessageCircle, Trash2, X } from "lucide-react";
-import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { safeAsyncHandler } from "@/utils/safeAsyncHandler";
 
 /** Stable noop for rows that aren't being renamed (they never invoke onSaveEdit). */
 const NOOP_SAVE = (): void => {};
+
+/**
+ * Bound the initial DOM work while keeping the complete history searchable.
+ * Saved chat history is unbounded, so mounting every row can slow Agent Home.
+ * https://github.com/logancyang/obsidian-copilot/issues/3040
+ */
+const PAGE_SIZE = 50;
 
 /**
  * Which landing this section renders under. `global` is the original Agent Home
@@ -324,10 +339,12 @@ const RecentChatRow = memo(function RecentChatRow({
  * rows manage chats in place — open, rename, delete, and (for markdown-saved
  * chats only) open the source note — the same affordances as the chat history
  * popover. Every chat stays in this section's scrollable list, and search
- * filters that same list without opening a second surface. Native (autosave-off)
- * sessions appear here too; they just have no source note. The per-project
- * landing reuses it (`variant="project"`) with scoped items and project empty
- * copy — identical rows, no extra chrome.
+ * filters that same list without opening a second surface. Rows mount in
+ * bounded batches as the user scrolls, while sorting and search still consider
+ * the complete history. Native (autosave-off) sessions appear here too; they
+ * just have no source note. The per-project landing reuses it
+ * (`variant="project"`) with scoped items and project empty copy — identical
+ * rows, no extra chrome.
  */
 export const GlobalRecentChatsSection = memo(function GlobalRecentChatsSection({
   items,
@@ -347,6 +364,8 @@ export const GlobalRecentChatsSection = memo(function GlobalRecentChatsSection({
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editingTitle, setEditingTitle] = useState("");
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [displayCount, setDisplayCount] = useState(PAGE_SIZE);
+  const observerRef = useRef<IntersectionObserver | null>(null);
 
   // Refresh once when the section first mounts so opening Recent Chats does
   // not rely on a stale history snapshot.
@@ -361,6 +380,39 @@ export const GlobalRecentChatsSection = memo(function GlobalRecentChatsSection({
     if (!q) return sortedItems;
     return sortedItems.filter((item) => item.title.toLowerCase().includes(q));
   }, [sortedItems, query]);
+  const visibleItems = useMemo(
+    () => filteredItems.slice(0, displayCount),
+    [displayCount, filteredItems]
+  );
+
+  // A new query starts from one bounded page before paint. Search still runs
+  // against filteredItems, so older matches remain discoverable by scrolling.
+  // https://github.com/logancyang/obsidian-copilot/issues/3040
+  useLayoutEffect(() => {
+    setDisplayCount(PAGE_SIZE);
+  }, [query]);
+
+  const sentinelRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      observerRef.current?.disconnect();
+      observerRef.current = null;
+      if (!node) return;
+
+      const IntersectionObserverConstructor =
+        node.ownerDocument.defaultView?.IntersectionObserver ?? IntersectionObserver;
+
+      const observer = new IntersectionObserverConstructor(
+        (entries) => {
+          if (!entries[0]?.isIntersecting) return;
+          setDisplayCount((current) => Math.min(current + PAGE_SIZE, filteredItems.length));
+        },
+        { threshold: 0.1 }
+      );
+      observer.observe(node);
+      observerRef.current = observer;
+    },
+    [filteredItems.length]
+  );
   const handleStartEdit = useCallback((id: string, title: string) => {
     setConfirmDeleteId(null);
     setEditingId(id);
@@ -437,7 +489,7 @@ export const GlobalRecentChatsSection = memo(function GlobalRecentChatsSection({
       ) : (
         <AgentHomePreviewList hasMoreItems={false}>
           <div className="tw-flex tw-flex-col tw-divide-y tw-divide-border">
-            {filteredItems.map((item) => (
+            {visibleItems.map((item) => (
               <RecentChatRow
                 key={item.id}
                 item={item}
@@ -465,6 +517,9 @@ export const GlobalRecentChatsSection = memo(function GlobalRecentChatsSection({
                 hasAttention={!!item.needsAttention || (attentionChatIds?.has(item.id) ?? false)}
               />
             ))}
+            {displayCount < filteredItems.length && (
+              <div ref={sentinelRef} className="tw-h-1" aria-hidden="true" />
+            )}
           </div>
         </AgentHomePreviewList>
       )}

--- a/src/agentMode/ui/ProjectPickerList.stories.tsx
+++ b/src/agentMode/ui/ProjectPickerList.stories.tsx
@@ -93,7 +93,7 @@ export const Default: StoryObj<ProjectPickerListProps> = {
   render: () => <ProjectPickerDemo projects={projects} />,
 };
 
-/** Overflow uses the same bottom-pinned View-all footer as Recent Chats. */
+/** Overflow keeps the Projects View-all footer pinned to the bottom. */
 export const Overflow: StoryObj<ProjectPickerListProps> = {
   render: () => <ProjectPickerDemo projects={overflowProjects} />,
 };


### PR DESCRIPTION
Fixes #3040

## Why

Agent Home's Recent Chats shelf already scrolls and searches. When the shelf contained more than ten chats, it also showed **View all chats**, which opened a second surface with the same chats and actions. That extra step did not add a capability.

## What

> **Before:** More than ten chats show a **View all chats** footer that opens another history surface.
>
> **After:** All recent chats stay in the existing bounded, scrollable, searchable shelf.

The shelf mounts 50 rows initially and appends 50-row batches as it scrolls, while search still considers the complete history. The saved chat-history sort preference continues to order the unified list. Global and project row actions, status indicators, and project badges remain unchanged. If rename or delete fails, the row keeps the draft or confirmation available for retry and handles the rejection.

## Non-goals

- Changing Projects **View all**.
- Removing active-conversation History.
- Changing chat retention, sorting, storage, or project scope.

## Screenshots

**Before — the bounded list ends with a redundant View all chats footer**

![Recent Chats with the redundant View all chats footer](https://github.com/user-attachments/assets/c038a7ad-2733-4616-8094-5d54a3e299ce)

**After — the same bounded list scrolls in place with no second surface**

![Recent Chats scrolling in place without the redundant footer](https://github.com/user-attachments/assets/06f06552-f481-4b22-8f13-aba95857f2cf)

## Risk

**Low**

| Criterion | Assessment |
| --- | --- |
| Behavior, cosmetic scope, and tests | UI-only change; deterministic component tests cover the 50-row initial batch, additional batches, full-history search, saved ordering, absent trigger, and failed rename/delete retries. |
| Defect caught by CI or obvious manual use | Covered by focused tests and the 60-item gallery story; the missing trigger is immediately visible with more than ten chats. |
| Revert safety | No persisted state or migration; reverting restores the previous footer and popover. |
| Authentication, permissions, secrets, or input surface | Unchanged. |
| API or contract changes | None; this changes an internal Agent Home UI surface only. |
| Concurrency or state-machine changes | A local `IntersectionObserver` advances rendered batches; it does not change stored history or session state. Rename/delete state clears only after the operation succeeds. |
| Hot path and deterministic coverage | Initial DOM work is capped at 50 rows; tests cover paging, older-chat search, saved ordering, actions, failure handling, and project badges. |
| New dependency | None; manifests are unchanged. |
| Human-only verification stays quick and bounded | Limited to Agent Home: inspect the first batch, scroll past row 50, and search for an older chat. Failure handling is covered with rejecting callback tests. |

Review: run the verification steps below and skim the focused deletion, batching, and action-error handling logic.

## Verification

1. Open Agent Chat home with more than 50 recent chats.
2. Confirm there is no **View all chats** footer and scroll past the initial 50 rows in the same list.
3. Search for an older chat and open it; confirm the saved History sort order, row actions, status indicators, and project badges still appear.
4. Run `npm test -- --runInBand src/agentMode/ui/GlobalRecentChatsSection.test.tsx`; the rejecting rename/delete cases must retain their retry state.
