### PR TITLE
[Relevant Notes on Miyo] - Step 1: Open a specific settings tab

### DIFF
--- a/src/contexts/TabContext.test.tsx
+++ b/src/contexts/TabContext.test.tsx
@@ -1,0 +1,50 @@
+import { TabProvider, useTab } from "@/contexts/TabContext";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+const TabProbe: React.FC = () => {
+  const { selectedTab, setSelectedTab } = useTab();
+  return (
+    <button type="button" onClick={() => setSelectedTab("skills")}>
+      {selectedTab}
+    </button>
+  );
+};
+
+describe("TabContext", () => {
+  describe("TabProvider()", () => {
+    it("selects Basic for an ordinary settings render", () => {
+      render(
+        <TabProvider>
+          <TabProbe />
+        </TabProvider>
+      );
+
+      expect(screen.getByText("basic")).toBeTruthy();
+    });
+
+    it("selects the requested initial tab for a direct handoff (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
+      render(
+        <TabProvider initialTab="advanced">
+          <TabProbe />
+        </TabProvider>
+      );
+
+      expect(screen.getByText("advanced")).toBeTruthy();
+    });
+  });
+
+  describe("useTab()", () => {
+    it("exposes the current tab and its selector", () => {
+      render(
+        <TabProvider>
+          <TabProbe />
+        </TabProvider>
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "basic" }));
+
+      expect(screen.getByRole("button", { name: "skills" })).toBeTruthy();
+    });
+  });
+});

--- a/src/contexts/TabContext.tsx
+++ b/src/contexts/TabContext.tsx
@@ -1,14 +1,20 @@
+import type { CopilotSettingsTabId } from "@/settings/settingsTabs";
 import React, { createContext, useContext, useMemo, useState } from "react";
 
 interface TabContextType {
-  selectedTab: string;
-  setSelectedTab: (tab: string) => void;
+  selectedTab: CopilotSettingsTabId;
+  setSelectedTab: (tab: CopilotSettingsTabId) => void;
 }
 
 const TabContext = createContext<TabContextType | undefined>(undefined);
 
-export const TabProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [selectedTab, setSelectedTab] = useState("basic");
+interface TabProviderProps {
+  children: React.ReactNode;
+  initialTab?: CopilotSettingsTabId;
+}
+
+export const TabProvider: React.FC<TabProviderProps> = ({ children, initialTab = "basic" }) => {
+  const [selectedTab, setSelectedTab] = useState<CopilotSettingsTabId>(initialTab);
 
   const value = useMemo(() => ({ selectedTab, setSelectedTab }), [selectedTab]);
 

--- a/src/settings/SettingsPage.tsx
+++ b/src/settings/SettingsPage.tsx
@@ -1,4 +1,5 @@
 import CopilotPlugin from "@/main";
+import { consumeRequestedCopilotSettingsTab } from "@/settings/openSettings";
 import { App, PluginSettingTab } from "obsidian";
 import React from "react";
 import SettingsMainV2 from "@/settings/v2/SettingsMainV2";
@@ -19,6 +20,8 @@ export class CopilotSettingTab extends PluginSettingTab {
     const div = containerEl.createDiv("div");
     const sections = createPluginRoot(div, this.app);
 
-    sections.render(<SettingsMainV2 plugin={this.plugin} />);
+    sections.render(
+      <SettingsMainV2 plugin={this.plugin} initialTab={consumeRequestedCopilotSettingsTab()} />
+    );
   }
 }

