### PR TITLE
Wait for both plugins before reloading the test vault

### DIFF
--- a/scripts/test-vault.sh
+++ b/scripts/test-vault.sh
@@ -131,29 +131,6 @@ BUILD_TAG="$(
 )"
 echo "==> Wrote development manifest (build: $BUILD_TAG, branch: $BRANCH)"
 
-# Reload by toggling disable -> enable, NOT `plugin:reload`. On this setup
-# `plugin:reload` returns success but does NOT re-run the plugin's onload, so the
-# freshly deployed main.js never executes. A disable+enable cycle re-runs onload.
-#
-# CRITICAL: the Obsidian CLI picks its TARGET VAULT from the current working
-# directory (it resolves the vault enclosing $PWD; `vault=` does NOT override
-# this). So we MUST run the CLI from inside the target vault's directory, or the
-# reload silently hits whatever vault the caller's cwd sits in (e.g. the
-# repo/worktree vault) instead of the deploy target. Hence the `cd "$VAULT_PATH"`.
-echo "==> Reloading plugin in Obsidian (vault dir: $VAULT_PATH)"
-if [[ ! -x "$OBSIDIAN_BIN" ]]; then
-  echo "warning: Obsidian CLI not found at $OBSIDIAN_BIN; skipping reload." >&2
-else
-  ( cd "$VAULT_PATH" && "$OBSIDIAN_BIN" plugin:disable id="$PLUGIN_ID" >/dev/null 2>&1 ) || true
-  if ( cd "$VAULT_PATH" && "$OBSIDIAN_BIN" plugin:enable id="$PLUGIN_ID" >/dev/null 2>&1 ); then
-    echo "    reloaded (onload re-ran). Note: the sidebar manifest label only"
-    echo "    refreshes on a full Obsidian restart; use a dev-console marker to"
-    echo "    confirm the loaded build, not the label."
-  else
-    echo "warning: could not reload via the CLI. Is Obsidian running with this vault open? The plugin will load on next open." >&2
-  fi
-fi
-
 # The component gallery plugin ships a near-complete copy of the production
 # stylesheet (scripts/prepare-gallery-css.mjs concatenates src/styles/tailwind.css
 # into its source), and Obsidian injects every enabled plugin's styles.css
@@ -184,6 +161,29 @@ if [[ -n "$GALLERY_ID" ]]; then
   if [[ -e "$GALLERY_PLUGIN_DIR" || -L "$GALLERY_PLUGIN_DIR" ]]; then
     echo "==> Redeploying the gallery plugin from this worktree so both stylesheets match"
     npm run gallery:vault
+  fi
+fi
+
+# Reload by toggling disable -> enable, NOT `plugin:reload`. On this setup
+# `plugin:reload` returns success but does NOT re-run the plugin's onload, so the
+# freshly deployed main.js never executes. A disable+enable cycle re-runs onload.
+#
+# CRITICAL: the Obsidian CLI picks its TARGET VAULT from the current working
+# directory (it resolves the vault enclosing $PWD; `vault=` does NOT override
+# this). So we MUST run the CLI from inside the target vault's directory, or the
+# reload silently hits whatever vault the caller's cwd sits in (e.g. the
+# repo/worktree vault) instead of the deploy target. Hence the `cd "$VAULT_PATH"`.
+echo "==> Reloading plugin in Obsidian (vault dir: $VAULT_PATH)"
+if [[ ! -x "$OBSIDIAN_BIN" ]]; then
+  echo "warning: Obsidian CLI not found at $OBSIDIAN_BIN; skipping reload." >&2
+else
+  ( cd "$VAULT_PATH" && "$OBSIDIAN_BIN" plugin:disable id="$PLUGIN_ID" >/dev/null 2>&1 ) || true
+  if ( cd "$VAULT_PATH" && "$OBSIDIAN_BIN" plugin:enable id="$PLUGIN_ID" >/dev/null 2>&1 ); then
+    echo "    reloaded (onload re-ran). Note: the sidebar manifest label only"
+    echo "    refreshes on a full Obsidian restart; use a dev-console marker to"
+    echo "    confirm the loaded build, not the label."
+  else
+    echo "warning: could not reload via the CLI. Is Obsidian running with this vault open? The plugin will load on next open." >&2
   fi
 fi
 

--- a/scripts/test-vault.test.sh
+++ b/scripts/test-vault.test.sh
@@ -24,14 +24,15 @@ printf 'clean styles\n' >"$FIXTURE_ROOT/styles.css"
 printf 'tracked\n' >"$FIXTURE_ROOT/source.txt"
 printf 'main.js\nstyles.css\n' >"$FIXTURE_ROOT/.gitignore"
 
-NPM_CALL_LOG="$TEST_ROOT/npm-calls.log"
+DEPLOY_CALL_LOG="$TEST_ROOT/deploy-calls.log"
 cat >"$FAKE_BIN/npm" <<'EOF'
 #!/usr/bin/env bash
-echo "$*" >>"$NPM_CALL_LOG"
+echo "npm $*" >>"$DEPLOY_CALL_LOG"
 exit 0
 EOF
 cat >"$FAKE_BIN/obsidian" <<'EOF'
 #!/usr/bin/env bash
