### PR TITLE
Make grouped Agent trail statistics match their steps

### DIFF
--- a/designdocs/AGENT_TRAIL_GROUPING.md
+++ b/designdocs/AGENT_TRAIL_GROUPING.md
@@ -36,7 +36,7 @@ run of machine rows before the next piece of prose.
 ## What an activity group is
 
 A maximal run of consecutive **tool calls and reasoning blocks**, folded into
-one collapsed row summarizing the work: `Read 2 files, ran 12 commands, thought
+one collapsed row summarizing the work: `Ran 12 commands, read 2 files, thought
 for 51s`. A run of one member keeps its own row — a single `Read` gets no group
 chrome.
 
@@ -63,18 +63,18 @@ chrome.
 
 ### How the line reads
 
-The vocabulary is deliberately coarse — three families plus reasoning, named in
-first-appearance order:
+The vocabulary is deliberately coarse: every grouped tool call contributes to
+the total command count, and file-specific tools add distinct file totals:
 
 - **read** — `Read` / `NotebookRead` by vendor name, or the ACP
   `toolKind: "read"` fallback, so a backend that sends no vendor names still
   says `read 2 files`.
 - **edit** — `Edit` / `MultiEdit` / `Write` / `NotebookEdit`, or
   `toolKind: "edit"`.
-- **command** — everything else, no exceptions: shell commands, searches,
-  fetches, skills, MCP calls, tools that do not exist yet.
+- **command** — every tool call, including reads and edits. This total matches
+  the number of tool rows in the expanded group.
 
-`Read 2 files, edited 1 file, ran 5 commands, thought for 51s` is the longest
+`Ran 8 commands, read 2 files, edited 1 file, thought for 51s` is the longest
 shape the line can take. An earlier revision named more families (searches,
 fetches, skills), kept unregistered tools under their own name (`Design sync
 ×16`), and keyed MCP tools per server — which then needed a family cap with
@@ -85,16 +85,17 @@ or an MCP call a "command" is a stretch that only lasts until the group is
 opened — and a lone call never enters a group at all, so it keeps its precise
 row.
 
-Reasoning duration is **not** derivable from the parts — `kind: "thought"`
-carries no timestamps. The caller measures it live and passes `thinkingMs` to
-`summarizeActivity`, the same way `ReasoningBlock` measures its own timer today.
-Because the clock lives in the group row, spans the row never saw go unmeasured:
-a leading thought only becomes a group when the first tool call arrives (by
-which point the thinking is over), and groups off the live edge never run the
-clock. The line therefore under-counts and never over-counts — accepted, since
-the duration is cosmetic and fixing it would mean timestamping thought parts in
-the session contract. `thought for Xs` simply drops off a line that measured
-nothing; the reasoning text itself stays in the expanded rows.
+Reasoning parts carry the local event time of their first chunk. The message
+store freezes a block's duration when prose, a new tool call, a plan update, an
+error, or turn completion proves the reasoning ended. Both the expanded
+reasoning row and its parent group use that duration. The active block adds its
+live elapsed time until the store freezes it. This keeps the two rows consistent
+when React batches several session updates or remounts a completed card.
+
+Read and edit totals prefer structured paths from tool locations and diff
+outputs. Paths are de-duplicated across the group. A file-classified tool with
+no structured path counts as one file, preserving useful output for backends
+that provide only a tool kind.
 
 ### Measured at pane width
 
@@ -151,5 +152,5 @@ absorbing their children — and every run of peers is pooled by
 
 `AgentTrailView` owns what a group cannot own itself: `useTrailExpansion` holds
 open/closed state above the node list (see invariant 2), and each group gets its
-own `useThinkingClock` via a per-group child component, because the trail's
-node list is a loop and hooks are not.
+own `useThinkingClock` for the active thought via a per-group child component,
+because the trail's node list is a loop and hooks are not.

--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -59,6 +59,8 @@ For Windows-specific installation help, see [Windows setup for Agent Chat](agent
 
 Select the **Agent Chat** ribbon icon or run **Open Copilot Agent Chat Window** from the command palette. If the default agent is not ready, Copilot opens **Select your agent**. Configure an agent, choose an installed row, then select **Start chat**.
 
+Agent Chat groups consecutive tool calls and reasoning into a compact activity row. The row reports the total tool commands, distinct files read or edited, and recorded reasoning time. Open it to inspect every step.
+
 When a newer Copilot release is available, the global Agent Chat home shows an update banner along the bottom of the pane. The banner stays above the home tabs when space is tight. Select **See what’s new** to read the release notes, or dismiss the banner for that release. Project homes and active conversations do not show it.
 
 ## Models, effort, and permissions

--- a/src/agentMode/session/AgentMessageStore.test.ts
+++ b/src/agentMode/session/AgentMessageStore.test.ts
@@ -121,6 +121,34 @@ describe("AgentMessageStore", () => {
         jest.useRealTimers();
       });
 
+      it("freezes a new late thought after completed prose and extends it with later chunks (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
+        jest.useFakeTimers();
+        jest.setSystemTime(1_000);
+        const store = new AgentMessageStore();
+        const id = store.addMessage(placeholder());
+        store.appendAgentText(id, "Done");
+        store.markTurnComplete(id, "end_turn", 1_000);
+
+        jest.setSystemTime(5_000);
+        store.appendAgentThought(id, "Late thought");
+        expect(store.getMessage(id)?.parts?.[1]).toEqual({
+          kind: "thought",
+          text: "Late thought",
+          startedAtMs: 5_000,
+          durationMs: 0,
+        });
+
+        jest.setSystemTime(7_000);
+        store.appendAgentThought(id, " continued");
+        expect(store.getMessage(id)?.parts?.[1]).toEqual({
+          kind: "thought",
+          text: "Late thought continued",
+          startedAtMs: 5_000,
+          durationMs: 2_000,
+        });
+        jest.useRealTimers();
+      });
+
       it("starts a new timed thought after a completed thought (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
         jest.useFakeTimers();
         jest.setSystemTime(1_000);

--- a/src/agentMode/session/AgentMessageStore.test.ts
+++ b/src/agentMode/session/AgentMessageStore.test.ts
@@ -67,14 +67,75 @@ describe("AgentMessageStore", () => {
     expect(store.appendAgentText("missing", "x")).toBe(false);
   });
 
-  it("appendAgentThought folds successive chunks into one part", () => {
+  it("appendAgentThought folds successive chunks into one timed part (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(1_000);
     const store = new AgentMessageStore();
     const id = store.addMessage(placeholder());
     store.appendAgentThought(id, "Thinking");
     store.appendAgentThought(id, " harder");
     const parts = store.getMessage(id)?.parts ?? [];
     expect(parts).toHaveLength(1);
-    expect(parts[0]).toEqual({ kind: "thought", text: "Thinking harder" });
+    expect(parts[0]).toEqual({
+      kind: "thought",
+      text: "Thinking harder",
+      startedAtMs: 1_000,
+    });
+    jest.useRealTimers();
+  });
+
+  it("freezes a thought when a tool call follows it (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(1_000);
+    const store = new AgentMessageStore();
+    const id = store.addMessage(placeholder());
+    store.appendAgentThought(id, "Thinking");
+    jest.advanceTimersByTime(12_648);
+    store.upsertAgentPart(id, {
+      kind: "tool_call",
+      id: "tc1",
+      title: "Edit files",
+      status: "completed",
+    });
+
+    expect(store.getMessage(id)?.parts?.[0]).toMatchObject({
+      kind: "thought",
+      startedAtMs: 1_000,
+      durationMs: 12_648,
+    });
+    jest.useRealTimers();
+  });
+
+  it("starts a new timed thought after a completed thought (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(1_000);
+    const store = new AgentMessageStore();
+    const id = store.addMessage(placeholder());
+    store.appendAgentThought(id, "First");
+    jest.advanceTimersByTime(2_000);
+    store.appendAgentText(id, "Update");
+    jest.advanceTimersByTime(3_000);
+    store.appendAgentThought(id, "Second");
+
+    expect(store.getMessage(id)?.parts).toEqual([
+      { kind: "thought", text: "First", startedAtMs: 1_000, durationMs: 2_000 },
+      { kind: "text", text: "Update" },
+      { kind: "thought", text: "Second", startedAtMs: 6_000 },
+    ]);
+    jest.useRealTimers();
+  });
+
+  it("freezes a trailing thought when the turn completes (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(1_000);
+    const store = new AgentMessageStore();
+    const id = store.addMessage(placeholder());
+    store.appendAgentThought(id, "Final thought");
+    jest.advanceTimersByTime(5_778);
+    store.markTurnComplete(id, "end_turn", 10_000);
+
+    expect(store.getMessage(id)?.parts?.[0]).toMatchObject({ durationMs: 5_778 });
+    jest.useRealTimers();
   });
 
   it("upsertAgentPart appends new tool_call by toolCallId", () => {
@@ -194,6 +255,24 @@ describe("AgentMessageStore", () => {
         expect.objectContaining({ content: "step 2" }),
       ]),
     });
+  });
+
+  it("lets a replacement plan freeze the trailing thought (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(1_000);
+    const store = new AgentMessageStore();
+    const id = store.addMessage(placeholder());
+    const plan: AgentMessagePart = {
+      kind: "plan",
+      entries: [{ content: "step 1", priority: "high", status: "pending" }],
+    };
+    store.upsertAgentPart(id, plan);
+    store.appendAgentThought(id, "Reconsider the next step");
+    jest.advanceTimersByTime(3_000);
+
+    expect(store.upsertAgentPart(id, { ...plan })).toBe(true);
+    expect(store.getMessage(id)?.parts?.[1]).toMatchObject({ durationMs: 3_000 });
+    jest.useRealTimers();
   });
 
   it("getDisplayMessages includes parts", () => {

--- a/src/agentMode/session/AgentMessageStore.test.ts
+++ b/src/agentMode/session/AgentMessageStore.test.ts
@@ -19,459 +19,7 @@ describe("AgentMessageStore", () => {
     parts: [] as AgentMessagePart[],
   });
 
-  it("appendDisplayText accumulates streaming chunks", () => {
-    const store = new AgentMessageStore();
-    const id = store.addMessage(placeholder());
-    store.appendDisplayText(id, "Hello, ");
-    store.appendDisplayText(id, "world.");
-    expect(store.getMessage(id)?.message).toBe("Hello, world.");
-  });
-
-  it("appendDisplayText returns false for unknown message", () => {
-    const store = new AgentMessageStore();
-    expect(store.appendDisplayText("missing", "x")).toBe(false);
-  });
-
-  it("appendAgentText folds successive chunks into one trailing text part", () => {
-    const store = new AgentMessageStore();
-    const id = store.addMessage(placeholder());
-    store.appendAgentText(id, "Hello, ");
-    store.appendAgentText(id, "world.");
-    const msg = store.getMessage(id);
-    const parts = msg?.parts ?? [];
-    expect(parts).toHaveLength(1);
-    expect(parts[0]).toEqual({ kind: "text", text: "Hello, world." });
-    // Flat body stays in sync for persistence / search / error append.
-    expect(msg?.message).toBe("Hello, world.");
-  });
-
-  it("appendAgentText starts a new text part when interrupted by a tool call", () => {
-    const store = new AgentMessageStore();
-    const id = store.addMessage(placeholder());
-    store.appendAgentText(id, "before");
-    store.upsertAgentPart(id, {
-      kind: "tool_call",
-      id: "tc1",
-      title: "Read README",
-      status: "completed",
-    });
-    store.appendAgentText(id, "after");
-    const parts = store.getMessage(id)?.parts ?? [];
-    expect(parts.map((p) => p.kind)).toEqual(["text", "tool_call", "text"]);
-    expect(parts[0]).toEqual({ kind: "text", text: "before" });
-    expect(parts[2]).toEqual({ kind: "text", text: "after" });
-  });
-
-  it("appendAgentText returns false for unknown message", () => {
-    const store = new AgentMessageStore();
-    expect(store.appendAgentText("missing", "x")).toBe(false);
-  });
-
-  it("appendAgentThought folds successive chunks into one timed part (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
-    jest.useFakeTimers();
-    jest.setSystemTime(1_000);
-    const store = new AgentMessageStore();
-    const id = store.addMessage(placeholder());
-    store.appendAgentThought(id, "Thinking");
-    store.appendAgentThought(id, " harder");
-    const parts = store.getMessage(id)?.parts ?? [];
-    expect(parts).toHaveLength(1);
-    expect(parts[0]).toEqual({
-      kind: "thought",
-      text: "Thinking harder",
-      startedAtMs: 1_000,
-    });
-    jest.useRealTimers();
-  });
-
-  it("freezes a thought when a tool call follows it (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
-    jest.useFakeTimers();
-    jest.setSystemTime(1_000);
-    const store = new AgentMessageStore();
-    const id = store.addMessage(placeholder());
-    store.appendAgentThought(id, "Thinking");
-    jest.advanceTimersByTime(12_648);
-    store.upsertAgentPart(id, {
-      kind: "tool_call",
-      id: "tc1",
-      title: "Edit files",
-      status: "completed",
-    });
-
-    expect(store.getMessage(id)?.parts?.[0]).toMatchObject({
-      kind: "thought",
-      startedAtMs: 1_000,
-      durationMs: 12_648,
-    });
-    jest.useRealTimers();
-  });
-
-  it("starts a new timed thought after a completed thought (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
-    jest.useFakeTimers();
-    jest.setSystemTime(1_000);
-    const store = new AgentMessageStore();
-    const id = store.addMessage(placeholder());
-    store.appendAgentThought(id, "First");
-    jest.advanceTimersByTime(2_000);
-    store.appendAgentText(id, "Update");
-    jest.advanceTimersByTime(3_000);
-    store.appendAgentThought(id, "Second");
-
-    expect(store.getMessage(id)?.parts).toEqual([
-      { kind: "thought", text: "First", startedAtMs: 1_000, durationMs: 2_000 },
-      { kind: "text", text: "Update" },
-      { kind: "thought", text: "Second", startedAtMs: 6_000 },
-    ]);
-    jest.useRealTimers();
-  });
-
-  it("freezes a trailing thought when the turn completes (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
-    jest.useFakeTimers();
-    jest.setSystemTime(1_000);
-    const store = new AgentMessageStore();
-    const id = store.addMessage(placeholder());
-    store.appendAgentThought(id, "Final thought");
-    jest.advanceTimersByTime(5_778);
-    store.markTurnComplete(id, "end_turn", 10_000);
-
-    expect(store.getMessage(id)?.parts?.[0]).toMatchObject({ durationMs: 5_778 });
-    jest.useRealTimers();
-  });
-
-  it("upsertAgentPart appends new tool_call by toolCallId", () => {
-    const store = new AgentMessageStore();
-    const id = store.addMessage(placeholder());
-    store.upsertAgentPart(id, {
-      kind: "tool_call",
-      id: "tc1",
-      title: "Read README",
-      status: "pending",
-    });
-    const parts = store.getMessage(id)?.parts ?? [];
-    expect(parts).toHaveLength(1);
-    expect(parts[0]).toMatchObject({ kind: "tool_call", id: "tc1", title: "Read README" });
-  });
-
-  it("upsertAgentPart replaces existing tool_call when ids match", () => {
-    const store = new AgentMessageStore();
-    const id = store.addMessage(placeholder());
-    store.upsertAgentPart(id, {
-      kind: "tool_call",
-      id: "tc1",
-      title: "Read README",
-      status: "pending",
-    });
-    store.upsertAgentPart(id, {
-      kind: "tool_call",
-      id: "tc1",
-      title: "Read README",
-      status: "completed",
-      output: [{ type: "text", text: "ok" }],
-    });
-    const parts = store.getMessage(id)?.parts ?? [];
-    expect(parts).toHaveLength(1);
-    expect(parts[0]).toMatchObject({
-      kind: "tool_call",
-      id: "tc1",
-      status: "completed",
-      output: [{ type: "text", text: "ok" }],
-    });
-  });
-
-  it("upsertAgentPart returns false when re-applying an identical snapshot", () => {
-    const store = new AgentMessageStore();
-    const id = store.addMessage(placeholder());
-    const part: AgentMessagePart = {
-      kind: "tool_call",
-      id: "tc1",
-      title: "Read README",
-      status: "pending",
-    };
-    expect(store.upsertAgentPart(id, part)).toBe(true);
-    expect(store.upsertAgentPart(id, { ...part })).toBe(false);
-  });
-
-  it("notifies for progress changes but skips identical progress", () => {
-    const store = new AgentMessageStore();
-    const id = store.addMessage(placeholder());
-    const part: AgentMessagePart = {
-      kind: "tool_call",
-      id: "tc1",
-      title: "Agent",
-      status: "in_progress",
-      progress: { description: "Inspect vault", toolUses: 1, durationMs: 1000 },
-    };
-
-    expect(store.upsertAgentPart(id, part)).toBe(true);
-    expect(store.upsertAgentPart(id, { ...part, progress: { ...part.progress } })).toBe(false);
-    expect(
-      store.upsertAgentPart(id, {
-        ...part,
-        progress: { ...part.progress, toolUses: 2 },
-      })
-    ).toBe(true);
-  });
-
-  it("upsertAgentPart compares large repeated tool outputs without duplicating", () => {
-    const store = new AgentMessageStore();
-    const id = store.addMessage(placeholder());
-    const part: AgentMessagePart = {
-      kind: "tool_call",
-      id: "tc1",
-      title: "Search",
-      status: "completed",
-      input: { query: "communication drill", nested: { text: "x".repeat(20_000) } },
-      output: [{ type: "text", text: "a".repeat(20_000) }],
-    };
-
-    expect(store.upsertAgentPart(id, part)).toBe(true);
-    expect(
-      store.upsertAgentPart(id, { ...part, output: part.output?.map((o) => ({ ...o })) })
-    ).toBe(false);
-    expect(store.getMessage(id)?.parts).toHaveLength(1);
-  });
-
-  it("upsertAgentPart treats plan as singleton (replace, not duplicate)", () => {
-    const store = new AgentMessageStore();
-    const id = store.addMessage(placeholder());
-    store.upsertAgentPart(id, {
-      kind: "plan",
-      entries: [{ content: "step 1", priority: "high", status: "pending" }],
-    });
-    store.upsertAgentPart(id, {
-      kind: "plan",
-      entries: [
-        { content: "step 1", priority: "high", status: "completed" },
-        { content: "step 2", priority: "medium", status: "pending" },
-      ],
-    });
-    const parts = store.getMessage(id)?.parts ?? [];
-    const planParts = parts.filter((p) => p.kind === "plan");
-    expect(planParts).toHaveLength(1);
-    expect(planParts[0]).toMatchObject({
-      kind: "plan",
-      entries: expect.arrayContaining([
-        expect.objectContaining({ content: "step 1", status: "completed" }),
-        expect.objectContaining({ content: "step 2" }),
-      ]),
-    });
-  });
-
-  it("lets a replacement plan freeze the trailing thought (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
-    jest.useFakeTimers();
-    jest.setSystemTime(1_000);
-    const store = new AgentMessageStore();
-    const id = store.addMessage(placeholder());
-    const plan: AgentMessagePart = {
-      kind: "plan",
-      entries: [{ content: "step 1", priority: "high", status: "pending" }],
-    };
-    store.upsertAgentPart(id, plan);
-    store.appendAgentThought(id, "Reconsider the next step");
-    jest.advanceTimersByTime(3_000);
-
-    expect(store.upsertAgentPart(id, { ...plan })).toBe(true);
-    expect(store.getMessage(id)?.parts?.[1]).toMatchObject({ durationMs: 3_000 });
-    jest.useRealTimers();
-  });
-
-  it("getDisplayMessages includes parts", () => {
-    const store = new AgentMessageStore();
-    const id = store.addMessage(placeholder());
-    store.upsertAgentPart(id, {
-      kind: "tool_call",
-      id: "tc1",
-      title: "x",
-      status: "pending",
-    });
-    const msg = store.getDisplayMessages().find((m) => m.id === id);
-    expect(msg?.parts).toHaveLength(1);
-  });
-
-  it("findMessageIdWithToolCall returns the message owning a tool call, or undefined", () => {
-    const store = new AgentMessageStore();
-    const first = store.addMessage(placeholder());
-    const second = store.addMessage(placeholder());
-    store.upsertAgentPart(first, {
-      kind: "tool_call",
-      id: "tc-old",
-      title: "Agent",
-      status: "in_progress",
-    });
-    store.upsertAgentPart(second, {
-      kind: "tool_call",
-      id: "tc-new",
-      title: "Read README",
-      status: "completed",
-    });
-
-    expect(store.findMessageIdWithToolCall("tc-old")).toBe(first);
-    expect(store.findMessageIdWithToolCall("tc-new")).toBe(second);
-    expect(store.findMessageIdWithToolCall("tc-missing")).toBeUndefined();
-  });
-
-  it("markMessageError flags the message and appends formatted error text", () => {
-    const store = new AgentMessageStore();
-    const id = store.addMessage({
-      message: "partial reply",
-      sender: AI_SENDER,
-      timestamp: formatDateTime(new Date()),
-      isVisible: true,
-    });
-    store.markMessageError(id, "boom", 12_345);
-    const msg = store.getMessage(id);
-    expect(msg?.isErrorMessage).toBe(true);
-    expect(msg?.message).toContain("partial reply");
-    expect(msg?.message).toContain("**Error:** boom");
-    expect(msg?.turnDurationMs).toBe(12_345);
-  });
-
-  describe("loadMessages()", () => {
-    it("keeps a message that has no send time undated instead of stamping the load time", () => {
-      // A replayed ACP transcript carries no times, and a saved chat can hold
-      // "Unknown time". Stamping now would date every restored message to the
-      // reopen, and autosave would write that back over the original.
-      const store = new AgentMessageStore();
-
-      store.loadMessages([
-        { id: "u1", sender: USER_SENDER, message: "hi", timestamp: null, isVisible: true },
-      ]);
-
-      expect(store.getDisplayMessages()[0].timestamp).toBeNull();
-    });
-
-    it("keeps the send time a message arrived with", () => {
-      const store = new AgentMessageStore();
-      const sent = formatDateTime(new Date("2026-01-02T03:04:05Z"));
-
-      store.loadMessages([
-        { id: "u1", sender: USER_SENDER, message: "hi", timestamp: sent, isVisible: true },
-      ]);
-
-      expect(store.getDisplayMessages()[0].timestamp).toEqual(sent);
-    });
-  });
-
-  describe("extendTurnDuration()", () => {
-    it("advances only an already-completed turn", () => {
-      const store = new AgentMessageStore();
-      const runningId = store.addMessage(placeholder());
-      const completedId = store.addMessage(placeholder());
-      store.markTurnComplete(completedId, "end_turn", 10_000);
-
-      expect(store.extendTurnDuration(runningId, 15_000)).toBe(false);
-      expect(store.extendTurnDuration(completedId, 9_000)).toBe(false);
-      expect(store.extendTurnDuration(completedId, 15_000)).toBe(true);
-      expect(store.getMessage(completedId)?.turnDurationMs).toBe(15_000);
-    });
-  });
-
-  it("truncateAfterMessageId drops everything after the target", () => {
-    const store = new AgentMessageStore();
-    const a = store.addMessage(placeholder());
-    store.addMessage(placeholder());
-    store.addMessage(placeholder());
-    store.truncateAfterMessageId(a);
-    expect(store.getDisplayMessages()).toHaveLength(1);
-  });
-
-  describe("getDisplayMessages memoization (streaming re-render coalescing)", () => {
-    it("returns the same array reference when nothing changed", () => {
-      const store = new AgentMessageStore();
-      store.addMessage(placeholder());
-      const first = store.getDisplayMessages();
-      const second = store.getDisplayMessages();
-      // An idle subscription tick (no mutation) must hand back the exact same
-      // array so the top-level `messages` memo bails out without diffing.
-      expect(second).toBe(first);
-    });
-
-    it("keeps stable identities for unchanged messages while one streams", () => {
-      const store = new AgentMessageStore();
-      const stable = store.addMessage({
-        message: "done",
-        sender: AI_SENDER,
-        timestamp: formatDateTime(new Date()),
-        isVisible: true,
-      });
-      const streaming = store.addMessage(placeholder());
-
-      const before = store.getDisplayMessages();
-      const stableBefore = before.find((m) => m.id === stable);
-      const streamingBefore = before.find((m) => m.id === streaming);
-
-      // Stream a token into only the second message.
-      store.appendAgentText(streaming, "Hello");
-
-      const after = store.getDisplayMessages();
-      const stableAfter = after.find((m) => m.id === stable);
-      const streamingAfter = after.find((m) => m.id === streaming);
-
-      // The array is rebuilt (something changed)...
-      expect(after).not.toBe(before);
-      // ...but the untouched message keeps its identity so its memoized React
-      // component skips re-rendering...
-      expect(stableAfter).toBe(stableBefore);
-      // ...while the streamed message gets a fresh object reflecting the new text.
-      expect(streamingAfter).not.toBe(streamingBefore);
-      expect(streamingAfter?.message).toBe("Hello");
-    });
-
-    it("re-adapts a message after every kind of in-place mutation", () => {
-      const store = new AgentMessageStore();
-      const id = store.addMessage(placeholder());
-
-      const v0 = store.getDisplayMessages()[0];
-      store.appendDisplayText(id, "x");
-      const v1 = store.getDisplayMessages()[0];
-      expect(v1).not.toBe(v0);
-
-      store.upsertAgentPart(id, { kind: "tool_call", id: "tc1", title: "t", status: "pending" });
-      const v2 = store.getDisplayMessages()[0];
-      expect(v2).not.toBe(v1);
-
-      store.markTurnComplete(id, "end_turn", 12_345);
-      const v3 = store.getDisplayMessages()[0];
-      expect(v3).not.toBe(v2);
-      expect(v3.turnStopReason).toBe("end_turn");
-      expect(v3.turnDurationMs).toBe(12_345);
-    });
-
-    it("does not re-adapt when upsertAgentPart is a no-op", () => {
-      const store = new AgentMessageStore();
-      const id = store.addMessage(placeholder());
-      const part: AgentMessagePart = {
-        kind: "tool_call",
-        id: "tc1",
-        title: "Read README",
-        status: "pending",
-      };
-      store.upsertAgentPart(id, part);
-      const before = store.getDisplayMessages()[0];
-      // Re-applying an identical snapshot is a no-op, so the cached view must
-      // survive — no spurious identity churn for the React tree.
-      expect(store.upsertAgentPart(id, { ...part })).toBe(false);
-      const after = store.getDisplayMessages()[0];
-      expect(after).toBe(before);
-    });
-
-    it("drops cached views for deleted and truncated messages", () => {
-      const store = new AgentMessageStore();
-      const a = store.addMessage(placeholder());
-      const b = store.addMessage(placeholder());
-      store.getDisplayMessages();
-
-      store.deleteMessage(b);
-      expect(store.getDisplayMessages().map((m) => m.id)).toEqual([a]);
-
-      const c = store.addMessage(placeholder());
-      store.truncateAfterMessageId(a);
-      expect(store.getDisplayMessages().map((m) => m.id)).toEqual([a]);
-      expect(store.getMessage(c)).toBeUndefined();
-    });
-  });
-
-  describe("fanout", () => {
+  describe("AgentMessageStore", () => {
     const liveTurn = (summaryText = "the summary"): FanoutTurn => ({
       answers: {
         opencode: { backendId: "opencode", status: "done", text: "opencode answer" },
@@ -480,55 +28,548 @@ describe("AgentMessageStore", () => {
       summary: { status: "done", text: summaryText },
     });
 
-    it("setFanout surfaces a FRESH snapshot each tick so React state updates don't bail", () => {
-      const store = new AgentMessageStore();
-      const id = store.addMessage(placeholder());
-      expect(store.getDisplayMessages().find((m) => m.id === id)?.fanout).toBeUndefined();
+    describe("appendDisplayText()", () => {
+      it("accumulates streaming chunks", () => {
+        const store = new AgentMessageStore();
+        const id = store.addMessage(placeholder());
+        store.appendDisplayText(id, "Hello, ");
+        store.appendDisplayText(id, "world.");
+        expect(store.getMessage(id)?.message).toBe("Hello, world.");
+      });
 
-      const turn = liveTurn();
-      expect(store.setFanout(id, turn)).toBe(true);
-      const after = store.getDisplayMessages().find((m) => m.id === id)?.fanout;
-      expect(after?.summary.text).toBe("the summary");
-      // A snapshot, not the same reference.
-      expect(after).not.toBe(turn);
-      expect(after?.answers).not.toBe(turn.answers);
-
-      // Re-setting (mutated live turn) yields a fresh reference, not a frozen one.
-      store.setFanout(id, liveTurn("updated summary"));
-      const second = store.getDisplayMessages().find((m) => m.id === id)?.fanout;
-      expect(second).not.toBe(after);
-      expect(second?.summary.text).toBe("updated summary");
+      it("returns false for an unknown message", () => {
+        const store = new AgentMessageStore();
+        expect(store.appendDisplayText("missing", "x")).toBe(false);
+      });
     });
 
-    it("setFanout returns false for an unknown message", () => {
-      const store = new AgentMessageStore();
-      expect(store.setFanout("nope", liveTurn())).toBe(false);
+    describe("appendAgentText()", () => {
+      it("folds successive chunks into one trailing text part", () => {
+        const store = new AgentMessageStore();
+        const id = store.addMessage(placeholder());
+        store.appendAgentText(id, "Hello, ");
+        store.appendAgentText(id, "world.");
+        const msg = store.getMessage(id);
+        const parts = msg?.parts ?? [];
+        expect(parts).toHaveLength(1);
+        expect(parts[0]).toEqual({ kind: "text", text: "Hello, world." });
+        // Flat body stays in sync for persistence / search / error append.
+        expect(msg?.message).toBe("Hello, world.");
+      });
+
+      it("starts a new text part when interrupted by a tool call", () => {
+        const store = new AgentMessageStore();
+        const id = store.addMessage(placeholder());
+        store.appendAgentText(id, "before");
+        store.upsertAgentPart(id, {
+          kind: "tool_call",
+          id: "tc1",
+          title: "Read README",
+          status: "completed",
+        });
+        store.appendAgentText(id, "after");
+        const parts = store.getMessage(id)?.parts ?? [];
+        expect(parts.map((p) => p.kind)).toEqual(["text", "tool_call", "text"]);
+        expect(parts[0]).toEqual({ kind: "text", text: "before" });
+        expect(parts[2]).toEqual({ kind: "text", text: "after" });
+      });
+
+      it("returns false for an unknown message", () => {
+        const store = new AgentMessageStore();
+        expect(store.appendAgentText("missing", "x")).toBe(false);
+      });
     });
 
-    it("loadMessages rebuilds the dropdown from an assistant composite, never from a user/plain body", () => {
-      const store = new AgentMessageStore();
-      const body = serializeFanoutComposite(liveTurn("loaded summary"), (x) => x.toUpperCase());
-      store.loadMessages([
-        // A user message carrying the same body must NOT be read as a composite.
-        { id: "u1", sender: USER_SENDER, message: body, timestamp: null, isVisible: true },
-        { id: "a1", sender: AI_SENDER, message: body, timestamp: null, isVisible: true },
-        {
-          id: "a2",
+    describe("appendAgentThought()", () => {
+      it("folds successive chunks into one timed part (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
+        jest.useFakeTimers();
+        jest.setSystemTime(1_000);
+        const store = new AgentMessageStore();
+        const id = store.addMessage(placeholder());
+        store.appendAgentThought(id, "Thinking");
+        store.appendAgentThought(id, " harder");
+        const parts = store.getMessage(id)?.parts ?? [];
+        expect(parts).toHaveLength(1);
+        expect(parts[0]).toEqual({
+          kind: "thought",
+          text: "Thinking harder",
+          startedAtMs: 1_000,
+        });
+        jest.useRealTimers();
+      });
+
+      it("extends a completed trailing thought when its final chunk arrives late (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
+        jest.useFakeTimers();
+        jest.setSystemTime(1_000);
+        const store = new AgentMessageStore();
+        const id = store.addMessage(placeholder());
+        store.appendAgentThought(id, "Thinking");
+        jest.advanceTimersByTime(2_000);
+        store.markTurnComplete(id, "end_turn", 2_000);
+
+        jest.advanceTimersByTime(3_000);
+        store.appendAgentThought(id, " after completion");
+
+        expect(store.getMessage(id)?.parts).toEqual([
+          {
+            kind: "thought",
+            text: "Thinking after completion",
+            startedAtMs: 1_000,
+            durationMs: 5_000,
+          },
+        ]);
+        jest.useRealTimers();
+      });
+
+      it("starts a new timed thought after a completed thought (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
+        jest.useFakeTimers();
+        jest.setSystemTime(1_000);
+        const store = new AgentMessageStore();
+        const id = store.addMessage(placeholder());
+        store.appendAgentThought(id, "First");
+        jest.advanceTimersByTime(2_000);
+        store.appendAgentText(id, "Update");
+        jest.advanceTimersByTime(3_000);
+        store.appendAgentThought(id, "Second");
+
+        expect(store.getMessage(id)?.parts).toEqual([
+          { kind: "thought", text: "First", startedAtMs: 1_000, durationMs: 2_000 },
+          { kind: "text", text: "Update" },
+          { kind: "thought", text: "Second", startedAtMs: 6_000 },
+        ]);
+        jest.useRealTimers();
+      });
+    });
+
+    describe("markTurnComplete()", () => {
+      it("freezes a trailing thought when the turn completes (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
+        jest.useFakeTimers();
+        jest.setSystemTime(1_000);
+        const store = new AgentMessageStore();
+        const id = store.addMessage(placeholder());
+        store.appendAgentThought(id, "Final thought");
+        jest.advanceTimersByTime(5_778);
+        store.markTurnComplete(id, "end_turn", 10_000);
+
+        expect(store.getMessage(id)?.parts?.[0]).toMatchObject({ durationMs: 5_778 });
+        jest.useRealTimers();
+      });
+    });
+
+    describe("upsertAgentPart()", () => {
+      it("appends a new tool call by its id", () => {
+        const store = new AgentMessageStore();
+        const id = store.addMessage(placeholder());
+        store.upsertAgentPart(id, {
+          kind: "tool_call",
+          id: "tc1",
+          title: "Read README",
+          status: "pending",
+        });
+        const parts = store.getMessage(id)?.parts ?? [];
+        expect(parts).toHaveLength(1);
+        expect(parts[0]).toMatchObject({ kind: "tool_call", id: "tc1", title: "Read README" });
+      });
+
+      it("freezes a thought when a tool call follows it (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
+        jest.useFakeTimers();
+        jest.setSystemTime(1_000);
+        const store = new AgentMessageStore();
+        const id = store.addMessage(placeholder());
+        store.appendAgentThought(id, "Thinking");
+        jest.advanceTimersByTime(12_648);
+        store.upsertAgentPart(id, {
+          kind: "tool_call",
+          id: "tc1",
+          title: "Edit files",
+          status: "completed",
+        });
+
+        expect(store.getMessage(id)?.parts?.[0]).toMatchObject({
+          kind: "thought",
+          startedAtMs: 1_000,
+          durationMs: 12_648,
+        });
+        jest.useRealTimers();
+      });
+
+      it("upsertAgentPart replaces existing tool_call when ids match", () => {
+        const store = new AgentMessageStore();
+        const id = store.addMessage(placeholder());
+        store.upsertAgentPart(id, {
+          kind: "tool_call",
+          id: "tc1",
+          title: "Read README",
+          status: "pending",
+        });
+        store.upsertAgentPart(id, {
+          kind: "tool_call",
+          id: "tc1",
+          title: "Read README",
+          status: "completed",
+          output: [{ type: "text", text: "ok" }],
+        });
+        const parts = store.getMessage(id)?.parts ?? [];
+        expect(parts).toHaveLength(1);
+        expect(parts[0]).toMatchObject({
+          kind: "tool_call",
+          id: "tc1",
+          status: "completed",
+          output: [{ type: "text", text: "ok" }],
+        });
+      });
+
+      it("upsertAgentPart returns false when re-applying an identical snapshot", () => {
+        const store = new AgentMessageStore();
+        const id = store.addMessage(placeholder());
+        const part: AgentMessagePart = {
+          kind: "tool_call",
+          id: "tc1",
+          title: "Read README",
+          status: "pending",
+        };
+        expect(store.upsertAgentPart(id, part)).toBe(true);
+        expect(store.upsertAgentPart(id, { ...part })).toBe(false);
+      });
+
+      it("notifies for progress changes but skips identical progress", () => {
+        const store = new AgentMessageStore();
+        const id = store.addMessage(placeholder());
+        const part: AgentMessagePart = {
+          kind: "tool_call",
+          id: "tc1",
+          title: "Agent",
+          status: "in_progress",
+          progress: { description: "Inspect vault", toolUses: 1, durationMs: 1000 },
+        };
+
+        expect(store.upsertAgentPart(id, part)).toBe(true);
+        expect(store.upsertAgentPart(id, { ...part, progress: { ...part.progress } })).toBe(false);
+        expect(
+          store.upsertAgentPart(id, {
+            ...part,
+            progress: { ...part.progress, toolUses: 2 },
+          })
+        ).toBe(true);
+      });
+
+      it("upsertAgentPart compares large repeated tool outputs without duplicating", () => {
+        const store = new AgentMessageStore();
+        const id = store.addMessage(placeholder());
+        const part: AgentMessagePart = {
+          kind: "tool_call",
+          id: "tc1",
+          title: "Search",
+          status: "completed",
+          input: { query: "communication drill", nested: { text: "x".repeat(20_000) } },
+          output: [{ type: "text", text: "a".repeat(20_000) }],
+        };
+
+        expect(store.upsertAgentPart(id, part)).toBe(true);
+        expect(
+          store.upsertAgentPart(id, { ...part, output: part.output?.map((o) => ({ ...o })) })
+        ).toBe(false);
+        expect(store.getMessage(id)?.parts).toHaveLength(1);
+      });
+
+      it("upsertAgentPart treats plan as singleton (replace, not duplicate)", () => {
+        const store = new AgentMessageStore();
+        const id = store.addMessage(placeholder());
+        store.upsertAgentPart(id, {
+          kind: "plan",
+          entries: [{ content: "step 1", priority: "high", status: "pending" }],
+        });
+        store.upsertAgentPart(id, {
+          kind: "plan",
+          entries: [
+            { content: "step 1", priority: "high", status: "completed" },
+            { content: "step 2", priority: "medium", status: "pending" },
+          ],
+        });
+        const parts = store.getMessage(id)?.parts ?? [];
+        const planParts = parts.filter((p) => p.kind === "plan");
+        expect(planParts).toHaveLength(1);
+        expect(planParts[0]).toMatchObject({
+          kind: "plan",
+          entries: expect.arrayContaining([
+            expect.objectContaining({ content: "step 1", status: "completed" }),
+            expect.objectContaining({ content: "step 2" }),
+          ]),
+        });
+      });
+
+      it("lets a replacement plan freeze the trailing thought (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
+        jest.useFakeTimers();
+        jest.setSystemTime(1_000);
+        const store = new AgentMessageStore();
+        const id = store.addMessage(placeholder());
+        const plan: AgentMessagePart = {
+          kind: "plan",
+          entries: [{ content: "step 1", priority: "high", status: "pending" }],
+        };
+        store.upsertAgentPart(id, plan);
+        store.appendAgentThought(id, "Reconsider the next step");
+        jest.advanceTimersByTime(3_000);
+
+        expect(store.upsertAgentPart(id, { ...plan })).toBe(true);
+        expect(store.getMessage(id)?.parts?.[1]).toMatchObject({ durationMs: 3_000 });
+        jest.useRealTimers();
+      });
+    });
+
+    describe("findMessageIdWithToolCall()", () => {
+      it("returns the message owning a tool call, or undefined", () => {
+        const store = new AgentMessageStore();
+        const first = store.addMessage(placeholder());
+        const second = store.addMessage(placeholder());
+        store.upsertAgentPart(first, {
+          kind: "tool_call",
+          id: "tc-old",
+          title: "Agent",
+          status: "in_progress",
+        });
+        store.upsertAgentPart(second, {
+          kind: "tool_call",
+          id: "tc-new",
+          title: "Read README",
+          status: "completed",
+        });
+
+        expect(store.findMessageIdWithToolCall("tc-old")).toBe(first);
+        expect(store.findMessageIdWithToolCall("tc-new")).toBe(second);
+        expect(store.findMessageIdWithToolCall("tc-missing")).toBeUndefined();
+      });
+    });
+
+    describe("markMessageError()", () => {
+      it("flags the message and appends formatted error text", () => {
+        const store = new AgentMessageStore();
+        const id = store.addMessage({
+          message: "partial reply",
           sender: AI_SENDER,
-          message: "just a normal reply",
-          timestamp: null,
+          timestamp: formatDateTime(new Date()),
           isVisible: true,
-        },
-      ]);
-      const display = store.getDisplayMessages();
-      const assistant = display.find((m) => m.id === "a1");
-      // The body is kept as-is (composite + markers) AND the dropdown is rebuilt.
-      expect(assistant?.message).toBe(body);
-      expect(assistant?.fanout?.summary.text).toBe("loaded summary");
-      expect(Object.keys(assistant?.fanout?.answers ?? {})).toEqual(["opencode", "codex"]);
-      // A plain assistant reply and the user message stay without a fanout.
-      expect(display.find((m) => m.id === "a2")?.fanout).toBeUndefined();
-      expect(display.find((m) => m.id === "u1")?.fanout).toBeUndefined();
+        });
+        store.markMessageError(id, "boom", 12_345);
+        const msg = store.getMessage(id);
+        expect(msg?.isErrorMessage).toBe(true);
+        expect(msg?.message).toContain("partial reply");
+        expect(msg?.message).toContain("**Error:** boom");
+        expect(msg?.turnDurationMs).toBe(12_345);
+      });
+    });
+
+    describe("loadMessages()", () => {
+      it("keeps a message that has no send time undated instead of stamping the load time", () => {
+        // A replayed ACP transcript carries no times, and a saved chat can hold
+        // "Unknown time". Stamping now would date every restored message to the
+        // reopen, and autosave would write that back over the original.
+        const store = new AgentMessageStore();
+
+        store.loadMessages([
+          { id: "u1", sender: USER_SENDER, message: "hi", timestamp: null, isVisible: true },
+        ]);
+
+        expect(store.getDisplayMessages()[0].timestamp).toBeNull();
+      });
+
+      it("keeps the send time a message arrived with", () => {
+        const store = new AgentMessageStore();
+        const sent = formatDateTime(new Date("2026-01-02T03:04:05Z"));
+
+        store.loadMessages([
+          { id: "u1", sender: USER_SENDER, message: "hi", timestamp: sent, isVisible: true },
+        ]);
+
+        expect(store.getDisplayMessages()[0].timestamp).toEqual(sent);
+      });
+
+      it("rebuilds fanout from an assistant composite but not a user or plain body", () => {
+        const store = new AgentMessageStore();
+        const body = serializeFanoutComposite(liveTurn("loaded summary"), (x) => x.toUpperCase());
+        store.loadMessages([
+          // A user message carrying the same body must NOT be read as a composite.
+          { id: "u1", sender: USER_SENDER, message: body, timestamp: null, isVisible: true },
+          { id: "a1", sender: AI_SENDER, message: body, timestamp: null, isVisible: true },
+          {
+            id: "a2",
+            sender: AI_SENDER,
+            message: "just a normal reply",
+            timestamp: null,
+            isVisible: true,
+          },
+        ]);
+        const display = store.getDisplayMessages();
+        const assistant = display.find((m) => m.id === "a1");
+        // The body is kept as-is (composite + markers) AND the dropdown is rebuilt.
+        expect(assistant?.message).toBe(body);
+        expect(assistant?.fanout?.summary.text).toBe("loaded summary");
+        expect(Object.keys(assistant?.fanout?.answers ?? {})).toEqual(["opencode", "codex"]);
+        // A plain assistant reply and the user message stay without a fanout.
+        expect(display.find((m) => m.id === "a2")?.fanout).toBeUndefined();
+        expect(display.find((m) => m.id === "u1")?.fanout).toBeUndefined();
+      });
+    });
+
+    describe("extendTurnDuration()", () => {
+      it("advances only an already-completed turn", () => {
+        const store = new AgentMessageStore();
+        const runningId = store.addMessage(placeholder());
+        const completedId = store.addMessage(placeholder());
+        store.markTurnComplete(completedId, "end_turn", 10_000);
+
+        expect(store.extendTurnDuration(runningId, 15_000)).toBe(false);
+        expect(store.extendTurnDuration(completedId, 9_000)).toBe(false);
+        expect(store.extendTurnDuration(completedId, 15_000)).toBe(true);
+        expect(store.getMessage(completedId)?.turnDurationMs).toBe(15_000);
+      });
+    });
+
+    describe("truncateAfterMessageId()", () => {
+      it("drops everything after the target", () => {
+        const store = new AgentMessageStore();
+        const a = store.addMessage(placeholder());
+        store.addMessage(placeholder());
+        store.addMessage(placeholder());
+        store.truncateAfterMessageId(a);
+        expect(store.getDisplayMessages()).toHaveLength(1);
+      });
+    });
+
+    describe("getDisplayMessages()", () => {
+      it("includes structured message parts", () => {
+        const store = new AgentMessageStore();
+        const id = store.addMessage(placeholder());
+        store.upsertAgentPart(id, {
+          kind: "tool_call",
+          id: "tc1",
+          title: "x",
+          status: "pending",
+        });
+        const msg = store.getDisplayMessages().find((m) => m.id === id);
+        expect(msg?.parts).toHaveLength(1);
+      });
+
+      it("returns the same array reference when nothing changed", () => {
+        const store = new AgentMessageStore();
+        store.addMessage(placeholder());
+        const first = store.getDisplayMessages();
+        const second = store.getDisplayMessages();
+        // An idle subscription tick (no mutation) must hand back the exact same
+        // array so the top-level `messages` memo bails out without diffing.
+        expect(second).toBe(first);
+      });
+
+      it("keeps stable identities for unchanged messages while one streams", () => {
+        const store = new AgentMessageStore();
+        const stable = store.addMessage({
+          message: "done",
+          sender: AI_SENDER,
+          timestamp: formatDateTime(new Date()),
+          isVisible: true,
+        });
+        const streaming = store.addMessage(placeholder());
+
+        const before = store.getDisplayMessages();
+        const stableBefore = before.find((m) => m.id === stable);
+        const streamingBefore = before.find((m) => m.id === streaming);
+
+        // Stream a token into only the second message.
+        store.appendAgentText(streaming, "Hello");
+
+        const after = store.getDisplayMessages();
+        const stableAfter = after.find((m) => m.id === stable);
+        const streamingAfter = after.find((m) => m.id === streaming);
+
+        // The array is rebuilt (something changed)...
+        expect(after).not.toBe(before);
+        // ...but the untouched message keeps its identity so its memoized React
+        // component skips re-rendering...
+        expect(stableAfter).toBe(stableBefore);
+        // ...while the streamed message gets a fresh object reflecting the new text.
+        expect(streamingAfter).not.toBe(streamingBefore);
+        expect(streamingAfter?.message).toBe("Hello");
+      });
+
+      it("re-adapts a message after every kind of in-place mutation", () => {
+        const store = new AgentMessageStore();
+        const id = store.addMessage(placeholder());
+
+        const v0 = store.getDisplayMessages()[0];
+        store.appendDisplayText(id, "x");
+        const v1 = store.getDisplayMessages()[0];
+        expect(v1).not.toBe(v0);
+
+        store.upsertAgentPart(id, { kind: "tool_call", id: "tc1", title: "t", status: "pending" });
+        const v2 = store.getDisplayMessages()[0];
+        expect(v2).not.toBe(v1);
+
+        store.markTurnComplete(id, "end_turn", 12_345);
+        const v3 = store.getDisplayMessages()[0];
+        expect(v3).not.toBe(v2);
+        expect(v3.turnStopReason).toBe("end_turn");
+        expect(v3.turnDurationMs).toBe(12_345);
+      });
+
+      it("does not re-adapt when upsertAgentPart is a no-op", () => {
+        const store = new AgentMessageStore();
+        const id = store.addMessage(placeholder());
+        const part: AgentMessagePart = {
+          kind: "tool_call",
+          id: "tc1",
+          title: "Read README",
+          status: "pending",
+        };
+        store.upsertAgentPart(id, part);
+        const before = store.getDisplayMessages()[0];
+        // Re-applying an identical snapshot is a no-op, so the cached view must
+        // survive — no spurious identity churn for the React tree.
+        expect(store.upsertAgentPart(id, { ...part })).toBe(false);
+        const after = store.getDisplayMessages()[0];
+        expect(after).toBe(before);
+      });
+
+      it("drops cached views for deleted and truncated messages", () => {
+        const store = new AgentMessageStore();
+        const a = store.addMessage(placeholder());
+        const b = store.addMessage(placeholder());
+        store.getDisplayMessages();
+
+        store.deleteMessage(b);
+        expect(store.getDisplayMessages().map((m) => m.id)).toEqual([a]);
+
+        const c = store.addMessage(placeholder());
+        store.truncateAfterMessageId(a);
+        expect(store.getDisplayMessages().map((m) => m.id)).toEqual([a]);
+        expect(store.getMessage(c)).toBeUndefined();
+      });
+    });
+
+    describe("setFanout()", () => {
+      it("surfaces a fresh snapshot each tick so React state updates do not bail", () => {
+        const store = new AgentMessageStore();
+        const id = store.addMessage(placeholder());
+        expect(store.getDisplayMessages().find((m) => m.id === id)?.fanout).toBeUndefined();
+
+        const turn = liveTurn();
+        expect(store.setFanout(id, turn)).toBe(true);
+        const after = store.getDisplayMessages().find((m) => m.id === id)?.fanout;
+        expect(after?.summary.text).toBe("the summary");
+        // A snapshot, not the same reference.
+        expect(after).not.toBe(turn);
+        expect(after?.answers).not.toBe(turn.answers);
+
+        // Re-setting (mutated live turn) yields a fresh reference, not a frozen one.
+        store.setFanout(id, liveTurn("updated summary"));
+        const second = store.getDisplayMessages().find((m) => m.id === id)?.fanout;
+        expect(second).not.toBe(after);
+        expect(second?.summary.text).toBe("updated summary");
+      });
+
+      it("setFanout returns false for an unknown message", () => {
+        const store = new AgentMessageStore();
+        expect(store.setFanout("nope", liveTurn())).toBe(false);
+      });
     });
   });
 });

--- a/src/agentMode/session/AgentMessageStore.test.ts
+++ b/src/agentMode/session/AgentMessageStore.test.ts
@@ -78,6 +78,27 @@ describe("AgentMessageStore", () => {
         const store = new AgentMessageStore();
         expect(store.appendAgentText("missing", "x")).toBe(false);
       });
+
+      it("extends a provisional late thought when completed prose ends it (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
+        jest.useFakeTimers();
+        jest.setSystemTime(1_000);
+        const store = new AgentMessageStore();
+        const id = store.addMessage(placeholder());
+        store.appendAgentText(id, "Done");
+        store.markTurnComplete(id, "end_turn", 1_000);
+        jest.setSystemTime(5_000);
+        store.appendAgentThought(id, "Late thought");
+
+        jest.setSystemTime(7_000);
+        store.appendAgentText(id, "After");
+
+        expect(store.getMessage(id)?.parts).toEqual([
+          { kind: "text", text: "Done" },
+          { kind: "thought", text: "Late thought", startedAtMs: 5_000, durationMs: 2_000 },
+          { kind: "text", text: "After" },
+        ]);
+        jest.useRealTimers();
+      });
     });
 
     describe("appendAgentThought()", () => {

--- a/src/agentMode/session/AgentMessageStore.ts
+++ b/src/agentMode/session/AgentMessageStore.ts
@@ -380,8 +380,8 @@ export class AgentMessageStore {
     if (!msg.parts) msg.parts = [];
     const last = msg.parts[msg.parts.length - 1];
     // A completed message can receive its final thought chunks after the
-    // prompt result. Keep those chunks in the frozen trailing span so the
-    // expanded row and grouped summary retain the same completed duration.
+    // prompt result. Extend a trailing span when possible; otherwise start a
+    // frozen span because another event may never arrive to finish it.
     // https://github.com/Brevilabs/obsidian-copilot-private/issues/336
     if (
       last &&
@@ -393,7 +393,13 @@ export class AgentMessageStore {
         last.durationMs = Math.max(0, Date.now() - last.startedAtMs);
       }
     } else {
-      msg.parts.push({ kind: "thought", text, startedAtMs: Date.now() });
+      const startedAtMs = Date.now();
+      msg.parts.push({
+        kind: "thought",
+        text,
+        startedAtMs,
+        ...(msg.turnStopReason !== undefined ? { durationMs: 0 } : {}),
+      });
     }
     this.touch(msg);
     return true;

--- a/src/agentMode/session/AgentMessageStore.ts
+++ b/src/agentMode/session/AgentMessageStore.ts
@@ -79,7 +79,7 @@ function partsEqual(a: AgentMessagePart, b: AgentMessagePart): boolean {
       return a.text === b.text;
     case "thought":
       if (b.kind !== "thought") return false;
-      return a.text === b.text;
+      return a.text === b.text && a.startedAtMs === b.startedAtMs && a.durationMs === b.durationMs;
     case "plan":
       if (b.kind !== "plan") return false;
       return planEntriesEqual(a.entries, b.entries);
@@ -241,6 +241,25 @@ export class AgentMessageStore {
     this.lastDisplay = null;
   }
 
+  /**
+   * Freeze the latest reasoning block at the event that ended it. React can
+   * batch over this transition, so render-time clocks cannot recover it later.
+   * https://github.com/Brevilabs/obsidian-copilot-private/issues/336
+   */
+  private finishTrailingThought(msg: StoredAgentMessage, endedAtMs = Date.now()): boolean {
+    const last = msg.parts?.[msg.parts.length - 1];
+    if (
+      !last ||
+      last.kind !== "thought" ||
+      last.startedAtMs === undefined ||
+      last.durationMs !== undefined
+    ) {
+      return false;
+    }
+    last.durationMs = Math.max(0, endedAtMs - last.startedAtMs);
+    return true;
+  }
+
   /** Add a message; returns its assigned id. */
   addMessage(message: NewAgentChatMessage): string {
     const id = message.id || this.generateId();
@@ -276,6 +295,7 @@ export class AgentMessageStore {
     const msg = this.messages.find((m) => m.id === id);
     if (!msg) return false;
     if (msg.turnStopReason !== undefined) return false;
+    this.finishTrailingThought(msg);
     msg.turnStopReason = stopReason;
     msg.turnDurationMs = Math.max(0, durationMs);
     this.touch(msg);
@@ -338,6 +358,7 @@ export class AgentMessageStore {
     if (!msg) return false;
     msg.displayText += text;
     if (!msg.parts) msg.parts = [];
+    this.finishTrailingThought(msg);
     const last = msg.parts[msg.parts.length - 1];
     if (last && last.kind === "text") {
       last.text += text;
@@ -358,10 +379,13 @@ export class AgentMessageStore {
     if (!msg) return false;
     if (!msg.parts) msg.parts = [];
     const last = msg.parts[msg.parts.length - 1];
-    if (last && last.kind === "thought") {
+    // A later thought chunk after another event starts a new timed block; it
+    // must not extend a duration that has already been frozen.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/336
+    if (last && last.kind === "thought" && last.durationMs === undefined) {
       last.text += text;
     } else {
-      msg.parts.push({ kind: "thought", text });
+      msg.parts.push({ kind: "thought", text, startedAtMs: Date.now() });
     }
     this.touch(msg);
     return true;
@@ -381,12 +405,20 @@ export class AgentMessageStore {
     if (partId !== undefined) {
       const idx = msg.parts.findIndex((p) => agentPartId(p) === partId);
       if (idx !== -1) {
-        if (partsEqual(msg.parts[idx], part)) return false;
+        // A fresh plan snapshot can replace its earlier singleton while still
+        // ending the reasoning block at the live edge.
+        // https://github.com/Brevilabs/obsidian-copilot-private/issues/336
+        const finishedThought = part.kind === "plan" && this.finishTrailingThought(msg);
+        if (partsEqual(msg.parts[idx], part)) {
+          if (finishedThought) this.touch(msg);
+          return finishedThought;
+        }
         msg.parts[idx] = part;
         this.touch(msg);
         return true;
       }
     }
+    this.finishTrailingThought(msg);
     msg.parts.push(part);
     this.touch(msg);
     return true;
@@ -418,6 +450,7 @@ export class AgentMessageStore {
   markMessageError(id: string, errorText: string, durationMs?: number): boolean {
     const msg = this.messages.find((m) => m.id === id);
     if (!msg) return false;
+    this.finishTrailingThought(msg);
     msg.isErrorMessage = true;
     if (durationMs !== undefined) msg.turnDurationMs = Math.max(0, durationMs);
     const suffix = msg.displayText.length > 0 ? "\n\n" : "";

--- a/src/agentMode/session/AgentMessageStore.ts
+++ b/src/agentMode/session/AgentMessageStore.ts
@@ -252,11 +252,13 @@ export class AgentMessageStore {
       !last ||
       last.kind !== "thought" ||
       last.startedAtMs === undefined ||
-      last.durationMs !== undefined
+      (last.durationMs !== undefined && msg.turnStopReason === undefined)
     ) {
       return false;
     }
-    last.durationMs = Math.max(0, endedAtMs - last.startedAtMs);
+    const durationMs = Math.max(last.durationMs ?? 0, endedAtMs - last.startedAtMs);
+    if (last.durationMs === durationMs) return false;
+    last.durationMs = durationMs;
     return true;
   }
 

--- a/src/agentMode/session/AgentMessageStore.ts
+++ b/src/agentMode/session/AgentMessageStore.ts
@@ -379,11 +379,19 @@ export class AgentMessageStore {
     if (!msg) return false;
     if (!msg.parts) msg.parts = [];
     const last = msg.parts[msg.parts.length - 1];
-    // A later thought chunk after another event starts a new timed block; it
-    // must not extend a duration that has already been frozen.
+    // A completed message can receive its final thought chunks after the
+    // prompt result. Keep those chunks in the frozen trailing span so the
+    // expanded row and grouped summary retain the same completed duration.
     // https://github.com/Brevilabs/obsidian-copilot-private/issues/336
-    if (last && last.kind === "thought" && last.durationMs === undefined) {
+    if (
+      last &&
+      last.kind === "thought" &&
+      (last.durationMs === undefined || msg.turnStopReason !== undefined)
+    ) {
       last.text += text;
+      if (msg.turnStopReason !== undefined && last.startedAtMs !== undefined) {
+        last.durationMs = Math.max(0, Date.now() - last.startedAtMs);
+      }
     } else {
       msg.parts.push({ kind: "thought", text, startedAtMs: Date.now() });
     }

--- a/src/agentMode/session/types.ts
+++ b/src/agentMode/session/types.ts
@@ -887,6 +887,10 @@ export type AgentMessagePart =
   | {
       kind: "thought";
       text: string;
+      /** Local event time for the first chunk in this reasoning block. */
+      startedAtMs?: number;
+      /** Frozen elapsed time once a later event proves the block ended. */
+      durationMs?: number;
     }
   | {
       // Streamed assistant prose. Each interruption by a tool_call or thought

--- a/src/agentMode/ui/ActivityGroupCard.stories.tsx
+++ b/src/agentMode/ui/ActivityGroupCard.stories.tsx
@@ -17,6 +17,15 @@ function action(title: string, overrides: Partial<ToolCallPart> = {}): ActivityM
 
 const THINKING: ActivityMember = {
   type: "reasoning",
+  part: {
+    kind: "thought",
+    text: "The migration note is the one that changed most recently.",
+    durationMs: 51_000,
+  },
+};
+
+const LIVE_THINKING: ActivityMember = {
+  type: "reasoning",
   part: { kind: "thought", text: "The migration note is the one that changed most recently." },
 };
 
@@ -49,7 +58,7 @@ const meta = {
     open: false,
     onToggle: () => undefined,
     renderMember,
-    thinkingMs: 51_000,
+    thinkingMs: 0,
   },
   parameters: { gallery: { host: "leaf", layout: "padded" } },
 } satisfies Meta<ActivityGroupCardProps>;
@@ -65,7 +74,7 @@ export const WithFailure: StoryObj<ActivityGroupCardProps> = {
       THINKING,
       action("npm run build", { vendorToolName: "Bash" }),
     ]),
-    thinkingMs: 7_000,
+    thinkingMs: 0,
   },
 };
 
@@ -79,8 +88,31 @@ export const InFlight: StoryObj<ActivityGroupCardProps> = {
         status: "in_progress",
       }),
     ]),
-    thinkingMs: 3_000,
+    thinkingMs: 0,
     liveStep: "npm run test -- ActivityGroupCard",
+  },
+};
+
+export const MultiFileEdit: StoryObj<ActivityGroupCardProps> = {
+  args: {
+    group: group([
+      action("Calculate description lengths", { toolKind: "execute" }),
+      action("Edit skill definitions", {
+        toolKind: "edit",
+        output: ["a.md", "b.md", "c.md", "d.md", "e.md"].map((path) => ({
+          type: "diff" as const,
+          path,
+          oldText: "before",
+          newText: "after",
+        })),
+      }),
+      action("Validate skill definitions", { toolKind: "execute" }),
+      {
+        type: "reasoning",
+        part: { kind: "thought", text: "Check the repaired files.", durationMs: 18_426 },
+      },
+    ]),
+    thinkingMs: 0,
   },
 };
 
@@ -96,7 +128,7 @@ export const LongLine: StoryObj<ActivityGroupCardProps> = {
       action("Design sync", { vendorToolName: "DesignSyncFromFigmaWorkspace" }),
       THINKING,
     ]),
-    thinkingMs: 214_000,
+    thinkingMs: 0,
   },
 };
 
@@ -106,7 +138,7 @@ const ExpandedDemo: React.FC = () => {
   return (
     <ActivityGroupCard
       group={MIXED}
-      thinkingMs={51_000}
+      thinkingMs={0}
       open={open}
       onToggle={() => setOpen((v) => !v)}
       renderMember={renderMember}
@@ -122,10 +154,10 @@ export const Expanded: StoryObj<ActivityGroupCardProps> = { render: ExpandedDemo
  * frame is the settled turn, where the live row retires entirely.
  */
 const LIVE_FRAMES: ActivityMember[][] = [
-  [action("Read Projects/Copilot/Roadmap.md", { vendorToolName: "Read" }), THINKING],
+  [action("Read Projects/Copilot/Roadmap.md", { vendorToolName: "Read" }), LIVE_THINKING],
   [
     action("Read Projects/Copilot/Roadmap.md", { vendorToolName: "Read" }),
-    THINKING,
+    LIVE_THINKING,
     action("lint", {
       vendorToolName: "Bash",
       status: "in_progress",
@@ -134,7 +166,7 @@ const LIVE_FRAMES: ActivityMember[][] = [
   ],
   [
     action("Read Projects/Copilot/Roadmap.md", { vendorToolName: "Read" }),
-    THINKING,
+    LIVE_THINKING,
     action("lint", { vendorToolName: "Bash", input: { command: "npm run lint" } }),
     action("test", {
       vendorToolName: "Bash",
@@ -144,7 +176,7 @@ const LIVE_FRAMES: ActivityMember[][] = [
   ],
   [
     action("Read Projects/Copilot/Roadmap.md", { vendorToolName: "Read" }),
-    THINKING,
+    LIVE_THINKING,
     action("lint", { vendorToolName: "Bash", input: { command: "npm run lint" } }),
     action("test", {
       vendorToolName: "Bash",

--- a/src/agentMode/ui/ActivityGroupCard.test.tsx
+++ b/src/agentMode/ui/ActivityGroupCard.test.tsx
@@ -48,7 +48,7 @@ describe("ActivityGroupCard", () => {
       });
 
       expect(screen.getByRole("button").textContent).toContain(
-        "Read 1 file, ran 2 commands, thought for 51s"
+        "Ran 3 commands, read 1 file, thought for 51s"
       );
     });
 

--- a/src/agentMode/ui/ActivityGroupCard.tsx
+++ b/src/agentMode/ui/ActivityGroupCard.tsx
@@ -11,9 +11,8 @@ import { AgentActivityCard } from "@/components/chat-components/AgentActivityCar
 export interface ActivityGroupCardProps {
   group: ActivityGroupNode;
   /**
-   * Measured reasoning wall-clock for this group, passed through to
-   * `summarizeActivity`. The card never measures time itself — `thought`
-   * parts carry no timestamps, so the trail owns the clock.
+   * Live elapsed time for the trailing reasoning span. Completed spans keep
+   * their duration on the thought parts, while the trail owns the active clock.
    */
   thinkingMs?: number;
   /**

--- a/src/agentMode/ui/AgentTrailView.test.tsx
+++ b/src/agentMode/ui/AgentTrailView.test.tsx
@@ -268,6 +268,32 @@ describe("AgentTrail", () => {
     expect(screen.queryByText("Thought for")).toBeNull();
   });
 
+  it("does not restart a frozen thought when a hidden tool trails it (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
+    jest.useFakeTimers();
+    try {
+      jest.setSystemTime(30_000);
+      renderTrail({
+        parts: [
+          READ_A,
+          {
+            kind: "thought",
+            text: "Finished reasoning",
+            startedAtMs: 12_000,
+            durationMs: 18_000,
+          },
+          toolCall("hidden", { vendorToolName: "ToolSearch", status: "in_progress" }),
+        ],
+        isStreaming: true,
+        turnStopReason: undefined,
+      });
+
+      expect(screen.getByText("Ran 1 command, read 1 file, thought for 18s")).toBeTruthy();
+      expect(screen.queryByText("Reasoning")).toBeNull();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it("renders prose between two groups at full size", () => {
     renderTrail({ parts: STREAMING_PARTS, isStreaming: true, turnStopReason: undefined });
 

--- a/src/agentMode/ui/AgentTrailView.test.tsx
+++ b/src/agentMode/ui/AgentTrailView.test.tsx
@@ -294,6 +294,29 @@ describe("AgentTrail", () => {
     }
   });
 
+  it("renders a frozen standalone trailing thought as complete (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
+    renderTrail({
+      parts: [
+        {
+          kind: "plan",
+          entries: [{ content: "Inspect the result", priority: "medium", status: "pending" }],
+        },
+        {
+          kind: "thought",
+          text: "Finished reasoning",
+          startedAtMs: 12_000,
+          durationMs: 18_000,
+        },
+      ],
+      isStreaming: true,
+      turnStopReason: undefined,
+    });
+
+    expect(screen.getByText("Thought for")).toBeTruthy();
+    expect(screen.getByText("18s")).toBeTruthy();
+    expect(screen.queryByText("Reasoning")).toBeNull();
+  });
+
   it("renders prose between two groups at full size", () => {
     renderTrail({ parts: STREAMING_PARTS, isStreaming: true, turnStopReason: undefined });
 

--- a/src/agentMode/ui/AgentTrailView.test.tsx
+++ b/src/agentMode/ui/AgentTrailView.test.tsx
@@ -260,7 +260,7 @@ describe("AgentTrail", () => {
       turnStopReason: undefined,
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /Read 1 file/ }));
+    fireEvent.click(screen.getByRole("button", { name: /read 1 file/i }));
 
     // The expanded member must report the same in-flight state the collapsed
     // live row did — not flip to a finished "Thought for" block.
@@ -276,8 +276,8 @@ describe("AgentTrail", () => {
     // Both runs around it stay folded into their own summary rows. The first
     // group's reasoning went unmeasured (the clock only runs at the live edge),
     // so its line names the tool work alone.
-    expect(screen.getByText("Read 1 file")).toBeTruthy();
-    expect(screen.getByText("Read 1 file, ran 1 command")).toBeTruthy();
+    expect(screen.getByText("Ran 1 command, read 1 file")).toBeTruthy();
+    expect(screen.getByText("Ran 2 commands, read 1 file")).toBeTruthy();
   });
 
   it("keeps a group the user opened open as more parts stream into it", () => {
@@ -287,7 +287,7 @@ describe("AgentTrail", () => {
       turnStopReason: undefined,
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /Read 1 file/ }));
+    fireEvent.click(screen.getByRole("button", { name: /read 1 file/i }));
     expect(screen.getByText("Read notes/a.md")).toBeTruthy();
 
     rerenderTrail({
@@ -296,7 +296,7 @@ describe("AgentTrail", () => {
       turnStopReason: undefined,
     });
 
-    const grown = screen.getByRole("button", { name: /Read 2 files/ });
+    const grown = screen.getByRole("button", { name: /read 2 files/i });
     expect(grown.getAttribute("aria-expanded")).toBe("true");
     expect(screen.getByText("Read notes/b.md")).toBeTruthy();
   });
@@ -316,7 +316,7 @@ describe("AgentTrail", () => {
     fireEvent.click(screen.getByText('Explore · "Look around"'));
 
     expect(screen.getByText("2 tools")).toBeTruthy();
-    expect(screen.getByText("Read 1 file, ran 1 command")).toBeTruthy();
+    expect(screen.getByText("Ran 2 commands, read 1 file")).toBeTruthy();
   });
 
   it("keeps an opened tool visible when streaming turns it into a group", () => {
@@ -339,7 +339,7 @@ describe("AgentTrail", () => {
       turnStopReason: undefined,
     });
 
-    const group = screen.getByRole("button", { name: /Read 1 file, ran 1 command/ });
+    const group = screen.getByRole("button", { name: /Ran 2 commands, read 1 file/ });
     expect(group.getAttribute("aria-expanded")).toBe("true");
     expect(screen.getByText("file contents")).toBeTruthy();
 
@@ -364,10 +364,10 @@ describe("AgentTrail", () => {
       ],
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /Read 1 file, ran 1 command/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Ran 2 commands, read 1 file/ }));
     fireEvent.click(screen.getByText('Explore · "Look around"'));
 
-    const groups = screen.getAllByRole("button", { name: /Read 1 file, ran 1 command/ });
+    const groups = screen.getAllByRole("button", { name: /Ran 2 commands, read 1 file/ });
     expect(groups.map((group) => group.getAttribute("aria-expanded"))).toEqual(["true", "false"]);
   });
 

--- a/src/agentMode/ui/AgentTrailView.tsx
+++ b/src/agentMode/ui/AgentTrailView.tsx
@@ -201,7 +201,13 @@ interface ActivityGroupRowProps {
 // A component rather than a branch of `renderNode` because each group owns its
 // own thinking clock, and hooks cannot run in a loop.
 const ActivityGroupRow: React.FC<ActivityGroupRowProps> = ({ group, atLiveEdge, ctx, trailId }) => {
-  const thinkingMs = useThinkingClock(isReasoningActive(group.members, atLiveEdge));
+  const reasoningActive = isReasoningActive(group.members, atLiveEdge);
+  const trailingMember = group.members[group.members.length - 1];
+  const activeThoughtStartedAtMs =
+    reasoningActive && trailingMember?.type === "reasoning"
+      ? trailingMember.part.startedAtMs
+      : undefined;
+  const thinkingMs = useThinkingClock(reasoningActive, activeThoughtStartedAtMs);
   const groupExpansionId = `${trailId}/group:${group.id}`;
   const memberExpansionIds = group.members.flatMap((member) =>
     member.type === "action" ? [actionExpansionId(trailId, member.part.id)] : []

--- a/src/agentMode/ui/AgentTrailView.tsx
+++ b/src/agentMode/ui/AgentTrailView.tsx
@@ -201,8 +201,12 @@ interface ActivityGroupRowProps {
 // A component rather than a branch of `renderNode` because each group owns its
 // own thinking clock, and hooks cannot run in a loop.
 const ActivityGroupRow: React.FC<ActivityGroupRowProps> = ({ group, atLiveEdge, ctx, trailId }) => {
-  const reasoningActive = isReasoningActive(group.members, atLiveEdge);
   const trailingMember = group.members[group.members.length - 1];
+  // A hidden trailing tool is absent from the rendered group but still ends
+  // the preceding reasoning span in the raw message parts.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/336
+  const groupAtLiveEdge = atLiveEdge && trailingMember?.part === ctx.lastPart;
+  const reasoningActive = isReasoningActive(group.members, groupAtLiveEdge);
   const activeThoughtStartedAtMs =
     reasoningActive && trailingMember?.type === "reasoning"
       ? trailingMember.part.startedAtMs
@@ -238,11 +242,11 @@ const ActivityGroupRow: React.FC<ActivityGroupRowProps> = ({ group, atLiveEdge, 
           member,
           member.type === "action" ? member.part.id : `thought-${i}`,
           ctx,
-          atLiveEdge,
+          groupAtLiveEdge,
           trailId
         )
       }
-      liveStep={activityLiveStep(group.members, atLiveEdge, ctx.summaryCtx)}
+      liveStep={activityLiveStep(group.members, groupAtLiveEdge, ctx.summaryCtx)}
     />
   );
 };

--- a/src/agentMode/ui/AgentTrailView.tsx
+++ b/src/agentMode/ui/AgentTrailView.tsx
@@ -180,7 +180,11 @@ function renderNode(
       );
     }
     case "reasoning": {
-      const isActive = atLiveEdge && node.part === ctx.lastPart;
+      // Replacing an earlier singleton plan can freeze the final thought
+      // without appending another raw part, so duration also ends live state.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/336
+      const isActive =
+        atLiveEdge && node.part === ctx.lastPart && node.part.durationMs === undefined;
       return <ReasoningBlock key={key} part={node.part} isStreaming={isActive} />;
     }
     case "text":

--- a/src/agentMode/ui/ReasoningBlock.stories.tsx
+++ b/src/agentMode/ui/ReasoningBlock.stories.tsx
@@ -11,6 +11,8 @@ type ReasoningBlockProps = React.ComponentProps<typeof ReasoningBlock>;
 const REASONING = {
   kind: "thought" as const,
   text: "Comparing the implementation with the current interface before making the change.",
+  startedAtMs: Date.now() - 18_426,
+  durationMs: 18_426,
 };
 
 const meta = {
@@ -24,7 +26,10 @@ export default meta;
 export const Complete: StoryObj<ReasoningBlockProps> = {};
 
 export const Active: StoryObj<ReasoningBlockProps> = {
-  args: { isStreaming: true },
+  args: {
+    part: { ...REASONING, startedAtMs: undefined, durationMs: undefined },
+    isStreaming: true,
+  },
 };
 
 /** Matches the completed trail order so the response footer can be inspected as one row. */

--- a/src/agentMode/ui/ReasoningBlock.test.tsx
+++ b/src/agentMode/ui/ReasoningBlock.test.tsx
@@ -1,0 +1,35 @@
+import { ReasoningBlock } from "@/agentMode/ui/ReasoningBlock";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+describe("ReasoningBlock", () => {
+  describe("ReasoningBlock()", () => {
+    it("renders the event-backed duration after remount (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
+      render(
+        <ReasoningBlock
+          part={{
+            kind: "thought",
+            text: "Compare the grouped steps.",
+            startedAtMs: 1_000,
+            durationMs: 18_426,
+          }}
+          isStreaming={false}
+        />
+      );
+
+      expect(screen.getByText("Thought for")).toBeTruthy();
+      expect(screen.getByText("18s")).toBeTruthy();
+    });
+
+    it("keeps legacy completed thoughts at less than one second when timing is unavailable (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
+      render(
+        <ReasoningBlock
+          part={{ kind: "thought", text: "A restored thought without timing." }}
+          isStreaming={false}
+        />
+      );
+
+      expect(screen.getByText("< 1s")).toBeTruthy();
+    });
+  });
+});

--- a/src/agentMode/ui/ReasoningBlock.tsx
+++ b/src/agentMode/ui/ReasoningBlock.tsx
@@ -12,35 +12,13 @@ interface ReasoningBlockProps {
 /**
  * Adapter that maps an agent-mode `thought` part onto the existing
  * `AgentReasoningBlock` UI (brain icon, final duration, collapse-on-done). The store
- * folds streamed `agent_thought_chunk`s into a single `thought` part, so
- * we have one part per assistant turn — `steps` derives from paragraph
- * splits within `part.text`.
+ * folds consecutive `agent_thought_chunk`s into one `thought` part per
+ * uninterrupted reasoning span. `steps` derives from paragraph splits within
+ * `part.text`.
  */
 export const ReasoningBlock: React.FC<ReasoningBlockProps> = ({ part, isStreaming }) => {
-  const startedAtRef = useRef<number | null>(null);
-  const frozenAtRef = useRef<number | null>(null);
-  const prevIsStreamingRef = useRef(isStreaming);
+  const fallbackStartedAtRef = useRef(Date.now());
   const [now, setNow] = useState(() => Date.now());
-
-  // Initialize start timestamp on first mount when the thought has content.
-  useEffect(() => {
-    if (startedAtRef.current === null && part.text.length > 0) {
-      startedAtRef.current = Date.now();
-    }
-  }, [part.text]);
-
-  // Derive the freeze timestamp during render so we don't render one frame
-  // with `isStreaming=false` and a still-null completion mark. Mutating a
-  // ref during render is safe as long as the result is deterministic for
-  // this set of inputs.
-  if (prevIsStreamingRef.current !== isStreaming) {
-    if (!isStreaming && startedAtRef.current !== null) {
-      frozenAtRef.current = Date.now();
-    } else if (isStreaming) {
-      frozenAtRef.current = null;
-    }
-    prevIsStreamingRef.current = isStreaming;
-  }
 
   // Tick the clock while streaming.
   useEffect(() => {
@@ -49,11 +27,12 @@ export const ReasoningBlock: React.FC<ReasoningBlockProps> = ({ part, isStreamin
     return () => window.clearInterval(id);
   }, [isStreaming]);
 
-  const frozenAt = frozenAtRef.current;
-
-  const startedAt = startedAtRef.current ?? Date.now();
-  const endedAt = frozenAt ?? (isStreaming ? now : startedAt);
-  const elapsedSeconds = Math.max(0, Math.round((endedAt - startedAt) / 1000));
+  // Older saved parts have no timing metadata. They retain the prior local
+  // fallback while live and render as `< 1s` once complete.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/336
+  const startedAt = part.startedAtMs ?? fallbackStartedAtRef.current;
+  const elapsedMs = part.durationMs ?? (isStreaming ? Math.max(0, now - startedAt) : 0);
+  const elapsedSeconds = Math.floor(elapsedMs / 1000);
 
   const steps = part.text
     .split(/\n\n+/)

--- a/src/agentMode/ui/activityGroups.test.ts
+++ b/src/agentMode/ui/activityGroups.test.ts
@@ -198,16 +198,16 @@ describe("activityGroups", () => {
         member("b", { vendorToolName: "Read" }),
         member("c", { vendorToolName: "Bash" }),
       ]);
-      expect(line).toBe("Read 2 files, ran 1 command");
+      expect(line).toBe("Ran 3 commands, read 2 files");
     });
 
-    it("pools tools that mean the same thing into one phrase", () => {
+    it("uses one-file fallbacks when file tools omit paths (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
       const { line } = summarizeActivity([
         member("a", { vendorToolName: "Edit" }),
         member("b", { vendorToolName: "Write" }),
         member("c", { vendorToolName: "MultiEdit" }),
       ]);
-      expect(line).toBe("Edited 3 files");
+      expect(line).toBe("Ran 3 commands, edited 3 files");
     });
 
     it("falls back to the ACP tool kind when there is no vendor name", () => {
@@ -215,10 +215,10 @@ describe("activityGroups", () => {
         member("a", { toolKind: "execute" }),
         member("b", { toolKind: "read" }),
       ]);
-      expect(line).toBe("Ran 1 command, read 1 file");
+      expect(line).toBe("Ran 2 commands, read 1 file");
     });
 
-    it("counts every tool that is not a read or an edit as a command", () => {
+    it("counts every grouped tool call as a command (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
       const { line } = summarizeActivity([
         member("a", { vendorToolName: "Grep" }),
         member("b", { vendorToolName: "WebFetch" }),
@@ -235,7 +235,7 @@ describe("activityGroups", () => {
         member("r", { vendorToolName: "Read" }),
         member("g", { vendorToolName: "Grep" }),
       ]);
-      expect(line).toBe("Ran 2 commands, read 1 file");
+      expect(line).toBe("Ran 3 commands, read 1 file");
     });
 
     it("does not let an MCP tool named like a native read count as one", () => {
@@ -251,6 +251,46 @@ describe("activityGroups", () => {
         { thinkingMs: 51_000 }
       );
       expect(line).toBe("Ran 1 command, thought for 51s");
+    });
+
+    it("adds frozen reasoning spans to the active span (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
+      const recorded: ActivityMember = {
+        type: "reasoning",
+        part: { kind: "thought", text: "first", durationMs: 12_648 },
+      };
+      const { line } = summarizeActivity(
+        [member("a", { vendorToolName: "Bash" }), recorded, REASONING_MEMBER],
+        { thinkingMs: 5_778 }
+      );
+
+      expect(line).toBe("Ran 1 command, thought for 18s");
+    });
+
+    it("counts structured diff paths and every tool call (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
+      const { line } = summarizeActivity([
+        member("python", { toolKind: "execute" }),
+        member("edit", {
+          toolKind: "edit",
+          output: ["a.md", "b.md", "c.md", "d.md", "e.md"].map((path) => ({
+            type: "diff" as const,
+            path,
+            oldText: "before",
+            newText: "after",
+          })),
+        }),
+        member("validate", { toolKind: "execute" }),
+      ]);
+
+      expect(line).toBe("Ran 3 commands, edited 5 files");
+    });
+
+    it("de-duplicates structured paths across file tools (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
+      const { line } = summarizeActivity([
+        member("a", { toolKind: "edit", locations: [{ path: "same.md" }] }),
+        member("b", { toolKind: "edit", locations: [{ path: "same.md" }] }),
+      ]);
+
+      expect(line).toBe("Ran 2 commands, edited 1 file");
     });
 
     it("omits a reasoning duration under a second rather than saying '< 1s'", () => {

--- a/src/agentMode/ui/activityGroups.ts
+++ b/src/agentMode/ui/activityGroups.ts
@@ -91,16 +91,12 @@ export function foldActivityGroups(nodes: RenderNode[]): GroupedTrailNode[] {
 }
 
 /**
- * Bucket for the summary line. The vocabulary is deliberately coarse: reads and
- * edits are named because they are what users scan a turn for; everything else —
- * searches, fetches, skills, MCP calls, tools that do not exist yet — counts as
- * a command, so no new tool can ever change how the line reads. The identity
- * the line gives up is one click away in the expanded rows, and a lone call
- * never enters a group at all, so it keeps its precise row.
+ * File-specific work supplements the total command count. Every action remains
+ * a command, while reads and edits add the file totals users scan a turn for.
  */
-type ActivityFamily = "read" | "edit" | "command";
+type FileActivityFamily = "read" | "edit";
 
-function familyFor(part: ToolCallPart): ActivityFamily {
+function fileFamilyFor(part: ToolCallPart): FileActivityFamily | null {
   // An MCP tool whose bare name collides with a native one (e.g.
   // `mcp__srv__read`) must not masquerade as it; only the ACP `toolKind` —
   // a semantic classification, not a name — can vouch for an MCP call.
@@ -122,33 +118,46 @@ function familyFor(part: ToolCallPart): ActivityFamily {
     case "edit":
       return "edit";
     default:
-      return "command";
+      return null;
   }
 }
 
-/** Lowercase sentence fragment for one family's contribution to the line. */
-function phraseFor(family: ActivityFamily, n: number): string {
+/** Lowercase sentence fragment for one file family's contribution to the line. */
+function filePhraseFor(family: FileActivityFamily, n: number): string {
   switch (family) {
     case "read":
       return `read ${pluralize(n, "file")}`;
     case "edit":
       return `edited ${pluralize(n, "file")}`;
-    case "command":
-      return `ran ${pluralize(n, "command")}`;
   }
+}
+
+interface FileCount {
+  paths: Set<string>;
+  withoutPath: number;
+}
+
+function filePathsFor(part: ToolCallPart): Set<string> {
+  // Codex sends one edit tool with a diff record per file, while other
+  // backends may put the same paths in `locations`.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/336
+  const paths = new Set(part.locations?.map((location) => location.path) ?? []);
+  for (const output of part.output ?? []) {
+    if (output.type === "diff") paths.add(output.path);
+  }
+  return paths;
 }
 
 export interface ActivitySummaryOptions {
   /**
-   * Wall-clock the group spent reasoning. `kind: "thought"` parts carry no
-   * timestamps, so the duration cannot be derived here — the rendering layer
-   * measures it live and passes it in. Omitted or zero renders no duration.
+   * Elapsed time for the one reasoning block still in flight. Completed
+   * blocks carry their frozen durations in `members`.
    */
   thinkingMs?: number;
 }
 
 export interface ActivitySummary {
-  /** The collapsed row's line, e.g. `Read 2 files, ran 12 commands, thought for 51s`. */
+  /** The collapsed row's line, e.g. `Ran 12 commands, read 2 files, thought for 51s`. */
   line: string;
   /** Members that failed, surfaced by the card as a badge. */
   failed: number;
@@ -165,25 +174,43 @@ export function summarizeActivity(
   members: ActivityMember[],
   options: ActivitySummaryOptions = {}
 ): ActivitySummary {
-  const order: ActivityFamily[] = [];
-  const counts = new Map<ActivityFamily, number>();
+  const fileOrder: FileActivityFamily[] = [];
+  const fileCounts = new Map<FileActivityFamily, FileCount>();
+  let commands = 0;
   let thoughts = 0;
+  let completedThinkingMs = 0;
   let failed = 0;
 
   for (const member of members) {
     if (member.type === "reasoning") {
       thoughts++;
+      completedThinkingMs += member.part.durationMs ?? 0;
       continue;
     }
+    commands++;
     if (member.part.status === "failed") failed++;
-    const family = familyFor(member.part);
-    if (!counts.has(family)) order.push(family);
-    counts.set(family, (counts.get(family) ?? 0) + 1);
+    const family = fileFamilyFor(member.part);
+    if (!family) continue;
+    if (!fileCounts.has(family)) {
+      fileOrder.push(family);
+      fileCounts.set(family, { paths: new Set(), withoutPath: 0 });
+    }
+    const count = fileCounts.get(family)!;
+    const paths = filePathsFor(member.part);
+    // Some backends classify a file tool but omit structured paths. Count the
+    // call as one file instead of dropping it from the summary entirely.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/336
+    if (paths.size === 0) count.withoutPath++;
+    else for (const path of paths) count.paths.add(path);
   }
 
-  const parts = order.map((family) => phraseFor(family, counts.get(family) ?? 0));
+  const parts = commands > 0 ? [`ran ${pluralize(commands, "command")}`] : [];
+  for (const family of fileOrder) {
+    const count = fileCounts.get(family)!;
+    parts.push(filePhraseFor(family, count.paths.size + count.withoutPath));
+  }
 
-  const thinkingMs = options.thinkingMs ?? 0;
+  const thinkingMs = completedThinkingMs + (options.thinkingMs ?? 0);
   if (thoughts > 0) {
     if (thinkingMs >= 1000) parts.push(`thought for ${formatDuration(thinkingMs)}`);
     else if (parts.length === 0) parts.push("thought");

--- a/src/agentMode/ui/activityLiveStep.test.ts
+++ b/src/agentMode/ui/activityLiveStep.test.ts
@@ -19,6 +19,15 @@ describe("activityLiveStep", () => {
       expect(isReasoningActive([REASONING, action("a")], true)).toBe(false);
       expect(isReasoningActive([], true)).toBe(false);
     });
+
+    it("is false for a frozen trailing thought (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
+      const frozen: ActivityMember = {
+        type: "reasoning",
+        part: { kind: "thought", text: "done", durationMs: 18_000 },
+      };
+
+      expect(isReasoningActive([action("a"), frozen], true)).toBe(false);
+    });
   });
 
   describe("activityLiveStep()", () => {

--- a/src/agentMode/ui/activityLiveStep.ts
+++ b/src/agentMode/ui/activityLiveStep.ts
@@ -6,8 +6,9 @@ const REASONING_LABEL = "Reasoning";
 
 /**
  * Whether the group is reasoning right now. Like the trail's own check, a
- * `thought` counts as live only while it trails the run: anything after it
- * proves the agent moved on, and no backend emits a "reasoning ended" event.
+ * `thought` counts as live only while it trails the run and has no frozen
+ * duration: anything after it proves the agent moved on, and no backend emits
+ * a "reasoning ended" event.
  *
  * @param members - The group's members, in stream order.
  * @param atLiveEdge - Whether this group is the streaming trail's live edge —
@@ -16,7 +17,15 @@ const REASONING_LABEL = "Reasoning";
  *   "reasoning" until the entire turn finished.
  */
 export function isReasoningActive(members: ActivityMember[], atLiveEdge: boolean): boolean {
-  return atLiveEdge && members[members.length - 1]?.type === "reasoning";
+  const trailingMember = members[members.length - 1];
+  // A frozen thought can remain at the visible edge when a trailing internal
+  // tool is filtered out, but restarting its clock would double-count it.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/336
+  return (
+    atLiveEdge &&
+    trailingMember?.type === "reasoning" &&
+    trailingMember.part.durationMs === undefined
+  );
 }
 
 /**

--- a/src/agentMode/ui/useThinkingClock.test.tsx
+++ b/src/agentMode/ui/useThinkingClock.test.tsx
@@ -6,38 +6,14 @@ describe("useThinkingClock", () => {
     beforeEach(() => jest.useFakeTimers());
     afterEach(() => jest.useRealTimers());
 
-    it("measures the reasoning span and freezes it the moment reasoning stops", () => {
-      const { result, rerender } = renderHook(({ active }) => useThinkingClock(active), {
-        initialProps: { active: true },
-      });
+    it("uses the thought event timestamp instead of mount time (https://github.com/Brevilabs/obsidian-copilot-private/issues/336)", () => {
+      jest.setSystemTime(10_000);
+      const { result } = renderHook(() => useThinkingClock(true, 2_000));
 
-      expect(result.current).toBe(0);
+      expect(result.current).toBe(8_000);
 
       act(() => jest.advanceTimersByTime(4_000));
-      expect(result.current).toBe(4_000);
-
-      rerender({ active: false });
-      expect(result.current).toBe(4_000);
-
-      // The turn is over: no interval is left running and the value stands.
-      act(() => jest.advanceTimersByTime(60_000));
-      expect(result.current).toBe(4_000);
-    });
-
-    it("adds each further reasoning span to the time already banked", () => {
-      const { result, rerender } = renderHook(({ active }) => useThinkingClock(active), {
-        initialProps: { active: true },
-      });
-
-      act(() => jest.advanceTimersByTime(3_000));
-      rerender({ active: false });
-
-      // A tool call runs in between; that time is not thinking time.
-      act(() => jest.advanceTimersByTime(10_000));
-      rerender({ active: true });
-      act(() => jest.advanceTimersByTime(2_000));
-
-      expect(result.current).toBe(5_000);
+      expect(result.current).toBe(12_000);
     });
 
     it("keeps the measurement across re-renders that change nothing", () => {
@@ -52,11 +28,18 @@ describe("useThinkingClock", () => {
       expect(result.current).toBe(7_000);
     });
 
-    it("stays at zero for a group that never reasons", () => {
-      const { result } = renderHook(() => useThinkingClock(false));
+    it("returns zero once the active span ends because completed time lives on the thought", () => {
+      const { result, rerender } = renderHook(({ active }) => useThinkingClock(active, 1_000), {
+        initialProps: { active: true },
+      });
+
+      act(() => jest.advanceTimersByTime(3_000));
+      expect(result.current).toBeGreaterThanOrEqual(3_000);
+
+      rerender({ active: false });
+      expect(result.current).toBe(0);
 
       act(() => jest.advanceTimersByTime(30_000));
-
       expect(result.current).toBe(0);
     });
   });

--- a/src/agentMode/ui/useThinkingClock.ts
+++ b/src/agentMode/ui/useThinkingClock.ts
@@ -1,31 +1,17 @@
 import { useEffect, useRef, useState } from "react";
 
 /**
- * Measure the wall-clock a group spends reasoning, for `summarizeActivity`'s
- * `thought for Xs`. `kind: "thought"` parts carry no timestamps, so the
- * duration has to be observed live, the same way `ReasoningBlock` times its
- * own block. A group can reason several times between tool calls, so spans
- * accumulate rather than restart.
+ * Measure only the group's active reasoning span. Completed spans are frozen
+ * on their thought parts by the session store, so a batched React render
+ * cannot skip them.
  *
- * @param active - Whether the group is reasoning at this moment; the clock runs
- *   only while this is true and freezes at the value it reached when it drops.
- * @returns Milliseconds spent reasoning so far.
+ * @param active - Whether the group is reasoning at this moment.
+ * @param startedAtMs - Event time for the active thought's first chunk.
+ * @returns Milliseconds spent in the current reasoning span.
  */
-export function useThinkingClock(active: boolean): number {
-  const elapsedRef = useRef(0);
-  const startedAtRef = useRef<number | null>(null);
+export function useThinkingClock(active: boolean, startedAtMs?: number): number {
+  const fallbackStartedAtRef = useRef(Date.now());
   const [, setTick] = useState(0);
-
-  // Bank the span during render rather than in an effect, so the frame that
-  // first sees `active: false` already shows the final duration instead of one
-  // stale value. Mutating a ref during render is safe while the result stays
-  // deterministic for these inputs.
-  if (active && startedAtRef.current === null) {
-    startedAtRef.current = Date.now();
-  } else if (!active && startedAtRef.current !== null) {
-    elapsedRef.current += Date.now() - startedAtRef.current;
-    startedAtRef.current = null;
-  }
 
   useEffect(() => {
     if (!active) return;
@@ -33,6 +19,6 @@ export function useThinkingClock(active: boolean): number {
     return () => window.clearInterval(id);
   }, [active]);
 
-  const startedAt = startedAtRef.current;
-  return startedAt === null ? elapsedRef.current : elapsedRef.current + (Date.now() - startedAt);
+  if (!active) return 0;
+  return Math.max(0, Date.now() - (startedAtMs ?? fallbackStartedAtRef.current));
 }


### PR DESCRIPTION
Fixes Brevilabs/obsidian-copilot-private#336

## Why

A Codex activity group expanded to three tool calls, five edited files, and several reasoning rows, but its parent counted only two commands and one edited file while completed thought rows reset to `< 1s` after remounting.

## What

> **Before:** The parent counted tool-call objects by category, treated a multi-file edit as one file, and timed reasoning from React mounts.
>
> **After:** The parent counts every grouped tool call, de-duplicates structured file paths, and sums the same event-timed reasoning spans shown by its children.

## Non goal

This PR does not change which trail steps form a group, how tools execute, or the wording of expanded tool rows.

## Screenshot

**Before**

![Before: the parent reports two commands and one edited file while the expanded edit reports five files](https://github.com/user-attachments/assets/b2ad0981-8e16-488c-871b-b31107eec35f)

**After: grouped summary**

![After: the parent reports three commands, five edited files, and eighteen seconds of reasoning](https://github.com/user-attachments/assets/21ebee38-2f46-4b93-a7f4-1c4f61960dd3)

**After: completed reasoning row**

![After: a completed reasoning row preserves its eighteen-second event duration](https://github.com/user-attachments/assets/03711e2e-eeab-4a5a-b63c-12582fce5862)

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Message-store, summary, clock, reasoning-row, and trail tests cover the changed counts and timing |
| A defect would fail CI or be obvious on first use | ✅ | Exact summary strings and completed durations are deterministic assertions |
| A revert fully restores prior state, including persisted data | ✅ | Timing metadata is in memory only and saved chat Markdown does not persist structured parts |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | The change reads existing normalized tool outputs and session events |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Optional timing fields stay inside Agent Mode's internal display model |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Existing synchronous message-store events only stamp elapsed time |
| No hot-path behavior lacks deterministic coverage | ✅ | Multi-file diffs, duplicate paths, missing paths, remounts, and legacy untimed thoughts are covered |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | The changed copy appears on the next grouped Agent trail card |

Review: run Verification steps 2 and 3, then confirm CI is green.

## Verification

1. Deploy the branch to `copilot-test-vault` with `npm run test:vault` and open the Component gallery.
2. Open `Agent Mode / Activity Group Card / MultiFileEdit` at 300px and 600px; confirm it reads `Ran 3 commands, edited 5 files, thought for 18s`.
3. Open `Agent Mode / Reasoning Block / Complete`; confirm the completed row reads `Thought for 18s` after switching away and back.