--- a/src/settings/openSettings.test.ts
+++ b/src/settings/openSettings.test.ts
@@ -1,0 +1,76 @@
+import { consumeRequestedCopilotSettingsTab, openCopilotSettings } from "@/settings/openSettings";
+import { COPILOT_SETTINGS_TAB_IDS } from "@/settings/settingsTabs";
+import type { App } from "obsidian";
+
+describe("openSettings", () => {
+  afterEach(() => {
+    consumeRequestedCopilotSettingsTab();
+    jest.restoreAllMocks();
+  });
+
+  describe("openCopilotSettings()", () => {
+    it("uses the first Copilot display without rendering the tab twice (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
+      const consumedTabs: string[] = [];
+      const openTabById = jest.fn(() => consumedTabs.push(consumeRequestedCopilotSettingsTab()));
+      const open = jest.fn(() => consumedTabs.push(consumeRequestedCopilotSettingsTab()));
+      let deferredHandoff: FrameRequestCallback | undefined;
+      const ownerWindow = {
+        requestAnimationFrame: jest.fn((callback: FrameRequestCallback) => {
+          deferredHandoff = callback;
+          return 1;
+        }),
+      } as unknown as Window;
+      const app = { setting: { open, openTabById } } as unknown as App;
+
+      openCopilotSettings(app, ownerWindow, "advanced");
+
+      expect(open).toHaveBeenCalledTimes(1);
+      expect(consumedTabs).toEqual(["advanced"]);
+
+      deferredHandoff?.(0);
+
+      expect(openTabById).not.toHaveBeenCalled();
+    });
+
+    it("hands off after another settings tab opens and schedules from the initiating window (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
+      const consumedTabs: string[] = [];
+      const openTabById = jest.fn(() => consumedTabs.push(consumeRequestedCopilotSettingsTab()));
+      const open = jest.fn();
+      let deferredHandoff: FrameRequestCallback | undefined;
+      const ownerWindow = {
+        requestAnimationFrame: jest.fn((callback: FrameRequestCallback) => {
+          deferredHandoff = callback;
+          return 1;
+        }),
+      } as unknown as Window;
+      const app = { setting: { open, openTabById } } as unknown as App;
+
+      openCopilotSettings(app, ownerWindow, "miyo");
+
+      expect(open).toHaveBeenCalledTimes(1);
+      expect(openTabById).not.toHaveBeenCalled();
+
+      deferredHandoff?.(0);
+
+      expect(openTabById).toHaveBeenCalledWith("copilot");
+      expect(consumedTabs).toEqual(["miyo"]);
+    });
+  });
+
+  describe("consumeRequestedCopilotSettingsTab()", () => {
+    it.each(COPILOT_SETTINGS_TAB_IDS)(
+      "consumes a requested %s tab once and defaults later ordinary opens to Basic (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)",
+      (tab) => {
+        const ownerWindow = { requestAnimationFrame: jest.fn() } as unknown as Window;
+        const app = {
+          setting: { open: jest.fn(), openTabById: jest.fn() },
+        } as unknown as App;
+
+        openCopilotSettings(app, ownerWindow, tab);
+
+        expect(consumeRequestedCopilotSettingsTab()).toBe(tab);
+        expect(consumeRequestedCopilotSettingsTab()).toBe("basic");
+      }
+    );
+  });
+});

--- a/src/settings/openSettings.ts
+++ b/src/settings/openSettings.ts
@@ -1,0 +1,43 @@
+import type { CopilotSettingsTabId } from "@/settings/settingsTabs";
+import type { App } from "obsidian";
+
+let requestedCopilotSettingsTab: CopilotSettingsTabId | null = null;
+
+interface ObsidianSettingsController {
+  open: () => void;
+  openTabById: (id: string) => void;
+}
+
+/**
+ * Open Copilot settings directly on a requested internal tab.
+ *
+ * @param app - The Obsidian app whose settings modal should open.
+ * @param ownerWindow - The window containing the control that initiated the handoff.
+ * @param tab - The Copilot settings tab to select on the next display.
+ */
+export function openCopilotSettings(
+  app: App,
+  ownerWindow: Window,
+  tab: CopilotSettingsTabId
+): void {
+  const settings = (app as unknown as { setting: ObsidianSettingsController }).setting;
+  requestedCopilotSettingsTab = tab;
+  settings.open();
+  // Opening settings consumes the request immediately when Copilot is already
+  // selected. Otherwise hand off after the modal opens so Copilot renders only
+  // once and no detached React tree is left behind.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+  ownerWindow.requestAnimationFrame(() => {
+    if (requestedCopilotSettingsTab !== null) settings.openTabById("copilot");
+  });
+}
+
+/** Consume the next requested Copilot tab, defaulting ordinary settings opens to Basic. */
+export function consumeRequestedCopilotSettingsTab(): CopilotSettingsTabId {
+  // A one-shot handoff must not change where later ordinary Copilot settings
+  // opens land.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+  const requestedTab = requestedCopilotSettingsTab ?? "basic";
+  requestedCopilotSettingsTab = null;
+  return requestedTab;
+}

--- a/src/settings/settingsTabs.ts
+++ b/src/settings/settingsTabs.ts
@@ -1,0 +1,11 @@
+export const COPILOT_SETTINGS_TAB_IDS = [
+  "basic",
+  "byok",
+  "miyo",
+  "skills",
+  "command",
+  "selfhost",
+  "advanced",
+] as const;
+
+export type CopilotSettingsTabId = (typeof COPILOT_SETTINGS_TAB_IDS)[number];

