### PR TITLE
Preserve Agent usage before and after cancellation

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -96,7 +96,7 @@ Agent Chat keeps each conversation separate:
 - Select **New Chat** to reset the current tab.
 - Use **Recent Chats** from the Agent Chat home screen, or **Chat History** inside a conversation, to resume saved work. The **Recent Chats** list can be scrolled or searched.
 - Add the active note, selected text, other notes, folders, a Copilot Web Viewer tab, or supported images. You can also mention a note with `[[Note title]]`.
-- Hover the context ring beside the send controls to see how much of the model's context window is in use. If the connected account reports usage limits, the same panel shows the available limit and reset time.
+- Hover the context ring beside the send controls to see how much of the model's context window is in use. The ring stays empty until the agent reports usage, and a stopped response keeps the last reported reading. If the connected account reports usage limits, the same panel shows the available limit and reset time.
 
 Attachments apply to the next message. For instructions and context that should be reused, create a [Project](projects.md) or add rules to [`AGENTS.md`](system-prompts.md). See [Context and Mentions](context-and-mentions.md) for every context option.
 

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -480,6 +480,48 @@ describe("AgentSession session usage", () => {
     expect(session.getSessionUsage()?.usedTokens).toBe(42);
   });
 
+  it("keeps the last positive usage when a stopped turn reports zero (https://github.com/logancyang/obsidian-copilot/issues/2975)", async () => {
+    const mock = makeMockBackend();
+    let resolvePrompt!: (value: { stopReason: "cancelled" }) => void;
+    mock.prompt.mockImplementation(() => new Promise((resolve) => (resolvePrompt = resolve)));
+    const session = makeSession(mock);
+    mock.emit({
+      sessionId: "acp-1",
+      update: {
+        sessionUpdate: "usage_update",
+        usage: { usedTokens: 5000, contextWindow: 200_000, updatedAt: 1 },
+      },
+    });
+    const { turn } = session.sendPrompt("stop this turn");
+    await session.cancel();
+
+    mock.emit({
+      sessionId: "acp-1",
+      update: {
+        sessionUpdate: "usage_update",
+        usage: { usedTokens: 0, contextWindow: 200_000, updatedAt: 2 },
+      },
+    });
+
+    expect(session.getSessionUsage()).toEqual({
+      usedTokens: 5000,
+      contextWindow: 200_000,
+      updatedAt: 1,
+    });
+
+    resolvePrompt({ stopReason: "cancelled" });
+    await expect(turn).resolves.toBe("cancelled");
+
+    mock.emit({
+      sessionId: "acp-1",
+      update: {
+        sessionUpdate: "usage_update",
+        usage: { usedTokens: 6000, contextWindow: 200_000, updatedAt: 3 },
+      },
+    });
+    expect(session.getSessionUsage()?.usedTokens).toBe(6000);
+  });
+
   it("ignores a used-only fallback once an occupancy snapshot exists", () => {
     const mock = makeMockBackend();
     const session = makeSession(mock);

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -1533,6 +1533,10 @@ export class AgentSession {
    * render a bogus percentage ring. A later live occupancy update supersedes it.
    */
   private applyUsageUpdate(usage: SessionUsage): void {
+    // Some backends use zero as an empty terminal snapshot after cancellation.
+    // It does not measure consumed context, so wait for a positive reading.
+    // https://github.com/logancyang/obsidian-copilot/issues/2975
+    if (!usage.usedTokens) return;
     if (usage.contextWindow === undefined && this.currentUsage?.contextWindow !== undefined) {
       return;
     }

--- a/src/agentMode/ui/AgentContextMeter.stories.tsx
+++ b/src/agentMode/ui/AgentContextMeter.stories.tsx
@@ -29,6 +29,18 @@ const CONTEXT: UsageMeterProps["usage"] = {
   updatedAt: NOW,
 };
 
+/** Plan limits are ready, but this new session has not reported context usage yet. */
+export const AwaitingSessionUsage: StoryObj<UsageMeterProps> = {
+  args: {
+    usage: null,
+    contextWindow: null,
+    planUsage: {
+      windows: [{ id: "weekly", label: "Weekly", percent: 15, resetsAt: NOW + 80 * HOUR }],
+      updatedAt: NOW,
+    },
+  },
+};
+
 /** Both windows, mid-usage: the everyday Claude Code and Copilot Plus state. */
 export const ContextAndCaps: StoryObj<UsageMeterProps> = {
   args: {

--- a/src/agentMode/ui/AgentContextMeter.stories.tsx
+++ b/src/agentMode/ui/AgentContextMeter.stories.tsx
@@ -1,6 +1,7 @@
 import { UsageMeter, type UsageMeterProps } from "@/agentMode/ui/AgentContextMeter";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { Meta, StoryObj } from "@/lib/story";
+import React from "react";
 
 function UsageMeterStory(props: UsageMeterProps) {
   return (

--- a/src/agentMode/ui/AgentContextMeter.stories.tsx
+++ b/src/agentMode/ui/AgentContextMeter.stories.tsx
@@ -1,5 +1,14 @@
 import { UsageMeter, type UsageMeterProps } from "@/agentMode/ui/AgentContextMeter";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import type { Meta, StoryObj } from "@/lib/story";
+
+function UsageMeterStory(props: UsageMeterProps) {
+  return (
+    <TooltipProvider>
+      <UsageMeter {...props} />
+    </TooltipProvider>
+  );
+}
 
 /**
  * The meter has two independent inputs — context occupancy and account plan caps — and a
@@ -9,7 +18,7 @@ import type { Meta, StoryObj } from "@/lib/story";
  */
 const meta = {
   title: "Agent Mode/UsageMeter",
-  component: UsageMeter,
+  component: UsageMeterStory,
 } satisfies Meta<UsageMeterProps>;
 export default meta;
 

--- a/src/agentMode/ui/AgentContextMeter.test.tsx
+++ b/src/agentMode/ui/AgentContextMeter.test.tsx
@@ -121,6 +121,18 @@ describe("AgentContextMeter", () => {
     expect(screen.queryByLabelText("Context usage")).toBeNull();
   });
 
+  it("shows an empty ring instead of 0 while plan usage is available before session usage", () => {
+    const planUsage: PlanUsage = {
+      windows: [{ id: "weekly", label: "Weekly", percent: 15 }],
+      updatedAt: 1,
+    };
+    renderMeter(makeBackend(null, planUsage));
+
+    const trigger = screen.getByLabelText("Usage");
+    expect(trigger.querySelector("svg")).not.toBeNull();
+    expect(trigger.textContent).not.toContain("0");
+  });
+
   it("shows each plan cap window, its percentage and its reset, under the context bar", () => {
     const usage: SessionUsage = { usedTokens: 50_000, contextWindow: 200_000, updatedAt: 1 };
     const planUsage: PlanUsage = {

--- a/src/agentMode/ui/AgentContextMeter.tsx
+++ b/src/agentMode/ui/AgentContextMeter.tsx
@@ -147,10 +147,12 @@ export interface UsageMeterProps {
 export function UsageMeter({ usage, contextWindow, planUsage }: UsageMeterProps) {
   // Guard a non-finite `usedTokens` (e.g. NaN from a malformed upstream value)
   // so it can't propagate into the rendered percent or the SVG dashoffset.
-  const used = usage && Number.isFinite(usage.usedTokens) ? usage.usedTokens : 0;
-  const fraction = contextWindow ? Math.min(1, Math.max(0, used / contextWindow)) : 0;
+  const hasUsage = !!usage;
+  const hasContext = contextWindow !== null;
+  const used = hasUsage && Number.isFinite(usage.usedTokens) ? usage.usedTokens : 0;
+  const fraction = hasContext ? Math.min(1, Math.max(0, used / contextWindow)) : 0;
   const percent = Math.round(fraction * 100);
-  const isWarning = contextWindow !== null && fraction >= WARNING_THRESHOLD;
+  const isWarning = hasContext && fraction >= WARNING_THRESHOLD;
 
   // Radix Tooltip handles hover/focus open/close and hoverable content natively,
   // so no manual open state or close timer is needed.
@@ -163,12 +165,12 @@ export function UsageMeter({ usage, contextWindow, planUsage }: UsageMeterProps)
           className={cn(isWarning ? "tw-text-warning" : "tw-text-accent")}
           aria-label="Usage"
         >
-          {contextWindow !== null ? <ContextRing fraction={fraction} /> : formatTokens(used)}
+          {!hasUsage || hasContext ? <ContextRing fraction={fraction} /> : formatTokens(used)}
         </Button>
       </TooltipTrigger>
       <TooltipContent align="end" side="top" className="tw-w-80">
         <div className="tw-flex tw-flex-col tw-gap-2">
-          {usage && (
+          {hasUsage && (
             <>
               <div className="tw-flex tw-items-center tw-justify-between tw-gap-3 tw-text-ui-smaller">
                 <span className="tw-whitespace-nowrap tw-text-muted">Context window</span>
@@ -178,12 +180,12 @@ export function UsageMeter({ usage, contextWindow, planUsage }: UsageMeterProps)
                     isWarning && "tw-text-warning"
                   )}
                 >
-                  {contextWindow !== null
+                  {hasContext
                     ? `${formatTokens(used)} / ${formatTokens(contextWindow)} (${percent}%)`
                     : formatTokens(used)}
                 </span>
               </div>
-              {contextWindow !== null && <Progress value={percent} className="tw-h-1.5" />}
+              {hasContext && <Progress value={percent} className="tw-h-1.5" />}
             </>
           )}
           {planUsage && <PlanUsageRows planUsage={planUsage} />}


### PR DESCRIPTION
Fixes #2975

## Why

Agent Chat currently shows `0` before a new session reports usage, and stopping a later turn can replace the last reliable reading with another zero.

## What

> **Before:** A new session shows `0`, and a cancellation-time zero hides the last reported usage.
>
> **After:** A new session shows an empty context ring, and cancellation retains the last positive reading until the next valid update.

## Non goal

- No estimates for tokens the backend did not report for a cancelled response.
- No changes to plan-limit displays or context-window sizing.
- No persistence of partial generated content for token accounting.

## Screenshot

Rendered in Obsidian's component gallery at 300px with the plan-limit tooltip open:

![An empty Agent usage ring before the session reports usage](https://github.com/user-attachments/assets/1ef54d70-a93a-42bb-ac0a-dfa41c1b2df1)

| State | Before | After |
| --- | --- | --- |
| New session before usage arrives | `0` | Empty context ring |
| Stopped turn emits a zero snapshot | Usage resets to `0` | Last positive reading remains |
| Next positive snapshot arrives | Meter updates | Meter updates |

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Component and session tests cover the empty ring, cancellation-time zero, and next positive update |
| A defect would fail CI or be obvious on first use | ✅ | The focused tests exercise both changed states |
| A revert fully restores prior state, including persisted data | ✅ | No migration or irreversible write |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Usage display state only |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Existing internal usage snapshots keep the same shape |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Snapshot precedence changes without altering cancellation control flow |
| No hot-path behavior lacks deterministic coverage | ✅ | Every changed production branch has a focused regression test |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | The meter state appears beside the Agent Chat send controls |

Review: run Verification steps 1-3 and confirm the initial, stopped-turn, and next-update states.

## Verification

1. Build and load this branch in a dedicated test vault, open Agent Chat, and start a new session with plan limits available; confirm the usage control is an empty circle rather than `0`.
2. Send a prompt until the meter has a positive reading, start another turn, and press Stop; confirm the prior reading remains visible.
3. Send another prompt that reports usage; confirm the meter advances to the new reading.
