### PR TITLE
[Relevant Notes on Miyo] - Step 2: Preserve hidden property filters

### DIFF
--- a/src/settings/v2/components/PatternListEditor.test.tsx
+++ b/src/settings/v2/components/PatternListEditor.test.tsx
@@ -1,0 +1,63 @@
+/* eslint-disable @eslint-react/hooks-extra/no-unnecessary-use-prefix -- Mock exports must preserve production hook names. */
+import { PatternListEditor } from "@/settings/v2/components/PatternListEditor";
+import { createPatternSettingsValue, getDecodedPatterns } from "@/search/searchUtils";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+jest.mock("@/context", () => ({ useApp: () => ({}) }));
+
+jest.mock("@/components/modals/CustomPatternInputModal", () => ({
+  CustomPatternInputModal: jest
+    .fn()
+    .mockImplementation((_app: unknown, onSubmit: (value: string) => void) => ({
+      open: () => onSubmit("Archive"),
+    })),
+}));
+
+beforeAll(() => {
+  (window as unknown as { activeDocument: Document }).activeDocument = window.document;
+  if (!("PointerEvent" in window)) {
+    (window as unknown as { PointerEvent: typeof MouseEvent }).PointerEvent = MouseEvent;
+  }
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.releasePointerCapture = () => {};
+  Element.prototype.scrollIntoView = () => {};
+});
+
+describe("PatternListEditor", () => {
+  describe("PatternListEditor()", () => {
+    it("preserves a hidden property rule when removing a visible rule (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
+      const onChange = jest.fn();
+      const value = createPatternSettingsValue({
+        tagPatterns: ["#old"],
+        propertyPatterns: ["[status:done]"],
+      });
+      render(<PatternListEditor value={value} onChange={onChange} />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Remove #old" }));
+
+      expect(getDecodedPatterns(onChange.mock.calls[0][0] as string)).toEqual(["[status:done]"]);
+    });
+
+    it("preserves a hidden property rule when adding a custom rule (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
+      const onChange = jest.fn();
+      const value = createPatternSettingsValue({
+        tagPatterns: ["#old"],
+        propertyPatterns: ["[status:done]"],
+      });
+      render(<PatternListEditor value={value} onChange={onChange} />);
+
+      fireEvent.pointerDown(screen.getByRole("button", { name: "Add..." }), {
+        button: 0,
+        ctrlKey: false,
+      });
+      fireEvent.click(screen.getByText("Custom"));
+
+      expect(getDecodedPatterns(onChange.mock.calls[0][0] as string)).toEqual([
+        "#old",
+        "[status:done]",
+        "Archive",
+      ]);
+    });
+  });
+});

--- a/src/settings/v2/components/PatternListEditor.tsx
+++ b/src/settings/v2/components/PatternListEditor.tsx
@@ -69,17 +69,11 @@ export const PatternListEditor: React.FC<PatternListEditorProps> = ({
   // Parse and deduplicate patterns
   const patterns = useMemo(() => getUniquePatterns(value), [value]);
 
-  // DESIGN NOTE — this editor owns four of the five categories `categorizePatterns`
-  // returns. The fifth, `propertyPatterns`, belongs to project context; here it has
-  // no badge, and the rebuilds in `updatePatterns` and `handleAddCustom` name their
-  // keys explicitly, so a property pattern typed in or synced from elsewhere is
-  // dropped on the next edit. The matcher itself honours stored property patterns,
-  // which is why nothing in this UI may offer `[key:value]` until the editor can
-  // show and remove them. If a future review flags this again, point them at this note.
-  const { tagPatterns, extensionPatterns, folderPatterns, notePatterns } = useMemo(
-    () => categorizePatterns(patterns),
-    [patterns]
-  );
+  // This editor shows four of the five categories returned by `categorizePatterns`.
+  // Property patterns are created on other surfaces, so visible edits must round-trip
+  // them unchanged until this editor can also show and remove them.
+  const { tagPatterns, extensionPatterns, folderPatterns, notePatterns, propertyPatterns } =
+    useMemo(() => categorizePatterns(patterns), [patterns]);
 
   // Use ResizeObserver to detect overflow (responds to container size changes)
   useLayoutEffect(() => {
@@ -121,6 +115,11 @@ export const PatternListEditor: React.FC<PatternListEditorProps> = ({
       extensionPatterns: newCategories.extensionPatterns ?? extensionPatterns,
       folderPatterns: newCategories.folderPatterns ?? folderPatterns,
       notePatterns: newCategories.notePatterns ?? notePatterns,
+      // Property rules are valid persisted filters even though this editor does
+      // not render them. Editing a visible rule must not widen scope by deleting
+      // a hidden rule.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+      propertyPatterns,
     });
     onChange(newValue);
   };
@@ -219,6 +218,7 @@ export const PatternListEditor: React.FC<PatternListEditorProps> = ({
           ...fresh.notePatterns,
           ...newNotePatterns.filter((p) => !fresh.notePatterns.includes(p)),
         ],
+        propertyPatterns: fresh.propertyPatterns,
       });
       onChange(newValue);
     }).open();


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#280

## Why

`PatternListEditor` displays folders, tags, notes, and extensions, but the same stored value can also contain property filters created by another surface. Editing any visible badge currently rebuilds the value from only the four displayed categories and silently deletes those hidden property filters.

The component has no active settings caller on `master`, but the later Index-scope change reuses it. Its data-integrity rule should land and be reviewed before that feature makes the latent deletion reachable.

## What

| Edit | Before | After |
| --- | --- | --- |
| Remove a visible pattern | Hidden property filters are discarded | Hidden property filters round-trip unchanged |
| Add a custom pattern | Hidden property filters are discarded | Hidden property filters round-trip unchanged |

The editor continues to display and edit the same four visible pattern categories.

## Non goal

- Exposing `PatternListEditor` on a settings page.
- Displaying, adding, or removing property filters in this editor.
- Changing Relevant Notes, Miyo, local Orama indexing, or filter matching semantics.

## Screenshot

Not applicable. The visible editor is unchanged; this preserves a hidden part of its serialized value.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Tests cover both editor rebuild paths that could discard hidden filters |
| A defect would fail CI or be obvious on first use | ✅ | Each output value is decoded and compared after the edit |
| A revert fully restores prior state, including persisted data | ✅ | This component returns values to callers but does not persist or migrate data itself |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Existing parsed filter values are only carried through unchanged |
| No public API, plugin API, message, or on-disk contract changes | ✅ | The internal component keeps the existing serialized format |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Both changed paths are synchronous editor callbacks |
| No hot-path behavior lacks deterministic coverage | ✅ | Removal and custom-add behavior are covered directly |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Any regression appears in the editor's next emitted value |

Review: inspect the value reconstruction in `PatternListEditor()` in `src/settings/v2/components/PatternListEditor.tsx`, then run Verification.

## Verification

1. Run `npm test -- --runInBand src/settings/v2/components/PatternListEditor.test.tsx`.
2. Confirm removing a visible tag leaves the hidden property filter in the emitted value.
3. Confirm adding a custom pattern leaves both the existing visible tag and hidden property filter in the emitted value.