--- a/src/settings/v2/SettingsMainV2.test.tsx
+++ b/src/settings/v2/SettingsMainV2.test.tsx
@@ -13,7 +13,9 @@ import React from "react";
 // Every tab body is stubbed empty. The real panels reach for the keychain, Node,
 // and the network, none of which has any bearing on the strip above them.
 jest.mock("@/settings/v2/components/BasicSettings", () => ({ BasicSettings: () => null }));
-jest.mock("@/settings/v2/components/MiyoSettings", () => ({ MiyoSettings: () => null }));
+jest.mock("@/settings/v2/components/MiyoSettings", () => ({
+  MiyoSettings: () => <div>Miyo settings content</div>,
+}));
 jest.mock("@/settings/v2/components/SelfHostSettings", () => ({ SelfHostSettings: () => null }));
 jest.mock("@/settings/v2/components/CommandSettings", () => ({ CommandSettings: () => null }));
 jest.mock("@/settings/v2/components/AdvancedSettings", () => ({ AdvancedSettings: () => null }));
@@ -88,6 +90,13 @@ describe("SettingsMainV2", () => {
       render(<SettingsMainV2 plugin={plugin} />);
 
       await waitFor(() => expect(mockSkillManagerRefresh).toHaveBeenCalledTimes(1));
+    });
+
+    it("opens on a requested tab (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
+      render(<SettingsMainV2 plugin={plugin} initialTab="miyo" />);
+
+      expect(screen.getByRole("tab", { name: "Miyo" }).getAttribute("aria-selected")).toBe("true");
+      expect(screen.getByText("Miyo settings content")).toBeTruthy();
     });
   });
 });

--- a/src/settings/v2/SettingsMainV2.tsx
+++ b/src/settings/v2/SettingsMainV2.tsx
@@ -7,6 +7,7 @@ import { useLatestVersion } from "@/hooks/useLatestVersion";
 import CopilotPlugin from "@/main";
 import { ByokPanel, ModelManagementProvider } from "@/modelManagement";
 import { resetSettings } from "@/settings/model";
+import { COPILOT_SETTINGS_TAB_IDS, type CopilotSettingsTabId } from "@/settings/settingsTabs";
 import { useSkillLoadErrorCount } from "@/settings/skillLoadErrorState";
 import { CommandSettings } from "@/settings/v2/components/CommandSettings";
 import { Cog, Command, Cpu, ShieldCheck, Sigma, Sparkle, Wrench } from "lucide-react";
@@ -37,9 +38,6 @@ import { SelfHostSettings } from "./components/SelfHostSettings";
 // The relabeled "Keyword (built-in) vs Miyo (semantic search)" engine toggle
 // and honest embedding-caveat copy land in a follow-up PR, not here. If a review
 // flags the missing QA/search UI again, point them at this note.
-const TAB_IDS = ["basic", "byok", "miyo", "skills", "command", "selfhost", "advanced"] as const;
-type TabId = (typeof TAB_IDS)[number];
-
 const LazySkillsSettings = React.lazy(() =>
   import("@/agentMode").then((module) => ({ default: module.SkillsSettings }))
 );
@@ -59,7 +57,7 @@ const SkillsSettingsPanel: React.FC = () => {
 };
 
 // tab icons
