### PR TITLE
Measure documentation visits without identifying readers

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -44,3 +44,20 @@ jobs:
         env:
           GEMINI_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
         run: npm run test:integration
+
+  docs:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: "npm"
+          cache-dependency-path: docs/package-lock.json
+      - run: npm ci
+      - run: npm test
+      - run: npm run build

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,17 +52,17 @@ allowlisted events and canonical paths arrive:
 ```sql
 SELECT
   event,
+  if(event IN ('$pageview', '$pageleave'), 'allowed', 'unexpected') AS contract_status,
   timestamp,
   properties.$host AS host,
   properties.$pathname AS path,
   properties.$referring_domain AS referring_domain
 FROM events
-WHERE event IN ('$pageview', '$pageleave')
-  AND properties.$host = 'docs.obsidiancopilot.com'
+WHERE properties.$host = 'docs.obsidiancopilot.com'
 ORDER BY timestamp DESC
 LIMIT 100
 ```
 
-Verify that paths contain no query strings, fragments, search terms, or ad-click identifiers, and
-that no autocapture or replay events appear. To roll back, remove both variables from Vercel
-Production and redeploy; the docs continue to work without analytics.
+Verify that every row is classified as `allowed`, paths contain no query strings, fragments, search
+terms, or ad-click identifiers, and no autocapture or replay events appear. To roll back, remove
+both variables from Vercel Production and redeploy; the docs continue to work without analytics.

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,4 +36,33 @@ Create a separate Vercel project for this site with these settings:
 - **Production Branch:** `master`
 - **Node.js Version:** `22.x`
 
-Attach `docs.obsidiancopilot.com` to that project. No environment variables are required.
+Attach `docs.obsidiancopilot.com` to that project. No environment variables are required to build
+or preview the site.
+
+## Production analytics
+
+Analytics is optional and must remain disabled until the privacy policy is confirmed to cover the
+docs subdomain. After that approval, add `PUBLIC_POSTHOG_KEY` and `PUBLIC_POSTHOG_HOST` to the
+Vercel **Production** environment only, using values from the approved production configuration.
+Keep their values out of the repository, issue comments, build logs, and preview environments.
+
+After deploying, visit a few docs pages and run this query in PostHog to confirm that only the
+allowlisted events and canonical paths arrive:
+
+```sql
+SELECT
+  event,
+  timestamp,
+  properties.$host AS host,
+  properties.$pathname AS path,
+  properties.$referring_domain AS referring_domain
+FROM events
+WHERE event IN ('$pageview', '$pageleave')
+  AND properties.$host = 'docs.obsidiancopilot.com'
+ORDER BY timestamp DESC
+LIMIT 100
+```
+
+Verify that paths contain no query strings, fragments, search terms, or ad-click identifiers, and
+that no autocapture or replay events appear. To roll back, remove both variables from Vercel
+Production and redeploy; the docs continue to work without analytics.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -2,6 +2,17 @@ import starlight from "@astrojs/starlight";
 import { defineConfig } from "astro/config";
 import { remarkPublishedDocs } from "./src/remark-published-docs.mjs";
 
+// Missing analytics configuration is non-fatal, but local development should make it visible once.
+// https://github.com/Brevilabs/obsidian-copilot-private/issues/335
+if (
+  process.env.NODE_ENV === "development" &&
+  (!process.env.PUBLIC_POSTHOG_KEY || !process.env.PUBLIC_POSTHOG_HOST)
+) {
+  process.emitWarning(
+    "Docs analytics is disabled because PUBLIC_POSTHOG_KEY or PUBLIC_POSTHOG_HOST is missing."
+  );
+}
+
 // Existing guide routes stay stable while section links make the most important
 // workflows visible without splitting their source files.
 const sidebar = [
@@ -66,6 +77,9 @@ export default defineConfig({
         dark: "./src/assets/copilot-mark-cream.svg",
         light: "./src/assets/copilot-icon-dark.svg",
         alt: "",
+      },
+      components: {
+        Head: "./src/components/Head.astro",
       },
       sidebar,
     }),

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -2,17 +2,6 @@ import starlight from "@astrojs/starlight";
 import { defineConfig } from "astro/config";
 import { remarkPublishedDocs } from "./src/remark-published-docs.mjs";
 
-// Missing analytics configuration is non-fatal, but local development should make it visible once.
-// https://github.com/Brevilabs/obsidian-copilot-private/issues/335
-if (
-  process.env.NODE_ENV === "development" &&
-  (!process.env.PUBLIC_POSTHOG_KEY || !process.env.PUBLIC_POSTHOG_HOST)
-) {
-  process.emitWarning(
-    "Docs analytics is disabled because PUBLIC_POSTHOG_KEY or PUBLIC_POSTHOG_HOST is missing."
-  );
-}
-
 // Existing guide routes stay stable while section links make the most important
 // workflows visible without splitting their source files.
 const sidebar = [

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/starlight": "0.41.7",
         "astro": "7.2.4",
+        "posthog-js": "1.422.5",
         "unist-util-visit": "5.1.0"
       },
       "engines": {
@@ -1958,6 +1959,31 @@
         "win32"
       ]
     },
+    "node_modules/@posthog/browser-common": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@posthog/browser-common/-/browser-common-0.7.0.tgz",
+      "integrity": "sha512-Kr6j9sH7NisT3fC3w7jZlonYeCFjPXZrDwHl3usFpjNEdgbHUrxPAmekEkTt+zRAa2huldFPIAmibZ3KC4hXoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "^1.49.2",
+        "@posthog/types": "^1.407.1"
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.49.2",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.49.2.tgz",
+      "integrity": "sha512-AXHDo/4nisUg7OPG1TQNgREK7n+chBQXLQyttp7bDTDsDg2k9lV06TmnpvuNbwJs53q9mP9hjezKEZu4fYadfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.407.1"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.407.1",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.407.1.tgz",
+      "integrity": "sha512-WhbkXPC2rgylXqmxHqv70ffI3k+KxyR6s7DBIfr5NvIqHkxp6v0pk31D/jbz0DNVbzwkLjyll2pxr4FNbJiYzg==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/binding-android-arm-eabi": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.5.tgz",
@@ -2400,6 +2426,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -2862,6 +2895,20 @@
       "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.50.0.tgz",