+echo "obsidian $*" >>"$DEPLOY_CALL_LOG"
 exit 0
 EOF
 chmod +x "$FAKE_BIN/npm" "$FAKE_BIN/obsidian"
@@ -45,11 +46,11 @@ git -C "$FIXTURE_ROOT" commit -qm "fixture"
 
 DEPLOY_STDERR="$TEST_ROOT/deploy-stderr.log"
 run_deploy() {
-  : >"$NPM_CALL_LOG"
+  : >"$DEPLOY_CALL_LOG"
   PATH="$FAKE_BIN:$PATH" \
     COPILOT_TEST_VAULT_PATH="$VAULT_ROOT" \
     OBSIDIAN_BIN="$FAKE_BIN/obsidian" \
-    NPM_CALL_LOG="$NPM_CALL_LOG" \
+    DEPLOY_CALL_LOG="$DEPLOY_CALL_LOG" \
     bash "$FIXTURE_ROOT/scripts/test-vault.sh" >/dev/null 2>"$DEPLOY_STDERR"
 }
 
@@ -131,7 +132,7 @@ cat >"$FIXTURE_ROOT/dev/gallery/manifest.json" <<EOF
 EOF
 
 run_deploy
-if grep -q "gallery:vault" "$NPM_CALL_LOG"; then
+if grep -q "gallery:vault" "$DEPLOY_CALL_LOG"; then
   echo "rebuilt the gallery when the vault has no gallery plugin installed" >&2
   exit 1
 fi
@@ -142,8 +143,14 @@ fi
 
 ln -s "$FIXTURE_ROOT/dev/gallery" "$GALLERY_PLUGIN_DIR"
 run_deploy
-if ! grep -q "run gallery:vault" "$NPM_CALL_LOG"; then
+if ! grep -q "npm run gallery:vault" "$DEPLOY_CALL_LOG"; then
   echo "did not rebuild the gallery deployed from this worktree" >&2
+  exit 1
+fi
+GALLERY_DEPLOY_LINE="$(grep -n -m1 '^npm run gallery:vault$' "$DEPLOY_CALL_LOG" | cut -d: -f1)"
+FIRST_RELOAD_LINE="$(grep -n -m1 '^obsidian ' "$DEPLOY_CALL_LOG" | cut -d: -f1)"
+if [[ -z "$GALLERY_DEPLOY_LINE" || -z "$FIRST_RELOAD_LINE" || "$FIRST_RELOAD_LINE" -le "$GALLERY_DEPLOY_LINE" ]]; then
+  echo "reloaded Obsidian before both plugins were deployed" >&2
   exit 1
 fi
 
@@ -152,14 +159,14 @@ mkdir -p "$FOREIGN_GALLERY"
 rm "$GALLERY_PLUGIN_DIR"
 ln -s "$FOREIGN_GALLERY" "$GALLERY_PLUGIN_DIR"
 run_deploy
-if ! grep -q "run gallery:vault" "$NPM_CALL_LOG"; then
+if ! grep -q "npm run gallery:vault" "$DEPLOY_CALL_LOG"; then
   echo "did not take over a gallery deployed from another worktree" >&2
   exit 1
 fi
 
 rm -r "$FOREIGN_GALLERY"
 run_deploy
-if ! grep -q "run gallery:vault" "$NPM_CALL_LOG"; then
+if ! grep -q "npm run gallery:vault" "$DEPLOY_CALL_LOG"; then
   echo "did not take over a gallery whose worktree no longer exists" >&2
   exit 1
 fi


### PR DESCRIPTION
## Why

`npm run test:vault` reloaded Copilot before it built and deployed an installed component gallery, so Obsidian could briefly run Copilot beside the gallery's stale shared stylesheet.

## What

When the gallery is installed, `test:vault` now waits for its build and deployment to finish before reloading Copilot; deployments without the gallery keep the same behavior.

## Non goal

This PR does not change the standalone `gallery:vault` reload behavior or the plugin artifacts copied into the vault.

## Screenshot

Not applicable because this changes headless deployment sequencing and no rendered UI.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | The deployment fixture records npm and Obsidian calls and rejects an early reload |
| A defect would fail CI or be obvious on first use | ✅ | The ordering assertion runs in the existing test-vault script suite |
| A revert fully restores prior state, including persisted data | ✅ | The change only reorders commands in a development deployment script |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Test-vault process ordering is the only changed behavior |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Plugin artifacts and CLI arguments are unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | This affects a sequential local test script only |
| No hot-path behavior lacks deterministic coverage | ✅ | The changed sequence is covered by the deployment fixture |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | A bad order appears directly in `test:vault` output |

Review: run Verification step 1, confirm CI is green, and merge.

## Verification

1. Run `npm run test:vault:script` and confirm the deployment tests pass, including the assertion that `npm run gallery:vault` precedes the first Obsidian command.
2. With the component gallery installed in a configured test vault, run `npm run test:vault` and confirm the gallery deployment finishes before `==> Reloading plugin in Obsidian` appears.