-const icons: Record<TabId, JSX.Element> = {
+const icons: Record<CopilotSettingsTabId, JSX.Element> = {
   basic: <Cog className="tw-size-5" />,
   byok: <Cpu className="tw-size-5" />,
   miyo: <Sigma className="tw-size-5" />,
@@ -70,7 +68,7 @@ const icons: Record<TabId, JSX.Element> = {
 };
 
 // tab components
-const components: Record<TabId, React.FC> = {
+const components: Record<CopilotSettingsTabId, React.FC> = {
   basic: () => <BasicSettings />,
   byok: () => <ByokPanel />,
   miyo: () => <MiyoSettings />,
@@ -82,7 +80,7 @@ const components: Record<TabId, React.FC> = {
 
 // Tab labels — most tabs derive from the id, but a few need a display form the
 // id can't produce ("byok" → "BYOK", "selfhost" → "Self-Host").
-const TAB_LABELS: Record<TabId, string> = {
+const TAB_LABELS: Record<CopilotSettingsTabId, string> = {
   basic: "Basic",
   byok: "BYOK",
   miyo: "Miyo",
@@ -93,11 +91,11 @@ const TAB_LABELS: Record<TabId, string> = {
 };
 
 // tabs
-const tabs: TabItemType[] = TAB_IDS.map((id) => ({
+const tabs = COPILOT_SETTINGS_TAB_IDS.map((id) => ({
   id,
   icon: icons[id],
   label: TAB_LABELS[id],
-}));
+})) satisfies TabItemType[];
 
 const SettingsContent: React.FC = () => {
   const { selectedTab, setSelectedTab } = useTab();
@@ -129,7 +127,7 @@ const SettingsContent: React.FC = () => {
       <div className="tw-w-full tw-border tw-border-solid" />
 
       <div>
-        {TAB_IDS.map((id) => {
+        {COPILOT_SETTINGS_TAB_IDS.map((id) => {
           const Component = components[id];
           return (
             <TabContent key={id} id={id} isSelected={selectedTab === id}>
@@ -144,9 +142,10 @@ const SettingsContent: React.FC = () => {
 
 interface SettingsMainV2Props {
   plugin: CopilotPlugin;
+  initialTab?: CopilotSettingsTabId;
 }
 
-const SettingsMainV2: React.FC<SettingsMainV2Props> = ({ plugin }) => {
+const SettingsMainV2: React.FC<SettingsMainV2Props> = ({ plugin, initialTab = "basic" }) => {
   // Add a key state that we'll change when resetting
   const [resetKey, setResetKey] = React.useState(0);
   const { latestVersion, hasUpdate } = useLatestVersion(plugin.manifest.version);
@@ -171,7 +170,7 @@ const SettingsMainV2: React.FC<SettingsMainV2Props> = ({ plugin }) => {
   return (
     <PluginProvider plugin={plugin}>
       <ModelManagementProvider api={plugin.modelManagement}>
-        <TabProvider>
+        <TabProvider initialTab={initialTab}>
           {/* Obsidian 1.13 made the settings window resizable, and the panel has
               no width of its own — without a cap the rows stretch to whatever
               the user dragged the window to and every control drifts far from


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#280

## Why

Copilot can open its settings page from elsewhere in the plugin, but it always starts on **Basic**. A feature that needs a user to review a specific setting must either leave navigation instructions or build a one-off handoff for that tab.

This change gives every existing Copilot settings tab the same direct-entry contract before any feature starts using it.

## What

| Situation | Result |
| --- | --- |
| A caller requests a Copilot settings tab | Obsidian opens Copilot settings with that tab selected |
| Copilot settings is already selected | The requested tab appears on the first render without rendering the settings tree twice |
| Another settings page is selected | The handoff waits for the modal to open, then selects Copilot once |
| The user later opens Copilot settings normally | Settings starts on **Basic** |

Only valid, currently registered Copilot tab IDs can be requested.

## Non goal

- Adding a product entry point that uses the handoff; later feature PRs own their call sites.
- Changing the contents, order, labels, or availability of settings tabs.
- Changing Relevant Notes, Miyo, or local index behavior.

## Screenshot

Not applicable. This changes which existing settings tab opens, not the appearance of any tab.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Tests cover every valid destination plus both settings-modal handoff paths |
| A defect would fail CI or be obvious on first use | ✅ | The destination and one-shot behavior are asserted before a caller can adopt the API |
| A revert fully restores prior state, including persisted data | ✅ | The handoff stores no user data |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | The change only selects an internal settings tab |
| No public API, plugin API, message, or on-disk contract changes | ✅ | The helper is internal to the plugin bundle |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | The one-frame handoff is confined to opening the optional settings modal |
| No hot-path behavior lacks deterministic coverage | ✅ | Ordinary opens, already-selected opens, deferred opens, and all destinations are covered |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | A wrong destination is visible as soon as settings opens |

Review: inspect the one-shot handoff in `openCopilotSettings()` in `src/settings/openSettings.ts` and the initial-tab flow through `TabProvider` in `src/contexts/TabContext.tsx`, then run Verification.

## Verification

1. Run `npm test -- --runInBand src/settings/openSettings.test.ts src/settings/v2/SettingsMainV2.test.tsx src/contexts/TabContext.test.tsx`.
2. Confirm the suite covers both an already-selected Copilot page and a handoff from another settings page.
3. Confirm each registered destination is accepted once and the next ordinary open returns to **Basic**.