+      "integrity": "sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/crossws": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
@@ -3125,6 +3172,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
@@ -3408,6 +3464,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.9.tgz",
+      "integrity": "sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==",
+      "license": "MIT"
     },
     "node_modules/find-process": {
       "version": "2.1.1",
@@ -5797,6 +5859,54 @@
         "node": ">=4"
       }
     },
+    "node_modules/posthog-js": {
+      "version": "1.422.5",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.422.5.tgz",
+      "integrity": "sha512-p1CLXsGoHwNkdElxXtd1KzNP/df8sIrp8CRII+lAPRhaHdpi1HfNxrybqLSzWvJLw2w5Nou5vpXfGABUI5BVwA==",
+      "license": "(Apache-2.0 AND MIT)",
+      "dependencies": {
+        "@posthog/browser-common": "^0.7.0",
+        "@posthog/core": "^1.49.2",
+        "@posthog/types": "^1.407.1",
+        "core-js": "^3.49.0",
+        "dompurify": "^3.4.13",
+        "fflate": "^0.4.8",
+        "preact": "^10.29.3",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.3.0",
+        "web-vitals-soft-navs": "npm:web-vitals@6.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.8",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.8.tgz",
+      "integrity": "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/prismjs": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
@@ -5824,6 +5934,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/radix3": {
       "version": "1.1.2",
@@ -7037,6 +7153,19 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/web-vitals-soft-navs": {
+      "name": "web-vitals",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-6.0.0.tgz",
+      "integrity": "sha512-Guaibvy/+uNtL6Bsu4jmMJGzuSl91oeRH5iO9pPRbYftnFUr3yqT1TUNX/OE4o9HexuEMU3Kb/Wg7iKhlffZUA==",
+      "license": "Apache-2.0"
     },
     "node_modules/xxhash-wasm": {
       "version": "1.1.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@astrojs/starlight": "0.41.7",
     "astro": "7.2.4",
+    "posthog-js": "1.422.5",
     "unist-util-visit": "5.1.0"
   }
 }

--- a/docs/src/analytics.mjs
+++ b/docs/src/analytics.mjs
@@ -1,0 +1,218 @@
+const CANONICAL_HOSTNAME = "docs.obsidiancopilot.com";
+const PERSISTENCE_NAME = "obsidian-copilot-docs";
+const STORAGE_PROBE_KEY = "__obsidian_copilot_docs_analytics_probe__";
+
+const URL_PROPERTIES = new Set(["$current_url", "$referrer"]);
+const PATH_PROPERTIES = new Set(["$pathname", "$prev_pageview_pathname"]);
+const PASSTHROUGH_PROPERTIES = new Set([
+  "$browser",
+  "$device_id",
+  "$device_type",
+  "$geoip_country_code",
+  "$insert_id",
+  "$lib",
+  "$lib_version",
+  "$os",
+  "$pageview_id",
+  "$prev_pageview_id",
+  "$prev_pageview_duration",
+  "$process_person_profile",
+  "$sent_at",
+  "$session_id",
+  "$session_start_timestamp",
+  "$time",
+  "$window_id",
+  "distinct_id",
+  "token",
+]);
+const CAMPAIGN_PROPERTY = /^\$?(?:(?:initial|session_entry)_)?utm_(?:source|medium|campaign)$/;
+const ALLOWED_EVENTS = new Set(["$pageview", "$pageleave"]);
+
+function sanitizeUrl(value) {
+  if (typeof value !== "string" || value.length === 0) return undefined;
+
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:" && url.protocol !== "http:") return undefined;
+    url.username = "";
+    url.password = "";
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+function sanitizePath(value) {
+  if (typeof value !== "string" || (!value.startsWith("/") && !/^https?:\/\//i.test(value))) {
+    return undefined;
+  }
+
+  try {
+    return new URL(value, `https://${CANONICAL_HOSTNAME}`).pathname;
+  } catch {
+    return undefined;
+  }
+}
+
+function sanitizeCampaignValue(value) {
+  if (typeof value !== "string") return undefined;
+  const sanitized = value.trim();
+  return sanitized.length > 0 && sanitized.length <= 80 ? sanitized : undefined;
+}
+
+function sanitizeProperties(properties) {
+  const sanitized = {};
+
+  for (const [key, value] of Object.entries(properties ?? {})) {
+    if (URL_PROPERTIES.has(key)) {
+      const safeUrl = key === "$referrer" && value === "$direct" ? "$direct" : sanitizeUrl(value);
+      if (safeUrl) sanitized[key] = safeUrl;
+      continue;
+    }
+
+    if (PATH_PROPERTIES.has(key)) {
+      const safePath = sanitizePath(value);
+      if (safePath) sanitized[key] = safePath;
+      continue;
+    }
+
+    if (CAMPAIGN_PROPERTY.test(key)) {
+      const safeCampaign = sanitizeCampaignValue(value);
+      if (safeCampaign) sanitized[key] = safeCampaign;
+      continue;
+    }
+
+    if (PASSTHROUGH_PROPERTIES.has(key)) sanitized[key] = value;
+  }
+
+  sanitized.$host = CANONICAL_HOSTNAME;
+  sanitized.$process_person_profile = false;
+
+  const referrer = sanitized.$referrer;
+  if (referrer) {
+    sanitized.$referring_domain = referrer === "$direct" ? "$direct" : new URL(referrer).hostname;
+  }
+
+  const currentUrl = sanitized.$current_url;
+  if (currentUrl) sanitized.$pathname = new URL(currentUrl).pathname;
+
+  return sanitized;
+}
+
+export function resolveAnalyticsConfig({ hostname, apiKey, apiHost }) {
+  // Production-only collection prevents previews from polluting metrics or testing real-user policy.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/335
+  if (hostname !== CANONICAL_HOSTNAME) return null;
+
+  // Analytics is optional so missing Vercel configuration can never break documentation rendering.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/335
+  if (!apiKey?.trim() || !apiHost?.trim()) return null;
+
+  try {
+    const host = new URL(apiHost);
+    if (host.protocol !== "https:" || host.username || host.password || host.search || host.hash) {
+      return null;
+    }
+    return { apiKey: apiKey.trim(), apiHost: host.toString().replace(/\/$/, "") };
+  } catch {
+    return null;
+  }
+}
+
+export function hasUsableStorage(getStorage) {
+  // A failed storage probe disables collection instead of falling back to shared cookies or identity.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/335
+  try {
+    const storage = getStorage();
+    if (!storage) return false;
+    try {
+      storage.setItem(STORAGE_PROBE_KEY, "1");
+      return storage.getItem(STORAGE_PROBE_KEY) === "1";
+    } finally {
+      storage.removeItem(STORAGE_PROBE_KEY);
+    }
+  } catch {
+    return false;
+  }
+}
+
+export function sanitizeAnalyticsEvent(event) {
+  // The allowlist is the final privacy boundary if an SDK default or remote setting changes.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/335
+  if (!event || !ALLOWED_EVENTS.has(event.event)) return null;
+
+  return {
+    uuid: event.uuid,
+    event: event.event,
+    properties: sanitizeProperties(event.properties),
+    ...(event.timestamp ? { timestamp: event.timestamp } : {}),
+  };
+}
+
+export function createPostHogOptions(apiHost) {
+  return {
+    api_host: apiHost,
+    autocapture: false,
+    rageclick: false,
+    capture_pageview: false,
+    // Boolean true keeps the SDK unload handler active when pageviews are captured manually.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/335
+    capture_pageleave: true,
+    capture_dead_clicks: false,
+    capture_exceptions: false,
+    capture_heatmaps: false,
+    capture_performance: false,
+    disable_session_recording: true,
+    disable_surveys: true,
+    disable_conversations: true,
+    disable_product_tours: true,
+    disable_external_dependency_loading: true,
+    advanced_disable_flags: true,
+    advanced_disable_feature_flags: true,
+    person_profiles: "never",
+    persistence: "localStorage",
+    persistence_name: PERSISTENCE_NAME,
+    cross_subdomain_cookie: false,
+    upgrade: false,
+    disable_capture_url_hashes: true,
+    disable_scroll_properties: true,
+    save_referrer: true,
+    save_campaign_params: true,
+    before_send: sanitizeAnalyticsEvent,
+  };
+}
+
+export function startDocsAnalytics({
+  posthog,
+  hostname,
+  apiKey,
+  apiHost,
+  getStorage,
+  getCurrentUrl,
+  addNavigationListener,
+}) {
+  const config = resolveAnalyticsConfig({ hostname, apiKey, apiHost });
+  if (!config || !hasUsableStorage(getStorage)) return false;
+
+  try {
+    posthog.init(config.apiKey, createPostHogOptions(config.apiHost));
+
+    let previousNavigation;
+    const capturePageview = () => {
+      const currentNavigation = getCurrentUrl();
+      // Astro can announce the initial page after this module runs; de-duplication keeps one pageview.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/335
+      if (currentNavigation === previousNavigation) return;
+      previousNavigation = currentNavigation;
+      posthog.capture("$pageview", { $current_url: currentNavigation });
+    };
+
+    capturePageview();
+    addNavigationListener(capturePageview);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/docs/src/analytics.mjs
+++ b/docs/src/analytics.mjs
@@ -3,7 +3,6 @@ const PERSISTENCE_NAME = "obsidian-copilot-docs";
 const STORAGE_PROBE_KEY = "__obsidian_copilot_docs_analytics_probe__";
 
 const URL_PROPERTIES = new Set(["$current_url", "$referrer"]);
-const PATH_PROPERTIES = new Set(["$pathname"]);
 const PASSTHROUGH_PROPERTIES = new Set([
   "$browser",
   "$device_id",
@@ -47,21 +46,11 @@ function sanitizeUrl(value, includePath = true) {
   }
 }
 
-function sanitizePath(value) {
-  if (typeof value !== "string" || (!value.startsWith("/") && !/^https?:\/\//i.test(value))) {
-    return undefined;
-  }
-
-  try {
-    return new URL(value, `https://${CANONICAL_HOSTNAME}`).pathname;
-  } catch {
-    return undefined;
-  }
-}
-
 function sanitizeCampaignValue(value) {
   if (typeof value !== "string") return undefined;
   const sanitized = value.trim();
+  // Campaign fields are free text, so a short bound prevents them from becoming a content channel.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/335
   return sanitized.length > 0 && sanitized.length <= 80 ? sanitized : undefined;
 }
 
@@ -75,12 +64,6 @@ function sanitizeProperties(properties) {
           ? "$direct"
           : sanitizeUrl(value, key !== "$referrer");
       if (safeUrl) sanitized[key] = safeUrl;
-      continue;
-    }
-
-    if (PATH_PROPERTIES.has(key)) {
-      const safePath = sanitizePath(value);
-      if (safePath) sanitized[key] = safePath;
       continue;
     }
 
@@ -189,7 +172,8 @@ export function createPostHogOptions(apiHost, getCanonicalUrl) {
     // The final event boundary replaces SDK-derived request paths with the generated route identity.
     // https://github.com/Brevilabs/obsidian-copilot-private/issues/335
     before_send: (event) => {
-      const canonicalUrl = getCanonicalUrl();
+      const canonicalUrl = sanitizeUrl(getCanonicalUrl());
+      if (!canonicalUrl || new URL(canonicalUrl).host !== CANONICAL_HOSTNAME) return null;
       return sanitizeAnalyticsEvent({
         ...event,
         properties: {
@@ -214,27 +198,33 @@ export async function startDocsAnalytics({
   const config = resolveAnalyticsConfig({ hostname, apiKey, apiHost });
   if (!config || !hasUsableStorage(getStorage)) return false;
 
+  const pendingNavigations = [];
+  let dispatchNavigation = (canonicalUrl) => pendingNavigations.push(canonicalUrl);
+  let previousNavigation;
+  const handleNavigation = () => {
+    const canonicalUrl = getCanonicalUrl();
+    // Missing route identity cannot satisfy the outgoing-event privacy contract.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/335
+    if (!canonicalUrl || canonicalUrl === previousNavigation) return;
+    previousNavigation = canonicalUrl;
+    dispatchNavigation(canonicalUrl);
+  };
+  let removeNavigationListener = () => {};
+
   try {
+    // Subscribe before the chunk load so cold-cache navigation still produces one event per route.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/335
+    removeNavigationListener = addNavigationListener(handleNavigation);
+    handleNavigation();
+
     const posthog = await loadPostHog();
     posthog.init(config.apiKey, createPostHogOptions(config.apiHost, getCanonicalUrl));
-
-    let previousNavigation;
-    const capturePageview = () => {
-      // Generated canonical URLs bucket missing routes as /404 instead of reporting arbitrary requests.
-      // https://github.com/Brevilabs/obsidian-copilot-private/issues/335
-      const currentNavigation = getCanonicalUrl();
-      if (!currentNavigation) return;
-      // Astro can announce the initial page after this module runs; de-duplication keeps one pageview.
-      // https://github.com/Brevilabs/obsidian-copilot-private/issues/335
-      if (currentNavigation === previousNavigation) return;
-      previousNavigation = currentNavigation;
-      posthog.capture("$pageview", { $current_url: currentNavigation });
-    };
-
-    capturePageview();
-    addNavigationListener(capturePageview);
+    dispatchNavigation = (canonicalUrl) =>
+      posthog.capture("$pageview", { $current_url: canonicalUrl });
+    pendingNavigations.forEach(dispatchNavigation);
     return true;
   } catch {
+    removeNavigationListener();
     return false;
   }
 }

--- a/docs/src/analytics.mjs
+++ b/docs/src/analytics.mjs
@@ -3,7 +3,7 @@ const PERSISTENCE_NAME = "obsidian-copilot-docs";
 const STORAGE_PROBE_KEY = "__obsidian_copilot_docs_analytics_probe__";
 
 const URL_PROPERTIES = new Set(["$current_url", "$referrer"]);
-const PATH_PROPERTIES = new Set(["$pathname", "$prev_pageview_pathname"]);
+const PATH_PROPERTIES = new Set(["$pathname"]);
 const PASSTHROUGH_PROPERTIES = new Set([
   "$browser",
   "$device_id",
@@ -28,7 +28,7 @@ const PASSTHROUGH_PROPERTIES = new Set([
 const CAMPAIGN_PROPERTY = /^\$?(?:(?:initial|session_entry)_)?utm_(?:source|medium|campaign)$/;
 const ALLOWED_EVENTS = new Set(["$pageview", "$pageleave"]);
 
-function sanitizeUrl(value) {
+function sanitizeUrl(value, includePath = true) {
   if (typeof value !== "string" || value.length === 0) return undefined;
 
   try {
@@ -36,6 +36,9 @@ function sanitizeUrl(value) {
     if (url.protocol !== "https:" && url.protocol !== "http:") return undefined;
     url.username = "";
     url.password = "";
+    // Referring-domain attribution does not need arbitrary paths that may contain private input.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/335
+    if (!includePath) url.pathname = "/";
     url.search = "";
     url.hash = "";
     return url.toString();
@@ -67,7 +70,10 @@ function sanitizeProperties(properties) {
 
   for (const [key, value] of Object.entries(properties ?? {})) {
     if (URL_PROPERTIES.has(key)) {
-      const safeUrl = key === "$referrer" && value === "$direct" ? "$direct" : sanitizeUrl(value);
+      const safeUrl =
+        key === "$referrer" && value === "$direct"
+          ? "$direct"
+          : sanitizeUrl(value, key !== "$referrer");
       if (safeUrl) sanitized[key] = safeUrl;
       continue;
     }
@@ -151,7 +157,7 @@ export function sanitizeAnalyticsEvent(event) {
   };
 }
 
-export function createPostHogOptions(apiHost) {
+export function createPostHogOptions(apiHost, getCanonicalUrl) {
   return {
     api_host: apiHost,
     autocapture: false,
@@ -180,28 +186,44 @@ export function createPostHogOptions(apiHost) {
     disable_scroll_properties: true,
     save_referrer: true,
     save_campaign_params: true,
-    before_send: sanitizeAnalyticsEvent,
+    // The final event boundary replaces SDK-derived request paths with the generated route identity.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/335
+    before_send: (event) => {
+      const canonicalUrl = getCanonicalUrl();
+      return sanitizeAnalyticsEvent({
+        ...event,
+        properties: {
+          ...event.properties,
+          $current_url: canonicalUrl,
+          $pathname: canonicalUrl,
+        },
+      });
+    },
   };
 }
 
-export function startDocsAnalytics({
-  posthog,
+export async function startDocsAnalytics({
+  loadPostHog,
   hostname,
   apiKey,
   apiHost,
   getStorage,
-  getCurrentUrl,
+  getCanonicalUrl,
   addNavigationListener,
 }) {
   const config = resolveAnalyticsConfig({ hostname, apiKey, apiHost });
   if (!config || !hasUsableStorage(getStorage)) return false;
 
   try {
-    posthog.init(config.apiKey, createPostHogOptions(config.apiHost));
+    const posthog = await loadPostHog();
+    posthog.init(config.apiKey, createPostHogOptions(config.apiHost, getCanonicalUrl));
 
     let previousNavigation;
     const capturePageview = () => {
-      const currentNavigation = getCurrentUrl();
+      // Generated canonical URLs bucket missing routes as /404 instead of reporting arbitrary requests.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/335
+      const currentNavigation = getCanonicalUrl();
+      if (!currentNavigation) return;
       // Astro can announce the initial page after this module runs; de-duplication keeps one pageview.
       // https://github.com/Brevilabs/obsidian-copilot-private/issues/335
       if (currentNavigation === previousNavigation) return;

--- a/docs/src/analytics.test.mjs
+++ b/docs/src/analytics.test.mjs
@@ -131,6 +131,16 @@ describe("analytics", () => {
         $process_person_profile: false,
       });
     });
+
+    it(`${ISSUE} drops events without a canonical docs route`, () => {
+      for (const canonicalUrl of [undefined, "not a URL", "https://example.com/private"]) {
+        const options = createPostHogOptions("https://us.i.posthog.com", () => canonicalUrl);
+        assert.equal(
+          options.before_send({ uuid: "event-id", event: "$pageleave", properties: {} }),
+          null
+        );
+      }
+    });
   });
 
   describe("sanitizeAnalyticsEvent()", () => {
@@ -158,7 +168,6 @@ describe("analytics", () => {
         properties: {
           $current_url:
             "https://person:secret@docs.obsidiancopilot.com/getting-started/?query=private#answer",
-          $pathname: "/wrong?query=private#answer",
           $referrer: "https://user:pass@example.com/article/?secret=yes#section",
           $referring_domain: "untrusted.example",
           $browser: "Chrome",
@@ -203,7 +212,7 @@ describe("analytics", () => {
       const direct = sanitizeAnalyticsEvent({
         uuid: "event-id",
         event: "$pageview",
-        properties: { $current_url: "not a URL", $referrer: "$direct", $pathname: "private" },
+        properties: { $current_url: "not a URL", $referrer: "$direct" },
       });
       assert.deepEqual(direct.properties, {
         $referrer: "$direct",
@@ -271,35 +280,39 @@ describe("analytics", () => {
           ...input,
           apiHost: "https://us.i.posthog.com",
           getCanonicalUrl: () => "https://docs.obsidiancopilot.com/",
-          addNavigationListener: () => {},
+          addNavigationListener: () => () => {},
         });
         assert.equal(enabled, false);
         assert.equal(loaded, false);
       }
     });
 
-    it(`${ISSUE} captures once per generated route and buckets missing requests as /404`, async () => {
+    it(`${ISSUE} buffers each generated route while the SDK loads`, async () => {
       const captures = [];
       let navigationListener;
-      let canonicalUrl;
+      let canonicalUrl = "https://docs.obsidiancopilot.com/404/";
       const enabled = await startDocsAnalytics({
-        loadPostHog: async () => ({
-          init: () => {},
-          capture: (event, properties) => captures.push({ event, properties }),
-        }),
+        loadPostHog: async () => {
+          canonicalUrl = "https://docs.obsidiancopilot.com/getting-started/";
+          navigationListener();
+          return {
+            init: () => {},
+            capture: (event, properties) => captures.push({ event, properties }),
+          };
+        },
         hostname: "docs.obsidiancopilot.com",
         apiKey: "phc_test",
         apiHost: "https://us.i.posthog.com",
         getStorage: () => ({ setItem: () => {}, getItem: () => "1", removeItem: () => {} }),
         getCanonicalUrl: () => canonicalUrl,
-        addNavigationListener: (listener) => (navigationListener = listener),
+        addNavigationListener: (listener) => {
+          navigationListener = listener;
+          return () => {};
+        },
       });
 
-      assert.deepEqual(captures, []);
-      canonicalUrl = "https://docs.obsidiancopilot.com/404/";
       navigationListener();
-      navigationListener();
-      canonicalUrl = "https://docs.obsidiancopilot.com/getting-started/";
+      canonicalUrl = "https://docs.obsidiancopilot.com/projects/";
       navigationListener();
 
       assert.equal(enabled, true);
@@ -314,10 +327,15 @@ describe("analytics", () => {
             $current_url: "https://docs.obsidiancopilot.com/getting-started/",
           },
         },
+        {
+          event: "$pageview",
+          properties: { $current_url: "https://docs.obsidiancopilot.com/projects/" },
+        },
       ]);
     });
 
     it(`${ISSUE} fails closed when the SDK cannot load`, async () => {
+      let listenerRemoved = false;
       const enabled = await startDocsAnalytics({
         loadPostHog: async () => {
           throw new Error("blocked");
@@ -327,10 +345,13 @@ describe("analytics", () => {
         apiHost: "https://us.i.posthog.com",
         getStorage: () => ({ setItem: () => {}, getItem: () => "1", removeItem: () => {} }),
         getCanonicalUrl: () => "https://docs.obsidiancopilot.com/",
-        addNavigationListener: () => {},
+        addNavigationListener: () => () => {
+          listenerRemoved = true;
+        },
       });
 
       assert.equal(enabled, false);
+      assert.equal(listenerRemoved, true);
     });
   });
 });

--- a/docs/src/analytics.test.mjs
+++ b/docs/src/analytics.test.mjs
@@ -1,0 +1,277 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  createPostHogOptions,
+  hasUsableStorage,
+  resolveAnalyticsConfig,
+  sanitizeAnalyticsEvent,
+  startDocsAnalytics,
+} from "./analytics.mjs";
+
+const ISSUE = "https://github.com/Brevilabs/obsidian-copilot-private/issues/335";
+
+describe("analytics", () => {
+  describe("resolveAnalyticsConfig()", () => {
+    it(`${ISSUE} enables only the canonical production hostname`, () => {
+      assert.deepEqual(
+        resolveAnalyticsConfig({
+          hostname: "docs.obsidiancopilot.com",
+          apiKey: " phc_test ",
+          apiHost: "https://us.i.posthog.com/",
+        }),
+        { apiKey: "phc_test", apiHost: "https://us.i.posthog.com" }
+      );
+      assert.equal(
+        resolveAnalyticsConfig({
+          hostname: "preview.example.com",
+          apiKey: "phc_test",
+          apiHost: "https://us.i.posthog.com",
+        }),
+        null
+      );
+    });
+
+    it(`${ISSUE} disables analytics when either optional setting is missing`, () => {
+      assert.equal(
+        resolveAnalyticsConfig({
+          hostname: "docs.obsidiancopilot.com",
+          apiKey: "",
+          apiHost: "https://us.i.posthog.com",
+        }),
+        null
+      );
+      assert.equal(
+        resolveAnalyticsConfig({
+          hostname: "docs.obsidiancopilot.com",
+          apiKey: "phc_test",
+          apiHost: undefined,
+        }),
+        null
+      );
+    });
+  });
+
+  describe("hasUsableStorage()", () => {
+    it(`${ISSUE} fails closed when browser storage is unavailable`, () => {
+      assert.equal(
+        hasUsableStorage(() => {
+          throw new Error("blocked");
+        }),
+        false
+      );
+    });
+
+    it(`${ISSUE} removes its successful storage probe`, () => {
+      const values = new Map();
+      assert.equal(
+        hasUsableStorage(() => ({
+          setItem: (key, value) => values.set(key, value),
+          getItem: (key) => values.get(key),
+          removeItem: (key) => values.delete(key),
+        })),
+        true
+      );
+      assert.equal(values.size, 0);
+    });
+
+    it(`${ISSUE} fails closed when storage silently drops writes`, () => {
+      assert.equal(
+        hasUsableStorage(() => ({
+          setItem: () => {},
+          getItem: () => null,
+          removeItem: () => {},
+        })),
+        false
+      );
+    });
+  });
+
+  describe("createPostHogOptions()", () => {
+    it(`${ISSUE} disables automatic collection and identity joining`, () => {
+      const options = createPostHogOptions("https://us.i.posthog.com");
+      assert.equal(options.autocapture, false);
+      assert.equal(options.capture_pageview, false);
+      assert.equal(options.capture_pageleave, true);
+      assert.equal(options.disable_session_recording, true);
+      assert.equal(options.disable_surveys, true);
+      assert.equal(options.disable_conversations, true);
+      assert.equal(options.disable_product_tours, true);
+      assert.equal(options.disable_external_dependency_loading, true);
+      assert.equal(options.advanced_disable_flags, true);
+      assert.equal(options.advanced_disable_feature_flags, true);
+      assert.equal(options.person_profiles, "never");
+      assert.equal(options.persistence, "localStorage");
+      assert.equal(options.persistence_name, "obsidian-copilot-docs");
+      assert.equal(options.cross_subdomain_cookie, false);
+      assert.equal(options.before_send, sanitizeAnalyticsEvent);
+    });
+  });
+
+  describe("sanitizeAnalyticsEvent()", () => {
+    it(`${ISSUE} allows only pageview and pageleave events`, () => {
+      assert.equal(
+        sanitizeAnalyticsEvent({ event: "$autocapture", properties: {}, uuid: "event-id" }),
+        null
+      );
+      assert.equal(
+        sanitizeAnalyticsEvent({ event: "docs_search", properties: {}, uuid: "event-id" }),
+        null
+      );
+      assert.equal(
+        sanitizeAnalyticsEvent({ event: "$pageleave", properties: {}, uuid: "event-id" }).event,
+        "$pageleave"
+      );
+    });
+
+    it(`${ISSUE} strips private URL, referrer, content, and person properties`, () => {
+      const timestamp = new Date("2026-08-31T12:00:00Z");
+      const result = sanitizeAnalyticsEvent({
+        uuid: "event-id",
+        event: "$pageview",
+        timestamp,
+        properties: {
+          $current_url:
+            "https://person:secret@docs.obsidiancopilot.com/getting-started/?query=private#answer",
+          $pathname: "/wrong?query=private#answer",
+          $referrer: "https://user:pass@example.com/article/?secret=yes#section",
+          $referring_domain: "untrusted.example",
+          $browser: "Chrome",
+          $browser_version: "140.0.0.0",
+          $device_type: "Desktop",
+          $geoip_country_code: "US",
+          $screen_height: 1080,
+          $screen_width: 1920,
+          distinct_id: "anonymous-id",
+          $set: { email: "reader@example.com" },
+          search: "private search",
+          $search_engine: "Google",
+          $event_type: "submit",
+          $element_text: "private form content",
+          email: "reader@example.com",
+          gclid: "ad-click-id",
+        },
+        $set: { email: "reader@example.com" },
+        $set_once: { initial_email: "reader@example.com" },
+      });
+
+      assert.deepEqual(result, {
+        uuid: "event-id",
+        event: "$pageview",
+        timestamp,
+        properties: {
+          $current_url: "https://docs.obsidiancopilot.com/getting-started/",
+          $referrer: "https://example.com/article/",
+          $browser: "Chrome",
+          $device_type: "Desktop",
+          $geoip_country_code: "US",
+          distinct_id: "anonymous-id",
+          $host: "docs.obsidiancopilot.com",
+          $process_person_profile: false,
+          $referring_domain: "example.com",
+          $pathname: "/getting-started/",
+        },
+      });
+    });
+
+    it(`${ISSUE} preserves direct traffic and drops malformed or non-URL values`, () => {
+      const direct = sanitizeAnalyticsEvent({
+        uuid: "event-id",
+        event: "$pageview",
+        properties: { $current_url: "not a URL", $referrer: "$direct", $pathname: "private" },
+      });
+      assert.deepEqual(direct.properties, {
+        $referrer: "$direct",
+        $host: "docs.obsidiancopilot.com",
+        $process_person_profile: false,
+        $referring_domain: "$direct",
+      });
+
+      const malformed = sanitizeAnalyticsEvent({
+        uuid: "event-id",
+        event: "$pageview",
+        properties: { $current_url: "https://[invalid", $referrer: "https://[invalid" },
+      });
+      assert.deepEqual(malformed.properties, {
+        $host: "docs.obsidiancopilot.com",
+        $process_person_profile: false,
+      });
+    });
+
+    it(`${ISSUE} keeps only bounded source, medium, and campaign attribution`, () => {
+      const result = sanitizeAnalyticsEvent({
+        uuid: "event-id",
+        event: "$pageview",
+        properties: {
+          $utm_source: " newsletter ",
+          $initial_utm_medium: "email",
+          $session_entry_utm_campaign: "launch",
+          utm_term: "private keyword",
+          $initial_gclid: "ad-click-id",
+          $utm_campaign: "x".repeat(81),
+          $session_entry_utm_source: "   ",
+        },
+      });
+
+      assert.deepEqual(result.properties, {
+        $utm_source: "newsletter",
+        $initial_utm_medium: "email",
+        $session_entry_utm_campaign: "launch",
+        $host: "docs.obsidiancopilot.com",
+        $process_person_profile: false,
+      });
+    });
+  });
+
+  describe("startDocsAnalytics()", () => {
+    it(`${ISSUE} does not initialize when storage cannot be used`, () => {
+      let initialized = false;
+      const enabled = startDocsAnalytics({
+        posthog: { init: () => (initialized = true) },
+        hostname: "docs.obsidiancopilot.com",
+        apiKey: "phc_test",
+        apiHost: "https://us.i.posthog.com",
+        getStorage: () => null,
+        getCurrentUrl: () => "https://docs.obsidiancopilot.com/",
+        addNavigationListener: () => {},
+      });
+      assert.equal(enabled, false);
+      assert.equal(initialized, false);
+    });
+
+    it(`${ISSUE} captures once per initial load or client-side navigation`, () => {
+      const captures = [];
+      let navigationListener;
+      let currentUrl = "https://docs.obsidiancopilot.com/?private=one";
+      const enabled = startDocsAnalytics({
+        posthog: {
+          init: () => {},
+          capture: (event, properties) => captures.push({ event, properties }),
+        },
+        hostname: "docs.obsidiancopilot.com",
+        apiKey: "phc_test",
+        apiHost: "https://us.i.posthog.com",
+        getStorage: () => ({ setItem: () => {}, getItem: () => "1", removeItem: () => {} }),
+        getCurrentUrl: () => currentUrl,
+        addNavigationListener: (listener) => (navigationListener = listener),
+      });
+
+      navigationListener();
+      currentUrl = "https://docs.obsidiancopilot.com/getting-started/?private=two";
+      navigationListener();
+
+      assert.equal(enabled, true);
+      assert.deepEqual(captures, [
+        {
+          event: "$pageview",
+          properties: { $current_url: "https://docs.obsidiancopilot.com/?private=one" },
+        },
+        {
+          event: "$pageview",
+          properties: {
+            $current_url: "https://docs.obsidiancopilot.com/getting-started/?private=two",
+          },
+        },
+      ]);
+    });
+  });
+});

--- a/docs/src/analytics.test.mjs
+++ b/docs/src/analytics.test.mjs
@@ -88,7 +88,10 @@ describe("analytics", () => {
 
   describe("createPostHogOptions()", () => {
     it(`${ISSUE} disables automatic collection and identity joining`, () => {
-      const options = createPostHogOptions("https://us.i.posthog.com");
+      const options = createPostHogOptions(
+        "https://us.i.posthog.com",
+        () => "https://docs.obsidiancopilot.com/"
+      );
       assert.equal(options.autocapture, false);
       assert.equal(options.capture_pageview, false);
       assert.equal(options.capture_pageleave, true);
@@ -103,7 +106,30 @@ describe("analytics", () => {
       assert.equal(options.persistence, "localStorage");
       assert.equal(options.persistence_name, "obsidian-copilot-docs");
       assert.equal(options.cross_subdomain_cookie, false);
-      assert.equal(options.before_send, sanitizeAnalyticsEvent);
+    });
+
+    it(`${ISSUE} replaces pageleave request paths with the generated 404 route`, () => {
+      const options = createPostHogOptions(
+        "https://us.i.posthog.com",
+        () => "https://docs.obsidiancopilot.com/404/"
+      );
+
+      const result = options.before_send({
+        uuid: "event-id",
+        event: "$pageleave",
+        properties: {
+          $current_url: "https://docs.obsidiancopilot.com/reset/private-token",
+          $pathname: "/reset/private-token",
+          $prev_pageview_pathname: "/another/private-path",
+        },
+      });
+
+      assert.deepEqual(result.properties, {
+        $current_url: "https://docs.obsidiancopilot.com/404/",
+        $pathname: "/404/",
+        $host: "docs.obsidiancopilot.com",
+        $process_person_profile: false,
+      });
     });
   });
 
@@ -160,7 +186,7 @@ describe("analytics", () => {
         timestamp,
         properties: {
           $current_url: "https://docs.obsidiancopilot.com/getting-started/",
-          $referrer: "https://example.com/article/",
+          $referrer: "https://example.com/",
           $browser: "Chrome",
           $device_type: "Desktop",
           $geoip_country_code: "US",
@@ -223,55 +249,88 @@ describe("analytics", () => {
   });
 
   describe("startDocsAnalytics()", () => {
-    it(`${ISSUE} does not initialize when storage cannot be used`, () => {
-      let initialized = false;
-      const enabled = startDocsAnalytics({
-        posthog: { init: () => (initialized = true) },
-        hostname: "docs.obsidiancopilot.com",
-        apiKey: "phc_test",
-        apiHost: "https://us.i.posthog.com",
-        getStorage: () => null,
-        getCurrentUrl: () => "https://docs.obsidiancopilot.com/",
-        addNavigationListener: () => {},
-      });
-      assert.equal(enabled, false);
-      assert.equal(initialized, false);
+    it(`${ISSUE} does not load the SDK when analytics is ineligible`, async () => {
+      const usableStorage = { setItem: () => {}, getItem: () => "1", removeItem: () => {} };
+      const ineligibleInputs = [
+        { hostname: "preview.example.com", apiKey: "phc_test", getStorage: () => usableStorage },
+        {
+          hostname: "docs.obsidiancopilot.com",
+          apiKey: undefined,
+          getStorage: () => usableStorage,
+        },
+        { hostname: "docs.obsidiancopilot.com", apiKey: "phc_test", getStorage: () => null },
+      ];
+
+      for (const input of ineligibleInputs) {
+        let loaded = false;
+        const enabled = await startDocsAnalytics({
+          loadPostHog: async () => {
+            loaded = true;
+            return { init: () => {} };
+          },
+          ...input,
+          apiHost: "https://us.i.posthog.com",
+          getCanonicalUrl: () => "https://docs.obsidiancopilot.com/",
+          addNavigationListener: () => {},
+        });
+        assert.equal(enabled, false);
+        assert.equal(loaded, false);
+      }
     });
 
-    it(`${ISSUE} captures once per initial load or client-side navigation`, () => {
+    it(`${ISSUE} captures once per generated route and buckets missing requests as /404`, async () => {
       const captures = [];
       let navigationListener;
-      let currentUrl = "https://docs.obsidiancopilot.com/?private=one";
-      const enabled = startDocsAnalytics({
-        posthog: {
+      let canonicalUrl;
+      const enabled = await startDocsAnalytics({
+        loadPostHog: async () => ({
           init: () => {},
           capture: (event, properties) => captures.push({ event, properties }),
-        },
+        }),
         hostname: "docs.obsidiancopilot.com",
         apiKey: "phc_test",
         apiHost: "https://us.i.posthog.com",
         getStorage: () => ({ setItem: () => {}, getItem: () => "1", removeItem: () => {} }),
-        getCurrentUrl: () => currentUrl,
+        getCanonicalUrl: () => canonicalUrl,
         addNavigationListener: (listener) => (navigationListener = listener),
       });
 
+      assert.deepEqual(captures, []);
+      canonicalUrl = "https://docs.obsidiancopilot.com/404/";
       navigationListener();
-      currentUrl = "https://docs.obsidiancopilot.com/getting-started/?private=two";
+      navigationListener();
+      canonicalUrl = "https://docs.obsidiancopilot.com/getting-started/";
       navigationListener();
 
       assert.equal(enabled, true);
       assert.deepEqual(captures, [
         {
           event: "$pageview",
-          properties: { $current_url: "https://docs.obsidiancopilot.com/?private=one" },
+          properties: { $current_url: "https://docs.obsidiancopilot.com/404/" },
         },
         {
           event: "$pageview",
           properties: {
-            $current_url: "https://docs.obsidiancopilot.com/getting-started/?private=two",
+            $current_url: "https://docs.obsidiancopilot.com/getting-started/",
           },
         },
       ]);
+    });
+
+    it(`${ISSUE} fails closed when the SDK cannot load`, async () => {
+      const enabled = await startDocsAnalytics({
+        loadPostHog: async () => {
+          throw new Error("blocked");
+        },
+        hostname: "docs.obsidiancopilot.com",
+        apiKey: "phc_test",
+        apiHost: "https://us.i.posthog.com",
+        getStorage: () => ({ setItem: () => {}, getItem: () => "1", removeItem: () => {} }),
+        getCanonicalUrl: () => "https://docs.obsidiancopilot.com/",
+        addNavigationListener: () => {},
+      });
+
+      assert.equal(enabled, false);
     });
   });
 });

--- a/docs/src/components/Head.astro
+++ b/docs/src/components/Head.astro
@@ -15,6 +15,9 @@ import DefaultHead from "@astrojs/starlight/components/Head.astro";
     getStorage: () => window.localStorage,
     getCanonicalUrl: () =>
       document.querySelector<HTMLLinkElement>('link[rel="canonical"]')?.href,
-    addNavigationListener: (listener) => document.addEventListener("astro:page-load", listener),
+    addNavigationListener: (listener) => {
+      document.addEventListener("astro:page-load", listener);
+      return () => document.removeEventListener("astro:page-load", listener);
+    },
   });
 </script>

--- a/docs/src/components/Head.astro
+++ b/docs/src/components/Head.astro
@@ -5,16 +5,16 @@ import DefaultHead from "@astrojs/starlight/components/Head.astro";
 <DefaultHead />
 
 <script>
-  import posthog from "posthog-js";
   import { startDocsAnalytics } from "../analytics.mjs";
 
-  startDocsAnalytics({
-    posthog,
+  void startDocsAnalytics({
+    loadPostHog: async () => (await import("posthog-js")).default,
     hostname: window.location.hostname,
     apiKey: import.meta.env.PUBLIC_POSTHOG_KEY,
     apiHost: import.meta.env.PUBLIC_POSTHOG_HOST,
     getStorage: () => window.localStorage,
-    getCurrentUrl: () => window.location.href,
+    getCanonicalUrl: () =>
+      document.querySelector<HTMLLinkElement>('link[rel="canonical"]')?.href,
     addNavigationListener: (listener) => document.addEventListener("astro:page-load", listener),
   });
 </script>

--- a/docs/src/components/Head.astro
+++ b/docs/src/components/Head.astro
@@ -1,0 +1,20 @@
+---
+import DefaultHead from "@astrojs/starlight/components/Head.astro";
+---
+
+<DefaultHead />
+
+<script>
+  import posthog from "posthog-js";
+  import { startDocsAnalytics } from "../analytics.mjs";
+
+  startDocsAnalytics({
+    posthog,
+    hostname: window.location.hostname,
+    apiKey: import.meta.env.PUBLIC_POSTHOG_KEY,
+    apiHost: import.meta.env.PUBLIC_POSTHOG_HOST,
+    getStorage: () => window.localStorage,
+    getCurrentUrl: () => window.location.href,
+    addNavigationListener: (listener) => document.addEventListener("astro:page-load", listener),
+  });
+</script>


### PR DESCRIPTION
Fixes Brevilabs/obsidian-copilot-private#335

## Why

Visits to `docs.obsidiancopilot.com` are absent from the production PostHog project, so the team cannot measure documentation traffic or understand which paths and referring domains help readers. The docs must remain fully usable when analytics is unconfigured or browser storage is unavailable, and no page content, search terms, private URL data, or identified-user data may leave the site.

## What

| Condition | Result |
| --- | --- |
| Canonical docs host with both public settings and usable storage | Send one anonymous `$pageview` per initial load or client navigation, plus an exit-only `$pageleave` |
| Local, preview, missing configuration, or unavailable storage | Do not initialize analytics; documentation continues to render normally |
| Any outgoing event | Allow only pageview/page-leave events and canonical paths, sanitized referrers, coarse device data, and bounded source/medium/campaign attribution |

The production runbook now documents the legal-policy gate, exact Vercel variables, verification query, and rollback switch.

## Non goal

- Track clicks, copy actions, searches, feedback, or custom conversions.
- Enable session replay, autocapture, advertising pixels, product UI, or user identification.
- Join documentation visitors to plugin or account identities.
- Change documentation content, information architecture, SEO, or visual design.
- Rebuild the shared `app-sites` analytics package in this repository.

## Screenshot

Not applicable. This changes headless analytics collection and has no visible UI.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Docs tests cover host/config gates, storage failures, event allowlisting, sanitization, and navigation de-duplication |
| A defect would fail CI or be obvious on first use | ✅ | A dedicated docs CI job installs the package, runs its tests, and builds the static site |
| A revert fully restores prior state, including persisted data | ❌ | A docs-scoped anonymous ID can remain inert in browser localStorage after a revert |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | URL, referrer, campaign, environment, and browser-storage inputs now cross an analytics privacy boundary |
| No public API, plugin API, message, or on-disk contract changes | ✅ | The behavior is confined to the standalone documentation site |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | The plugin runtime is untouched; docs collection follows the existing Astro navigation event |
| No hot-path behavior lacks deterministic coverage | ✅ | Deterministic tests exercise every host/config/storage branch and the sanitizer and navigation paths |
| No new dependency | ❌ | The docs package adds pinned `posthog-js` 1.422.5 |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Production verification is isolated to docs traffic and appears in PostHog Live Events on the next visit |

Review: inspect `resolveAnalyticsConfig`, `sanitizeAnalyticsEvent`, `createPostHogOptions`, and `startDocsAnalytics` in `docs/src/analytics.mjs` line by line, then run Verification steps 1-4, including the preview-host, private-URL, blocked-storage, and missing-setting variants.

## Verification

1. In `docs/`, unset both `PUBLIC_POSTHOG_*` variables, run `npm ci && npm test && npm run build`, and confirm the tests and static build pass while analytics stays optional.
2. Start the docs locally with valid project settings, visit a path containing a query string, fragment, and ad-click parameter, and confirm the non-canonical host sends no PostHog requests. Block localStorage and confirm the site still works without collection.
3. After confirming the privacy policy covers the docs subdomain, set `PUBLIC_POSTHOG_KEY` and `PUBLIC_POSTHOG_HOST` only in Vercel Production and deploy. Visit two canonical paths, including private query/fragment and campaign variants, then exit the site.
4. In PostHog project 119931, run the README query and confirm one pageview per path, an exit page-leave, the canonical host, sanitized referrer/campaign fields, no preview traffic, and no query strings, fragments, search terms, ad-click IDs, person properties, autocapture, or replay events.

