### PR TITLE
[Relevant Notes on Miyo] - Step 5: Explain missing notes with Miyo status

### DIFF
--- a/docs/vault-search-and-indexing.md
+++ b/docs/vault-search-and-indexing.md
@@ -52,7 +52,7 @@ A successful search with zero results shows **No semantic matches yet** without 
 - **Miyo couldn't index this note** includes Miyo's error message. On a local desktop connection, **Open Miyo** opens this vault's folder under Sources.
 - **This note is excluded in Miyo** names the matching filter when Miyo provides it. On a local desktop connection, **Open folder settings in Miyo** opens this vault's folder under Sources.
 
-For a remote Miyo or mobile device, error and exclusion cards tell you to review the folder on the host machine. Copilot cannot open or change that machine's Miyo settings. Older Miyo builds show **This note isn't indexed in Miyo** and **Update Miyo to see why** because they cannot report the more specific reason. Their local desktop action still opens the vault's folder under Sources; remote and mobile connections offer **Review Miyo connection** in Copilot.
+For a remote Miyo or mobile device, error and exclusion cards tell you to review the folder on the host machine. Copilot cannot open or change that machine's Miyo settings. Older Miyo builds show **This note isn't indexed in Miyo** and **Update Miyo to the latest version to see why** because they cannot report the more specific reason. Their local desktop action still opens the vault's folder under Sources; remote and mobile connections offer **Review Miyo connection** in Copilot.
 
 Links and backlinks do not create rows in any of these empty states. Copilot's own inclusion and exclusion patterns do not filter Relevant Notes; Miyo's folder filters are the only scope there.
 

--- a/docs/vault-search-and-indexing.md
+++ b/docs/vault-search-and-indexing.md
@@ -45,7 +45,16 @@ Miyo is the source of Relevant Notes results and similarity percentages; Copilot
 
 If Miyo is disabled, unavailable, or its vault registration cannot be confirmed, the pane does not fall back to link and backlink rows. Instead, it offers Miyo download or setup actions. **Open Miyo settings** returns directly to the existing connection flow under **Settings → Copilot → Miyo**, including when you use a remote endpoint or mobile device.
 
-A successful search with zero results shows **No semantic matches yet** without treating the empty result as a setup failure. When Miyo reports that the active path has no indexed chunks but the vault is registered, the pane instead shows **This note isn't indexed in Miyo**. Miyo uses that response for both a note that is still indexing and a path excluded from Miyo, so Copilot does not claim to know which one applies. On a local desktop connection, **Open Miyo** opens the Miyo app so you can review the folder's indexing and exclusion settings; after indexing finishes, return to Copilot and select **Refresh** to check the note again. Mobile and remote connections instead offer **Review Miyo connection**, which opens Copilot's Miyo tab to review the configured server without implying that Copilot can change Miyo's exclusions. Neither state shows link-only or backlink-only rows.
+A successful search with zero results shows **No semantic matches yet** without treating the empty result as a setup failure. If the active note has no indexed chunks, Copilot asks Miyo for that file's current state:
+
+- **Miyo found no text in this note** means Miyo processed the file but found no searchable text.
+- **Miyo is still indexing this note** covers files that are pending, not scanned yet, or not yet visible to Miyo. Select **Refresh** to check again.
+- **Miyo couldn't index this note** includes Miyo's error message. On a local desktop connection, **Open Miyo** opens this vault's folder under Sources.
+- **This note is excluded in Miyo** names the matching filter when Miyo provides it. On a local desktop connection, **Open folder settings in Miyo** opens this vault's folder under Sources.
+
+For a remote Miyo or mobile device, error and exclusion cards tell you to review the folder on the host machine. Copilot cannot open or change that machine's Miyo settings. Older Miyo builds show **This note isn't indexed in Miyo** and **Update Miyo to see why** because they cannot report the more specific reason. Their local desktop action still opens the vault's folder under Sources; remote and mobile connections offer **Review Miyo connection** in Copilot.
+
+Links and backlinks do not create rows in any of these empty states. Copilot's own inclusion and exclusion patterns do not filter Relevant Notes; Miyo's folder filters are the only scope there.
 
 ## Search conversations and process documents
 
@@ -71,7 +80,7 @@ Connector access is separate from Agent Chat search. Review the folders, remote 
 - **Register this vault:** register the folder in Miyo, then connect again.
 - **Semantic search is missing:** confirm the connection is healthy and turn on **Semantic search**. Copilot installs the shared Miyo skill for opencode, Claude, and Codex.
 - **New notes are missing:** ask Miyo to refresh the registered folder. Indexing progress is shown in Miyo.
-- **Relevant Notes has no semantic results:** **No semantic matches yet** means Miyo answered successfully but found no related notes. **This note isn't indexed in Miyo** means the note may still be indexing or may be excluded from Miyo. Neither state shows link-only or backlink-only rows.
+- **Relevant Notes has no semantic results:** Read the card for the active note's Miyo state. **No semantic matches yet** means Miyo found no related notes. The other cards distinguish an empty note, indexing work, an indexing error, and a Miyo folder filter. Older Miyo builds use the less specific **This note isn't indexed in Miyo** card. None of these states shows link-only or backlink-only rows.
 - **Agent Chat Miyo document processing fails:** install Miyo on this computer so its local CLI is available, or switch **Document Processor** to **Plus**. A remote Miyo search connection does not provide the local CLI Agent Chat needs.
 - **Quick Chat Miyo document processing fails:** confirm that the connected Miyo service can access the registered vault and document. When a remote server is configured, troubleshoot the document on that server.
 - **Copilot asks for a resync:** use **Resync Miyo** so Miyo excludes Copilot's own working folder and conversation files.

--- a/src/components/chat-components/RelevantNotes.test.tsx
+++ b/src/components/chat-components/RelevantNotes.test.tsx
@@ -269,7 +269,7 @@ describe("RelevantNotes", () => {
       expect(await screen.findByText("This note isn't indexed in Miyo")).toBeTruthy();
       expect(
         screen.getByText(
-          "It may still be indexing or be excluded from Miyo. Update Miyo to see why."
+          "It may still be indexing or be excluded from Miyo. Update Miyo to the latest version to see why."
         )
       ).toBeTruthy();
       expect(screen.queryByText("Target")).toBeNull();

--- a/src/components/chat-components/RelevantNotes.test.tsx
+++ b/src/components/chat-components/RelevantNotes.test.tsx
@@ -13,6 +13,7 @@ const mockApp = {
   vault: {
     getAbstractFileByPath: jest.fn(),
     cachedRead: jest.fn().mockResolvedValue(""),
+    getName: jest.fn(() => "Work Vault"),
   },
   workspace: {
     getLeaf: mockGetLeaf,
@@ -268,12 +269,12 @@ describe("RelevantNotes", () => {
       expect(await screen.findByText("This note isn't indexed in Miyo")).toBeTruthy();
       expect(
         screen.getByText(
-          "It may still be indexing or be excluded from Miyo. Open Miyo to review this folder's indexing and exclusion settings."
+          "It may still be indexing or be excluded from Miyo. Update Miyo to see why."
         )
       ).toBeTruthy();
       expect(screen.queryByText("Target")).toBeNull();
       fireEvent.click(screen.getByRole("button", { name: "Open Miyo" }));
-      expect(openSpy).toHaveBeenCalledWith("miyo://", "_blank");
+      expect(openSpy).toHaveBeenCalledWith("miyo://open?tab=sources&folder=Work%20Vault", "_blank");
       openSpy.mockRestore();
     });
 

--- a/src/components/chat-components/RelevantNotes.tsx
+++ b/src/components/chat-components/RelevantNotes.tsx
@@ -7,7 +7,7 @@ import { useActiveFile } from "@/hooks/useActiveFile";
 import { useNoteDrag } from "@/hooks/useNoteDrag";
 import { cn } from "@/lib/utils";
 import { logError, logWarn } from "@/logger";
-import { isLocalMiyoUrl, MIYO_DEEPLINK_URL } from "@/miyo/miyoUtils";
+import { getMiyoFolderName, isLocalMiyoUrl, MIYO_DEEPLINK_URL } from "@/miyo/miyoUtils";
 import { useMiyoStatus } from "@/miyo/useMiyoStatus";
 import { findRelevantNotes, type RelevantNoteEntry } from "@/search/findRelevantNotes";
 import { onIndexChanged } from "@/search/indexSignal";
@@ -22,18 +22,22 @@ const EMPTY_RELEVANT_NOTES: readonly RelevantNoteEntry[] = Object.freeze([]);
 const IDLE_RELEVANT_NOTES_RESULT = Object.freeze({
   notes: EMPTY_RELEVANT_NOTES,
   status: "idle" as const,
+  details: undefined,
 });
 const DISABLED_RELEVANT_NOTES_RESULT = Object.freeze({
   notes: EMPTY_RELEVANT_NOTES,
   status: "disabled" as const,
+  details: undefined,
 });
 const LOADING_RELEVANT_NOTES_RESULT = Object.freeze({
   notes: EMPTY_RELEVANT_NOTES,
   status: "loading" as const,
+  details: undefined,
 });
 const UNAVAILABLE_RELEVANT_NOTES_RESULT = Object.freeze({
   notes: EMPTY_RELEVANT_NOTES,
   status: "unavailable" as const,
+  details: undefined,
 });
 
 type RelevantNotesViewResult =
@@ -444,6 +448,9 @@ export const RelevantNotes = memo(
     // or by an explicit remote endpoint, so those runtimes stay in Copilot.
     // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
     const canOpenMiyoApp = !Platform.isMobile && isLocalMiyoUrl(settings.miyoServerUrl);
+    const miyoFolderUrl = `${MIYO_DEEPLINK_URL}open?tab=sources&folder=${encodeURIComponent(
+      getMiyoFolderName(app)
+    )}`;
 
     return (
       <div className={cn("tw-flex tw-min-h-full tw-w-full tw-flex-1 tw-flex-col", className)}>
@@ -452,6 +459,7 @@ export const RelevantNotes = memo(
           <div className="tw-absolute tw-inset-0 tw-overflow-y-auto tw-p-2">
             <RelevantNotesPane
               status={result.status}
+              details={result.details}
               noteRows={relevantNotes.map((note) => (
                 <RelevantNoteRow
                   key={note.note.path}
@@ -469,7 +477,7 @@ export const RelevantNotes = memo(
                   destination: canOpenMiyoApp ? "miyo" : "settings",
                   onSelect: (event) => {
                     if (canOpenMiyoApp) {
-                      event.currentTarget.win.open(MIYO_DEEPLINK_URL, "_blank");
+                      event.currentTarget.win.open(miyoFolderUrl, "_blank");
                     } else {
                       openCopilotSettings(app, event.currentTarget.win, "miyo");
                     }

--- a/src/components/chat-components/ui/RelevantNotesPane.stories.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.stories.tsx
@@ -80,6 +80,54 @@ export const NotIndexedGuidance: StoryObj<RelevantNotesPaneProps> = {
   args: { status: "not-indexed", noteRows: [] },
 };
 
+export const NoTextGuidance: StoryObj<RelevantNotesPaneProps> = {
+  args: { status: "no-text", noteRows: [] },
+};
+
+export const IndexingGuidance: StoryObj<RelevantNotesPaneProps> = {
+  args: { status: "indexing", noteRows: [] },
+};
+
+export const IndexErrorGuidance: StoryObj<RelevantNotesPaneProps> = {
+  args: {
+    status: "index-error",
+    details: { errorMessage: "Markdown parser failed" },
+    noteRows: [],
+  },
+};
+
+export const IndexErrorRemoteGuidance: StoryObj<RelevantNotesPaneProps> = {
+  args: {
+    status: "index-error",
+    details: { errorMessage: "Markdown parser failed" },
+    noteRows: [],
+    actions: {
+      ...baseArgs.actions,
+      reviewIndexing: { ...baseArgs.actions.reviewIndexing, destination: "settings" },
+    },
+  },
+};
+
+export const ExcludedGuidance: StoryObj<RelevantNotesPaneProps> = {
+  args: {
+    status: "excluded",
+    details: { exclusionReason: "exclude_pattern", exclusionRule: "**/journal/**" },
+    noteRows: [],
+  },
+};
+
+export const ExcludedRemoteGuidance: StoryObj<RelevantNotesPaneProps> = {
+  args: {
+    status: "excluded",
+    details: { exclusionReason: "exclude_pattern", exclusionRule: "**/journal/**" },
+    noteRows: [],
+    actions: {
+      ...baseArgs.actions,
+      reviewIndexing: { ...baseArgs.actions.reviewIndexing, destination: "settings" },
+    },
+  },
+};
+
 export const NotIndexedRemoteGuidance: StoryObj<RelevantNotesPaneProps> = {
   args: {
     status: "not-indexed",

--- a/src/components/chat-components/ui/RelevantNotesPane.test.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.test.tsx
@@ -81,7 +81,7 @@ describe("RelevantNotesPane", () => {
       expect(screen.getByText("This note isn't indexed in Miyo")).toBeTruthy();
       expect(
         screen.getByText(
-          "It may still be indexing or be excluded from Miyo. Open Miyo to review this folder's indexing and exclusion settings."
+          "It may still be indexing or be excluded from Miyo. Update Miyo to see why."
         )
       ).toBeTruthy();
       expect(screen.queryByText("Related note")).toBeNull();
@@ -107,13 +107,110 @@ describe("RelevantNotesPane", () => {
       expect(screen.queryByRole("button", { name: "Open Miyo" })).toBeNull();
       expect(
         screen.getByText(
-          "It may still be indexing or be excluded from Miyo. Review the configured Miyo connection or server in Copilot."
+          "It may still be indexing or be excluded from Miyo. Update Miyo to see why."
         )
       ).toBeTruthy();
       expect(screen.queryByText("Related note")).toBeNull();
       fireEvent.click(screen.getByRole("button", { name: "Review Miyo connection" }));
       expect(BASE_ACTIONS.reviewIndexing.onSelect).toHaveBeenCalledTimes(1);
     });
+
+    it.each([
+      { status: "no-text" as const, title: "Miyo found no text in this note" },
+      { status: "indexing" as const, title: "Miyo is still indexing this note" },
+    ])(
+      "shows $status guidance without rows and refreshes on request (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)",
+      ({ status, title }) => {
+        render(<RelevantNotesPane {...BASE_PROPS} status={status} />);
+
+        expect(screen.getByText(title)).toBeTruthy();
+        expect(screen.queryByText("Related note")).toBeNull();
+        fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+        expect(BASE_ACTIONS.onRefresh).toHaveBeenCalledTimes(1);
+      }
+    );
+
+    it("shows Miyo's file error without rows and opens the local folder (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
+      render(
+        <RelevantNotesPane
+          {...BASE_PROPS}
+          status="index-error"
+          details={{ errorMessage: "Markdown parser failed" }}
+        />
+      );
+
+      expect(screen.getByText("Miyo couldn't index this note")).toBeTruthy();
+      expect(screen.getByText("Markdown parser failed")).toBeTruthy();
+      expect(screen.queryByText("Related note")).toBeNull();
+      fireEvent.click(screen.getByRole("button", { name: "Open Miyo" }));
+      expect(BASE_ACTIONS.reviewIndexing.onSelect).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps remote index errors actionable without claiming it can open the host folder (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
+      render(
+        <RelevantNotesPane
+          {...BASE_PROPS}
+          status="index-error"
+          details={{ errorMessage: "Markdown parser failed" }}
+          actions={{
+            ...BASE_ACTIONS,
+            reviewIndexing: { ...BASE_ACTIONS.reviewIndexing, destination: "settings" },
+          }}
+        />
+      );
+
+      expect(
+        screen.getByText("Markdown parser failed Review the folder in Miyo on the host machine.")
+      ).toBeTruthy();
+      expect(screen.queryByText("Related note")).toBeNull();
+      expect(screen.queryByRole("button", { name: "Open Miyo" })).toBeNull();
+    });
+
+    it.each([
+      ["exclude_folder" as const, "notes/private", "Excluded by folder notes/private."],
+      ["exclude_pattern" as const, "**/journal/**", "Excluded by pattern **/journal/**."],
+      ["include_folder" as const, "work", "Not included by folder work."],
+      ["include_pattern" as const, "projects/**", "Not included by pattern projects/**."],
+      ["extension" as const, undefined, "This file type isn't included in Miyo's folder settings."],
+      ["hidden" as const, undefined, "Miyo excludes hidden files."],
+      [undefined, undefined, "Miyo's folder filters exclude this note."],
+    ])(
+      "explains the %s exclusion and exposes folder settings only on local desktop (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)",
+      (exclusionReason, exclusionRule, expectedDescription) => {
+        const { rerender } = render(
+          <RelevantNotesPane
+            {...BASE_PROPS}
+            status="excluded"
+            details={{ exclusionReason, exclusionRule }}
+          />
+        );
+
+        expect(screen.getByText("This note is excluded in Miyo")).toBeTruthy();
+        expect(screen.getByText(expectedDescription)).toBeTruthy();
+        expect(screen.queryByText("Related note")).toBeNull();
+        fireEvent.click(screen.getByRole("button", { name: "Open folder settings in Miyo" }));
+        expect(BASE_ACTIONS.reviewIndexing.onSelect).toHaveBeenCalledTimes(1);
+
+        rerender(
+          <RelevantNotesPane
+            {...BASE_PROPS}
+            status="excluded"
+            details={{ exclusionReason, exclusionRule }}
+            actions={{
+              ...BASE_ACTIONS,
+              reviewIndexing: { ...BASE_ACTIONS.reviewIndexing, destination: "settings" },
+            }}
+          />
+        );
+
+        expect(
+          screen.getByText(
+            `${expectedDescription} Adjust this folder's filters in Miyo on the host machine.`
+          )
+        ).toBeTruthy();
+        expect(screen.queryByRole("button", { name: "Open folder settings in Miyo" })).toBeNull();
+      }
+    );
 
     it("renders the neutral empty state when no source note is active (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
       render(<RelevantNotesPane {...BASE_PROPS} status="idle" noteRows={[]} />);

--- a/src/components/chat-components/ui/RelevantNotesPane.test.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.test.tsx
@@ -81,7 +81,7 @@ describe("RelevantNotesPane", () => {
       expect(screen.getByText("This note isn't indexed in Miyo")).toBeTruthy();
       expect(
         screen.getByText(
-          "It may still be indexing or be excluded from Miyo. Update Miyo to see why."
+          "It may still be indexing or be excluded from Miyo. Update Miyo to the latest version to see why."
         )
       ).toBeTruthy();
       expect(screen.queryByText("Related note")).toBeNull();
@@ -107,7 +107,7 @@ describe("RelevantNotesPane", () => {
       expect(screen.queryByRole("button", { name: "Open Miyo" })).toBeNull();
       expect(
         screen.getByText(
-          "It may still be indexing or be excluded from Miyo. Update Miyo to see why."
+          "It may still be indexing or be excluded from Miyo. Update Miyo to the latest version to see why."
         )
       ).toBeTruthy();
       expect(screen.queryByText("Related note")).toBeNull();

--- a/src/components/chat-components/ui/RelevantNotesPane.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.tsx
@@ -1,15 +1,12 @@
 import { Button } from "@/components/ui/button";
+import type {
+  RelevantNotesSearchStatus,
+  RelevantNotesStatusDetails,
+} from "@/search/findRelevantNotes";
 import { Download, Loader2 } from "lucide-react";
 import React from "react";
 
-type RelevantNotesPaneStatus =
-  | "idle"
-  | "loading"
-  | "disabled"
-  | "unavailable"
-  | "matches"
-  | "no-matches"
-  | "not-indexed";
+type RelevantNotesPaneStatus = RelevantNotesSearchStatus | "idle" | "loading";
 
 interface RelevantNotesIndexingReviewAction {
   destination: "miyo" | "settings";
@@ -25,12 +22,21 @@ export interface RelevantNotesPaneActions {
 
 export interface RelevantNotesPaneProps {
   status: RelevantNotesPaneStatus;
+  details?: RelevantNotesStatusDetails;
   noteRows: readonly React.ReactNode[];
   actions: RelevantNotesPaneActions;
 }
 
 interface GuidancePanelProps {
-  id: "download" | "unavailable" | "no-matches" | "not-indexed";
+  id:
+    | "download"
+    | "unavailable"
+    | "no-matches"
+    | "no-text"
+    | "indexing"
+    | "index-error"
+    | "excluded"
+    | "not-indexed";
   title: string;
   description: string;
   children?: React.ReactNode;
@@ -64,11 +70,13 @@ function GuidancePanel({
  * Render Relevant Notes states without plugin or Obsidian runtime access.
  *
  * @param status - Current lifecycle or settled search status.
+ * @param details - Optional Miyo error or exclusion details for the active note.
  * @param noteRows - Rendered note rows in result order.
  * @param actions - Runtime-owned destinations for pane actions.
  */
 export function RelevantNotesPane({
   status,
+  details,
   noteRows,
   actions,
 }: RelevantNotesPaneProps): React.ReactElement {
@@ -129,17 +137,114 @@ export function RelevantNotesPane({
         />
       );
       break;
+    case "no-text":
+      guidancePanel = (
+        <GuidancePanel
+          id="no-text"
+          title="Miyo found no text in this note"
+          description="The note may be empty or contain only content Miyo can't read."
+        >
+          <Button variant="secondary" size="sm" onClick={actions.onRefresh}>
+            Refresh
+          </Button>
+        </GuidancePanel>
+      );
+      break;
+    case "indexing":
+      guidancePanel = (
+        <GuidancePanel
+          id="indexing"
+          title="Miyo is still indexing this note"
+          description="Miyo hasn't finished processing this note. Try again shortly."
+        >
+          <Button variant="secondary" size="sm" onClick={actions.onRefresh}>
+            Refresh
+          </Button>
+        </GuidancePanel>
+      );
+      break;
+    case "index-error": {
+      const reviewInMiyo = actions.reviewIndexing.destination === "miyo";
+      const errorMessage =
+        details?.errorMessage?.trim() || "Miyo reported an error while processing this note.";
+      guidancePanel = (
+        <GuidancePanel
+          id="index-error"
+          title="Miyo couldn't index this note"
+          description={
+            reviewInMiyo
+              ? errorMessage
+              : `${errorMessage} Review the folder in Miyo on the host machine.`
+          }
+        >
+          {reviewInMiyo && (
+            <Button variant="default" size="sm" onClick={actions.reviewIndexing.onSelect}>
+              Open Miyo
+            </Button>
+          )}
+        </GuidancePanel>
+      );
+      break;
+    }
+    case "excluded": {
+      const reviewInMiyo = actions.reviewIndexing.destination === "miyo";
+      let reason: string;
+      switch (details?.exclusionReason) {
+        case "exclude_folder":
+          reason = details.exclusionRule
+            ? `Excluded by folder ${details.exclusionRule}.`
+            : "Excluded by a folder filter.";
+          break;
+        case "exclude_pattern":
+          reason = details.exclusionRule
+            ? `Excluded by pattern ${details.exclusionRule}.`
+            : "Excluded by a pattern filter.";
+          break;
+        case "include_folder":
+          reason = details.exclusionRule
+            ? `Not included by folder ${details.exclusionRule}.`
+            : "Not included by the folder filters.";
+          break;
+        case "include_pattern":
+          reason = details.exclusionRule
+            ? `Not included by pattern ${details.exclusionRule}.`
+            : "Not included by the pattern filters.";
+          break;
+        case "extension":
+          reason = "This file type isn't included in Miyo's folder settings.";
+          break;
+        case "hidden":
+          reason = "Miyo excludes hidden files.";
+          break;
+        default:
+          reason = "Miyo's folder filters exclude this note.";
+      }
+      guidancePanel = (
+        <GuidancePanel
+          id="excluded"
+          title="This note is excluded in Miyo"
+          description={
+            reviewInMiyo
+              ? reason
+              : `${reason} Adjust this folder's filters in Miyo on the host machine.`
+          }
+        >
+          {reviewInMiyo && (
+            <Button variant="default" size="sm" onClick={actions.reviewIndexing.onSelect}>
+              Open folder settings in Miyo
+            </Button>
+          )}
+        </GuidancePanel>
+      );
+      break;
+    }
     case "not-indexed": {
       const reviewInMiyo = actions.reviewIndexing.destination === "miyo";
       guidancePanel = (
         <GuidancePanel
           id="not-indexed"
           title="This note isn't indexed in Miyo"
-          description={
-            reviewInMiyo
-              ? "It may still be indexing or be excluded from Miyo. Open Miyo to review this folder's indexing and exclusion settings."
-              : "It may still be indexing or be excluded from Miyo. Review the configured Miyo connection or server in Copilot."
-          }
+          description="It may still be indexing or be excluded from Miyo. Update Miyo to see why."
         >
           <Button variant="secondary" size="sm" onClick={actions.onRefresh}>
             Refresh

--- a/src/components/chat-components/ui/RelevantNotesPane.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.tsx
@@ -144,7 +144,7 @@ export function RelevantNotesPane({
           title="Miyo found no text in this note"
           description="The note may be empty or contain only content Miyo can't read."
         >
-          <Button variant="secondary" size="sm" onClick={actions.onRefresh}>
+          <Button variant="default" size="sm" onClick={actions.onRefresh}>
             Refresh
           </Button>
         </GuidancePanel>
@@ -157,7 +157,7 @@ export function RelevantNotesPane({
           title="Miyo is still indexing this note"
           description="Miyo hasn't finished processing this note. Try again shortly."
         >
-          <Button variant="secondary" size="sm" onClick={actions.onRefresh}>
+          <Button variant="default" size="sm" onClick={actions.onRefresh}>
             Refresh
           </Button>
         </GuidancePanel>
@@ -244,7 +244,7 @@ export function RelevantNotesPane({
         <GuidancePanel
           id="not-indexed"
           title="This note isn't indexed in Miyo"
-          description="It may still be indexing or be excluded from Miyo. Update Miyo to see why."
+          description="It may still be indexing or be excluded from Miyo. Update Miyo to the latest version to see why."
         >
           <Button variant="secondary" size="sm" onClick={actions.onRefresh}>
             Refresh

--- a/src/miyo/MiyoClient.test.ts
+++ b/src/miyo/MiyoClient.test.ts
@@ -52,6 +52,11 @@ describe("MiyoClient", () => {
       it("preserves the Miyo status and detail without changing the request message (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
         const error = new MiyoRequestError(404, "folder not registered");
         const errorWithoutDetail = new MiyoRequestError(503, "");
+        const unsupportedEndpoint = new MiyoRequestError(
+          501,
+          '{"error":"not_implemented"}',
+          "not_implemented"
+        );
 
         expect(error).toBeInstanceOf(Error);
         expect(error).toMatchObject({
@@ -61,6 +66,7 @@ describe("MiyoClient", () => {
           message: "Miyo request failed with status 404: folder not registered",
         });
         expect(errorWithoutDetail.message).toBe("Miyo request failed with status 503");
+        expect(unsupportedEndpoint.errorCode).toBe("not_implemented");
       });
     });
   });
@@ -192,6 +198,56 @@ describe("MiyoClient", () => {
       status: 404,
       detail: "folder not registered",
       message: "Miyo request failed with status 404: folder not registered",
+    });
+  });
+
+  describe("fileStatus()", () => {
+    it("gets one vault-relative file status with encoded folder and file queries (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      mockedRequestUrl.mockResolvedValue({
+        status: 200,
+        json: {
+          status: "excluded",
+          file_path: "daily notes/Today.md",
+          reason: "exclude_pattern",
+          rule: "daily notes/**",
+        },
+        text: "",
+      } as RequestUrlResponse);
+
+      const result = await new MiyoClient().fileStatus(
+        "http://127.0.0.1:8742",
+        "Work Vault",
+        "daily notes/Today.md"
+      );
+
+      expect(result).toEqual({
+        status: "excluded",
+        file_path: "daily notes/Today.md",
+        reason: "exclude_pattern",
+        rule: "daily notes/**",
+      });
+      expect(mockedRequestUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "http://127.0.0.1:8742/v0/folder/file-status?folder_name=Work+Vault&file_path=daily+notes%2FToday.md",
+          method: "GET",
+          throw: false,
+        })
+      );
+    });
+
+    it("preserves the old-build error code as structured data (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      mockedRequestUrl.mockResolvedValue({
+        status: 501,
+        json: { error: "not_implemented" },
+        text: '{"error":"not_implemented"}',
+      } as RequestUrlResponse);
+
+      await expect(
+        new MiyoClient().fileStatus("http://127.0.0.1:8742", "vault", "source.md")
+      ).rejects.toMatchObject({
+        status: 501,
+        errorCode: "not_implemented",
+      });
     });
   });
 

--- a/src/miyo/MiyoClient.test.ts
+++ b/src/miyo/MiyoClient.test.ts
@@ -202,12 +202,11 @@ describe("MiyoClient", () => {
   });
 
   describe("fileStatus()", () => {
-    it("gets one vault-relative file status with encoded folder and file queries (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+    it("gets one file status using Miyo's encoded public path (https://github.com/Brevilabs/miyo/issues/543)", async () => {
       mockedRequestUrl.mockResolvedValue({
         status: 200,
         json: {
           status: "excluded",
-          file_path: "daily notes/Today.md",
           reason: "exclude_pattern",
           rule: "daily notes/**",
         },
@@ -216,19 +215,17 @@ describe("MiyoClient", () => {
 
       const result = await new MiyoClient().fileStatus(
         "http://127.0.0.1:8742",
-        "Work Vault",
-        "daily notes/Today.md"
+        "Work Vault/daily notes/Today.md"
       );
 
       expect(result).toEqual({
         status: "excluded",
-        file_path: "daily notes/Today.md",
         reason: "exclude_pattern",
         rule: "daily notes/**",
       });
       expect(mockedRequestUrl).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: "http://127.0.0.1:8742/v0/folder/file-status?folder_name=Work+Vault&file_path=daily+notes%2FToday.md",
+          url: "http://127.0.0.1:8742/v0/folder/file-status?file_path=Work+Vault%2Fdaily+notes%2FToday.md",
           method: "GET",
           throw: false,
         })
@@ -243,7 +240,7 @@ describe("MiyoClient", () => {
       } as RequestUrlResponse);
 
       await expect(
-        new MiyoClient().fileStatus("http://127.0.0.1:8742", "vault", "source.md")
+        new MiyoClient().fileStatus("http://127.0.0.1:8742", "vault/source.md")
       ).rejects.toMatchObject({
         status: 501,
         errorCode: "not_implemented",

--- a/src/miyo/MiyoClient.ts
+++ b/src/miyo/MiyoClient.ts
@@ -19,7 +19,8 @@ export type {
 export class MiyoRequestError extends Error {
   public constructor(
     public readonly status: number,
-    public readonly detail: string
+    public readonly detail: string,
+    public readonly errorCode?: string
   ) {
     // Some Miyo failures have no response body; retaining the prior status-only
     // message keeps those callers stable while exposing structured fields.
@@ -164,6 +165,35 @@ export interface MiyoRelatedSearchResult {
  */
 export interface MiyoRelatedSearchResponse {
   results: MiyoRelatedSearchResult[];
+}
+
+export type MiyoFileStatus =
+  | "indexed"
+  | "pending"
+  | "error"
+  | "excluded"
+  | "not_scanned"
+  | "missing";
+
+export type MiyoFileStatusReason =
+  | "exclude_folder"
+  | "exclude_pattern"
+  | "include_folder"
+  | "include_pattern"
+  | "extension"
+  | "hidden";
+
+/**
+ * Miyo's classification of one vault-relative file within a registered folder.
+ */
+export interface MiyoFileStatusResponse {
+  status: MiyoFileStatus;
+  file_path: string;
+  total_chunks?: number;
+  last_indexed_at?: string;
+  error_message?: string;
+  reason?: MiyoFileStatusReason;
+  rule?: string;
 }
 
 /**
@@ -629,6 +659,28 @@ export class MiyoClient {
   }
 
   /**
+   * Classify one file when related search cannot find indexed chunks for it.
+   *
+   * @param baseUrl - Miyo base URL.
+   * @param folderName - Vault folder name registered in Miyo.
+   * @param filePath - File path relative to the registered folder.
+   * @returns Miyo's current file classification and available details.
+   */
+  public async fileStatus(
+    baseUrl: string,
+    folderName: string,
+    filePath: string
+  ): Promise<MiyoFileStatusResponse> {
+    return this.requestJson<MiyoFileStatusResponse>(baseUrl, "/v0/folder/file-status", {
+      method: "GET",
+      query: {
+        folder_name: folderName,
+        file_path: filePath,
+      },
+    });
+  }
+
+  /**
    * Parse a local document via Miyo.
    *
    * @param baseUrl - Miyo base URL.
@@ -711,16 +763,16 @@ export class MiyoClient {
     });
 
     if (response.status >= 400) {
-      const errorPayload = this.parseResponseJson<{ detail?: string }>(
+      const errorPayload = this.parseResponseJson<{ detail?: string; error?: string }>(
         response.json,
         response.text
       );
-      const errorText = errorPayload?.detail || response.text || "";
+      const errorText = errorPayload?.detail || response.text || errorPayload?.error || "";
       logWarn(`Miyo request failed (${response.status}): ${errorText}`);
       // Relevant Notes must distinguish an unindexed source from a service
       // outage without parsing human-readable error messages.
       // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
-      throw new MiyoRequestError(response.status, errorText);
+      throw new MiyoRequestError(response.status, errorText, errorPayload?.error);
     }
 
     const parsed = this.parseResponseJson<T>(response.json, response.text);

--- a/src/miyo/MiyoClient.ts
+++ b/src/miyo/MiyoClient.ts
@@ -188,10 +188,9 @@ export type MiyoFileStatusReason =
  */
 export interface MiyoFileStatusResponse {
   status: MiyoFileStatus;
-  file_path: string;
   total_chunks?: number;
-  last_indexed_at?: string;
-  error_message?: string;
+  last_indexed_at?: number | null;
+  error_message?: string | null;
   reason?: MiyoFileStatusReason;
   rule?: string;
 }
@@ -662,21 +661,13 @@ export class MiyoClient {
    * Classify one file when related search cannot find indexed chunks for it.
    *
    * @param baseUrl - Miyo base URL.
-   * @param folderName - Vault folder name registered in Miyo.
-   * @param filePath - File path relative to the registered folder.
+   * @param filePath - File path in Miyo's public `FolderName/path/to/file` format.
    * @returns Miyo's current file classification and available details.
    */
-  public async fileStatus(
-    baseUrl: string,
-    folderName: string,
-    filePath: string
-  ): Promise<MiyoFileStatusResponse> {
+  public async fileStatus(baseUrl: string, filePath: string): Promise<MiyoFileStatusResponse> {
     return this.requestJson<MiyoFileStatusResponse>(baseUrl, "/v0/folder/file-status", {
       method: "GET",
-      query: {
-        folder_name: folderName,
-        file_path: filePath,
-      },
+      query: { file_path: filePath },
     });
   }
 

--- a/src/search/findRelevantNotes.test.ts
+++ b/src/search/findRelevantNotes.test.ts
@@ -20,7 +20,7 @@ jest.mock("@/settings/model", () => ({ getSettings: jest.fn() }));
 
 const mockResolveBaseUrl = jest.fn();
 const mockSearchRelated = jest.fn();
-const mockGetFolder = jest.fn();
+const mockFileStatus = jest.fn();
 
 jest.mock("@/miyo/MiyoClient", () => {
   const actual = jest.requireActual<typeof import("@/miyo/MiyoClient")>("@/miyo/MiyoClient");
@@ -29,7 +29,7 @@ jest.mock("@/miyo/MiyoClient", () => {
     MiyoClient: jest.fn().mockImplementation(() => ({
       resolveBaseUrl: (...args: unknown[]) => mockResolveBaseUrl(...args) as unknown,
       searchRelated: (...args: unknown[]) => mockSearchRelated(...args) as unknown,
-      getFolder: (...args: unknown[]) => mockGetFolder(...args) as unknown,
+      fileStatus: (...args: unknown[]) => mockFileStatus(...args) as unknown,
     })),
   };
 });
@@ -87,11 +87,11 @@ describe("findRelevantNotes", () => {
       );
       mockResolveBaseUrl.mockResolvedValue("http://127.0.0.1:8742");
       mockSearchRelated.mockResolvedValue({ results: [] });
-      mockGetFolder.mockResolvedValue({ path: "vault" });
+      mockFileStatus.mockResolvedValue({ status: "pending", file_path: "source.md" });
       mockedMiyoClient.mockImplementation(() => ({
         resolveBaseUrl: mockResolveBaseUrl,
         searchRelated: mockSearchRelated,
-        getFolder: mockGetFolder,
+        fileStatus: mockFileStatus,
       }));
 
       const paths = [
@@ -205,7 +205,7 @@ describe("findRelevantNotes", () => {
       });
 
       expect(result).toEqual({ status: "no-matches", notes: [] });
-      expect(mockGetFolder).not.toHaveBeenCalled();
+      expect(mockFileStatus).not.toHaveBeenCalled();
       expect(mockedGetLinkedNotes).not.toHaveBeenCalled();
       expect(mockedGetBacklinkedNotes).not.toHaveBeenCalled();
     });
@@ -292,6 +292,9 @@ describe("findRelevantNotes", () => {
       const noMatchesResult = await findRelevantNotes({ app: window.app, filePath: "source.md" });
 
       mockSearchRelated.mockRejectedValue(new MiyoRequestError(404, ""));
+      mockFileStatus.mockRejectedValue(
+        new MiyoRequestError(501, '{"error":"not_implemented"}', "not_implemented")
+      );
       const notIndexedResult = await findRelevantNotes({
         app: window.app,
         filePath: "source.md",
@@ -327,9 +330,76 @@ describe("findRelevantNotes", () => {
     });
 
     it.each(["", "Source file is not indexed"])(
-      "returns no rows and reports not-indexed for 404 detail %p (https://github.com/Brevilabs/obsidian-copilot-private/issues/280; https://github.com/logancyang/obsidian-copilot/pull/2992#discussion_r3919646861)",
+      "classifies every related-search 404 regardless of detail %p (https://github.com/Brevilabs/obsidian-copilot-private/issues/280; https://github.com/logancyang/obsidian-copilot/pull/2992#discussion_r3919646861)",
       async (detail) => {
         mockSearchRelated.mockRejectedValue(new MiyoRequestError(404, detail));
+        mockFileStatus.mockResolvedValue({ status: "pending", file_path: "source.md" });
+
+        const result = await findRelevantNotes({
+          app: window.app,
+          filePath: "source.md",
+        });
+
+        expect(result.status).toBe("indexing");
+        expect(mockFileStatus).toHaveBeenCalledWith("http://127.0.0.1:8742", "vault", "source.md");
+      }
+    );
+
+    it.each([
+      {
+        fileStatus: { status: "indexed", file_path: "source.md", total_chunks: 4 },
+        expectedStatus: "no-matches",
+        expectedDetails: undefined,
+      },
+      {
+        fileStatus: { status: "indexed", file_path: "source.md", total_chunks: 0 },
+        expectedStatus: "no-text",
+        expectedDetails: undefined,
+      },
+      {
+        fileStatus: { status: "pending", file_path: "source.md" },
+        expectedStatus: "indexing",
+        expectedDetails: undefined,
+      },
+      {
+        fileStatus: { status: "not_scanned", file_path: "source.md" },
+        expectedStatus: "indexing",
+        expectedDetails: undefined,
+      },
+      {
+        fileStatus: { status: "missing", file_path: "source.md" },
+        expectedStatus: "indexing",
+        expectedDetails: undefined,
+      },
+      {
+        fileStatus: {
+          status: "error",
+          file_path: "source.md",
+          error_message: "Markdown parser failed",
+        },
+        expectedStatus: "index-error",
+        expectedDetails: { errorMessage: "Markdown parser failed" },
+      },
+      {
+        fileStatus: {
+          status: "excluded",
+          file_path: "source.md",
+          reason: "exclude_pattern",
+          rule: "private/**",
+        },
+        expectedStatus: "excluded",
+        expectedDetails: {
+          exclusionReason: "exclude_pattern",
+          exclusionRule: "private/**",
+        },
+      },
+    ])(
+      "maps $fileStatus.status status without returning link-only rows (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)",
+      async ({ fileStatus, expectedStatus, expectedDetails }) => {
+        mockSearchRelated.mockRejectedValue(
+          new MiyoRequestError(404, "No indexed chunks found for file_path")
+        );
+        mockFileStatus.mockResolvedValue(fileStatus);
         mockedGetLinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);
 
         const result = await findRelevantNotes({
@@ -338,15 +408,17 @@ describe("findRelevantNotes", () => {
         });
 
         expect(result.notes).toEqual([]);
-        expect(result.status).toBe("not-indexed");
-        expect(mockGetFolder).toHaveBeenCalledWith("http://127.0.0.1:8742", "vault");
+        expect(result.status).toBe(expectedStatus);
+        expect(result.details).toEqual(expectedDetails);
+        expect(mockFileStatus).toHaveBeenCalledWith("http://127.0.0.1:8742", "vault", "source.md");
+        expect(mockedGetMiyoFilePath).toHaveBeenCalledWith(window.app, "source.md");
         expect(mockedGetLinkedNotes).not.toHaveBeenCalled();
         expect(mockedGetBacklinkedNotes).not.toHaveBeenCalled();
         expect(mockedLogError).not.toHaveBeenCalled();
       }
     );
 
-    it("keeps the original authorization identity for related search and its 404 folder probe after live settings change (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+    it("keeps the original authorization identity for related search and its file-status probe after live settings change (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
       const requestAuthorizationIdentities: Array<string | undefined> = [];
       mockedGetSettings.mockReturnValue({
         enableMiyo: true,
@@ -368,27 +440,76 @@ describe("findRelevantNotes", () => {
             } as CopilotSettings);
             return mockSearchRelated(...args) as unknown;
           },
-          getFolder: (...args: unknown[]) => {
+          fileStatus: (...args: unknown[]) => {
             requestAuthorizationIdentities.push(clientAuthSnapshot.plusLicenseKey);
-            return mockGetFolder(...args) as unknown;
+            return mockFileStatus(...args) as unknown;
           },
         };
       });
       mockSearchRelated.mockRejectedValue(new MiyoRequestError(404, ""));
+      mockFileStatus.mockResolvedValue({ status: "pending" });
 
       const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
 
-      expect(result.status).toBe("not-indexed");
+      expect(result.status).toBe("indexing");
       expect(mockedMiyoClient).toHaveBeenCalledWith({ plusLicenseKey: "old-license" });
       expect(requestAuthorizationIdentities).toEqual(["old-license", "old-license"]);
       expect(mockedGetSettings).toHaveBeenCalledTimes(1);
     });
 
-    it("returns no link-only rows when an unindexed source cannot confirm folder registration (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+    it("returns no link-only rows for the compatibility state from an exact old-Miyo response (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
       mockSearchRelated.mockRejectedValue(
         new MiyoRequestError(404, "No indexed chunks found for file_path")
       );
-      mockGetFolder.mockRejectedValue(new MiyoRequestError(404, "Folder unavailable"));
+      mockFileStatus.mockRejectedValue(
+        new MiyoRequestError(501, '{"error":"not_implemented"}', "not_implemented")
+      );
+      mockedGetLinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);
+
+      const result = await findRelevantNotes({
+        app: window.app,
+        filePath: "source.md",
+      });
+
+      expect(result.notes).toEqual([]);
+      expect(result.status).toBe("not-indexed");
+      expect(mockFileStatus).toHaveBeenCalledWith("http://127.0.0.1:8742", "vault", "source.md");
+      expect(mockedGetLinkedNotes).not.toHaveBeenCalled();
+      expect(mockedGetBacklinkedNotes).not.toHaveBeenCalled();
+      expect(mockedLogError).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      new MiyoRequestError(501, "not supported", "other_error"),
+      new MiyoRequestError(501, "not_implemented"),
+      new MiyoRequestError(404, "Folder unavailable"),
+      new Error("network down"),
+    ])(
+      "returns no graph-only rows when file status fails with $message (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)",
+      async (statusError) => {
+        mockSearchRelated.mockRejectedValue(
+          new MiyoRequestError(404, "No indexed chunks found for file_path")
+        );
+        mockFileStatus.mockRejectedValue(statusError);
+        mockedGetBacklinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);
+
+        const result = await findRelevantNotes({
+          app: window.app,
+          filePath: "source.md",
+        });
+
+        expect(result).toEqual({ notes: [], status: "unavailable" });
+        expect(mockedGetLinkedNotes).not.toHaveBeenCalled();
+        expect(mockedGetBacklinkedNotes).not.toHaveBeenCalled();
+        expect(mockedLogError).toHaveBeenCalledTimes(1);
+      }
+    );
+
+    it("returns no graph-only rows for an unknown file-status classification (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+      mockSearchRelated.mockRejectedValue(
+        new MiyoRequestError(404, "No indexed chunks found for file_path")
+      );
+      mockFileStatus.mockResolvedValue({ status: "future_status", file_path: "source.md" });
       mockedGetBacklinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);
 
       const result = await findRelevantNotes({
@@ -402,13 +523,13 @@ describe("findRelevantNotes", () => {
       expect(mockedLogError).toHaveBeenCalledTimes(1);
     });
 
-    it("reports unavailable when the registration probe times out (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
+    it("reports unavailable when the file-status request times out (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
       jest.useFakeTimers();
       try {
         mockSearchRelated.mockRejectedValue(
           new MiyoRequestError(404, "No indexed chunks found for file_path")
         );
-        mockGetFolder.mockReturnValue(new Promise(() => undefined));
+        mockFileStatus.mockReturnValue(new Promise(() => undefined));
 
         const resultPromise = findRelevantNotes({
           app: window.app,
@@ -438,7 +559,7 @@ describe("findRelevantNotes", () => {
         await jest.advanceTimersByTimeAsync(8000);
 
         await expect(resultPromise).resolves.toEqual({ notes: [], status: "unavailable" });
-        expect(mockGetFolder).not.toHaveBeenCalled();
+        expect(mockFileStatus).not.toHaveBeenCalled();
         expect(mockedGetLinkedNotes).not.toHaveBeenCalled();
       } finally {
         jest.useRealTimers();
@@ -473,7 +594,7 @@ describe("findRelevantNotes", () => {
       });
 
       expect(result.status).toBe("unavailable");
-      expect(mockGetFolder).not.toHaveBeenCalled();
+      expect(mockFileStatus).not.toHaveBeenCalled();
       expect(mockedLogError).toHaveBeenCalledTimes(1);
     });
   });

--- a/src/search/findRelevantNotes.test.ts
+++ b/src/search/findRelevantNotes.test.ts
@@ -87,7 +87,7 @@ describe("findRelevantNotes", () => {
       );
       mockResolveBaseUrl.mockResolvedValue("http://127.0.0.1:8742");
       mockSearchRelated.mockResolvedValue({ results: [] });
-      mockFileStatus.mockResolvedValue({ status: "pending", file_path: "source.md" });
+      mockFileStatus.mockResolvedValue({ status: "pending" });
       mockedMiyoClient.mockImplementation(() => ({
         resolveBaseUrl: mockResolveBaseUrl,
         searchRelated: mockSearchRelated,
@@ -333,7 +333,7 @@ describe("findRelevantNotes", () => {
       "classifies every related-search 404 regardless of detail %p (https://github.com/Brevilabs/obsidian-copilot-private/issues/280; https://github.com/logancyang/obsidian-copilot/pull/2992#discussion_r3919646861)",
       async (detail) => {
         mockSearchRelated.mockRejectedValue(new MiyoRequestError(404, detail));
-        mockFileStatus.mockResolvedValue({ status: "pending", file_path: "source.md" });
+        mockFileStatus.mockResolvedValue({ status: "pending" });
 
         const result = await findRelevantNotes({
           app: window.app,
@@ -341,40 +341,34 @@ describe("findRelevantNotes", () => {
         });
 
         expect(result.status).toBe("indexing");
-        expect(mockFileStatus).toHaveBeenCalledWith("http://127.0.0.1:8742", "vault", "source.md");
+        expect(mockFileStatus).toHaveBeenCalledWith("http://127.0.0.1:8742", "vault/source.md");
       }
     );
 
     it.each([
       {
-        fileStatus: { status: "indexed", file_path: "source.md", total_chunks: 4 },
-        expectedStatus: "no-matches",
-        expectedDetails: undefined,
-      },
-      {
-        fileStatus: { status: "indexed", file_path: "source.md", total_chunks: 0 },
+        fileStatus: { status: "indexed", total_chunks: 0 },
         expectedStatus: "no-text",
         expectedDetails: undefined,
       },
       {
-        fileStatus: { status: "pending", file_path: "source.md" },
+        fileStatus: { status: "pending" },
         expectedStatus: "indexing",
         expectedDetails: undefined,
       },
       {
-        fileStatus: { status: "not_scanned", file_path: "source.md" },
+        fileStatus: { status: "not_scanned" },
         expectedStatus: "indexing",
         expectedDetails: undefined,
       },
       {
-        fileStatus: { status: "missing", file_path: "source.md" },
+        fileStatus: { status: "missing" },
         expectedStatus: "indexing",
         expectedDetails: undefined,
       },
       {
         fileStatus: {
           status: "error",
-          file_path: "source.md",
           error_message: "Markdown parser failed",
         },
         expectedStatus: "index-error",
@@ -383,7 +377,6 @@ describe("findRelevantNotes", () => {
       {
         fileStatus: {
           status: "excluded",
-          file_path: "source.md",
           reason: "exclude_pattern",
           rule: "private/**",
         },
@@ -410,7 +403,7 @@ describe("findRelevantNotes", () => {
         expect(result.notes).toEqual([]);
         expect(result.status).toBe(expectedStatus);
         expect(result.details).toEqual(expectedDetails);
-        expect(mockFileStatus).toHaveBeenCalledWith("http://127.0.0.1:8742", "vault", "source.md");
+        expect(mockFileStatus).toHaveBeenCalledWith("http://127.0.0.1:8742", "vault/source.md");
         expect(mockedGetMiyoFilePath).toHaveBeenCalledWith(window.app, "source.md");
         expect(mockedGetLinkedNotes).not.toHaveBeenCalled();
         expect(mockedGetBacklinkedNotes).not.toHaveBeenCalled();
@@ -457,6 +450,41 @@ describe("findRelevantNotes", () => {
       expect(mockedGetSettings).toHaveBeenCalledTimes(1);
     });
 
+    it("retries related search when indexing completes after the first 404 (https://github.com/logancyang/obsidian-copilot/pull/3088#discussion_r3921456717)", async () => {
+      mockSearchRelated
+        .mockRejectedValueOnce(new MiyoRequestError(404, "No indexed chunks found for file_path"))
+        .mockResolvedValueOnce({ results: [{ path: "vault/alpha.md", score: 0.82 }] });
+      mockFileStatus.mockResolvedValue({ status: "indexed", total_chunks: 4 });
+
+      const result = await findRelevantNotes({
+        app: window.app,
+        filePath: "source.md",
+      });
+
+      expect(result.status).toBe("matches");
+      expect(result.notes.map((entry) => entry.note.path)).toEqual(["alpha.md"]);
+      expect(mockSearchRelated).toHaveBeenCalledTimes(2);
+      expect(mockFileStatus).toHaveBeenCalledTimes(1);
+    });
+
+    it("reports unavailable when the indexed-race retry fails (https://github.com/logancyang/obsidian-copilot/pull/3088#discussion_r3921456717)", async () => {
+      mockSearchRelated
+        .mockRejectedValueOnce(new MiyoRequestError(404, "No indexed chunks found for file_path"))
+        .mockRejectedValueOnce(new MiyoRequestError(503, "Service unavailable"));
+      mockFileStatus.mockResolvedValue({ status: "indexed", total_chunks: 4 });
+      mockedGetLinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);
+
+      const result = await findRelevantNotes({
+        app: window.app,
+        filePath: "source.md",
+      });
+
+      expect(result).toEqual({ notes: [], status: "unavailable" });
+      expect(mockSearchRelated).toHaveBeenCalledTimes(2);
+      expect(mockedGetLinkedNotes).not.toHaveBeenCalled();
+      expect(mockedLogError).toHaveBeenCalledTimes(1);
+    });
+
     it("returns no link-only rows for the compatibility state from an exact old-Miyo response (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", async () => {
       mockSearchRelated.mockRejectedValue(
         new MiyoRequestError(404, "No indexed chunks found for file_path")
@@ -473,7 +501,7 @@ describe("findRelevantNotes", () => {
 
       expect(result.notes).toEqual([]);
       expect(result.status).toBe("not-indexed");
-      expect(mockFileStatus).toHaveBeenCalledWith("http://127.0.0.1:8742", "vault", "source.md");
+      expect(mockFileStatus).toHaveBeenCalledWith("http://127.0.0.1:8742", "vault/source.md");
       expect(mockedGetLinkedNotes).not.toHaveBeenCalled();
       expect(mockedGetBacklinkedNotes).not.toHaveBeenCalled();
       expect(mockedLogError).not.toHaveBeenCalled();
@@ -509,7 +537,7 @@ describe("findRelevantNotes", () => {
       mockSearchRelated.mockRejectedValue(
         new MiyoRequestError(404, "No indexed chunks found for file_path")
       );
-      mockFileStatus.mockResolvedValue({ status: "future_status", file_path: "source.md" });
+      mockFileStatus.mockResolvedValue({ status: "future_status" });
       mockedGetBacklinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);
 
       const result = await findRelevantNotes({

--- a/src/search/findRelevantNotes.ts
+++ b/src/search/findRelevantNotes.ts
@@ -1,5 +1,10 @@
 import { logError, logInfo } from "@/logger";
-import { MiyoClient, MiyoRequestError, type MiyoFileStatusReason } from "@/miyo/MiyoClient";
+import {
+  MiyoClient,
+  MiyoRequestError,
+  type MiyoFileStatusReason,
+  type MiyoRelatedSearchResponse,
+} from "@/miyo/MiyoClient";
 import {
   getMiyoCustomUrl,
   getMiyoFilePath,
@@ -50,11 +55,8 @@ async function searchRelatedNotesWithMiyo(
     return { scoreByPath: new Map(), status: "unavailable" };
   }
 
-  try {
-    // Obsidian's requestUrl can stay pending after a connection is accepted.
-    // Bound the primary request so unavailable guidance can replace loading.
-    // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
-    const response = await withTimeout(
+  const requestRelated = () =>
+    withTimeout(
       () =>
         miyoClient.searchRelated(baseUrl, miyoFilePath, {
           folderName,
@@ -63,6 +65,10 @@ async function searchRelatedNotesWithMiyo(
       MIYO_RELATED_SEARCH_TIMEOUT_MS,
       "Relevant Notes Miyo related search"
     );
+
+  const classifyRelatedResponse = (
+    response: MiyoRelatedSearchResponse
+  ): RelatedNotesSearchResult => {
     // A successful HTTP status without Miyo's result collection does not prove
     // a valid empty search. Keep recovery guidance visible for malformed peers.
     // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
@@ -106,6 +112,13 @@ async function searchRelatedNotesWithMiyo(
       scoreByPath,
       status: scoreByPath.size > 0 ? "matches" : "no-matches",
     };
+  };
+
+  try {
+    // Obsidian's requestUrl can stay pending after a connection is accepted.
+    // Bound the primary request so unavailable guidance can replace loading.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+    return classifyRelatedResponse(await requestRelated());
   } catch (error) {
     // Miyo defines every 404 from related search as a source with no indexed
     // chunks. The detail text is not part of that contract, so gating on it can
@@ -123,20 +136,30 @@ async function searchRelatedNotesWithMiyo(
 
     try {
       // A search miss does not distinguish indexing, filter, parse, and absent-file
-      // states. Ask Miyo for the source classification without converting the
-      // vault-relative path to the absolute path used by related search.
+      // states. Ask Miyo for the source classification using its public path.
       // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
       const fileStatus = await withTimeout(
-        () => miyoClient.fileStatus(baseUrl, folderName, filePath),
+        () => miyoClient.fileStatus(baseUrl, miyoFilePath),
         MIYO_FILE_STATUS_TIMEOUT_MS,
         "Relevant Notes Miyo file status"
       );
       switch (fileStatus.status) {
-        case "indexed":
-          return {
-            scoreByPath: new Map(),
-            status: fileStatus.total_chunks === 0 ? "no-text" : "no-matches",
-          };
+        case "indexed": {
+          if (fileStatus.total_chunks === 0) {
+            return { scoreByPath: new Map(), status: "no-text" };
+          }
+          try {
+            // Indexing can finish between the first 404 and this status response.
+            // Retry once so newly available semantic matches are not hidden.
+            // https://github.com/logancyang/obsidian-copilot/pull/3088#discussion_r3921456717
+            return classifyRelatedResponse(await requestRelated());
+          } catch (retryError) {
+            logError(
+              `RelevantNotes(Miyo): searchRelated retry failed for file_path=${miyoFilePath} folder_name=${folderName}: ${(retryError as Error).message}`
+            );
+            return { scoreByPath: new Map(), status: "unavailable" };
+          }
+        }
         case "pending":
         case "not_scanned":
         case "missing":
@@ -145,7 +168,7 @@ async function searchRelatedNotesWithMiyo(
           return {
             scoreByPath: new Map(),
             status: "index-error",
-            details: { errorMessage: fileStatus.error_message },
+            details: { errorMessage: fileStatus.error_message ?? undefined },
           };
         case "excluded":
           return {

--- a/src/search/findRelevantNotes.ts
+++ b/src/search/findRelevantNotes.ts
@@ -1,5 +1,5 @@
 import { logError, logInfo } from "@/logger";
-import { MiyoClient, MiyoRequestError } from "@/miyo/MiyoClient";
+import { MiyoClient, MiyoRequestError, type MiyoFileStatusReason } from "@/miyo/MiyoClient";
 import {
   getMiyoCustomUrl,
   getMiyoFilePath,
@@ -14,7 +14,7 @@ import { App, TFile } from "obsidian";
 
 const MAX_RESULTS = 20;
 const MIYO_RELATED_SEARCH_TIMEOUT_MS = 8000;
-const MIYO_FOLDER_LOOKUP_TIMEOUT_MS = 8000;
+const MIYO_FILE_STATUS_TIMEOUT_MS = 8000;
 
 /**
  * Fetch Miyo's ordered related-note results.
@@ -122,21 +122,62 @@ async function searchRelatedNotesWithMiyo(
     }
 
     try {
-      // A registered folder proves setup is healthy, but Miyo cannot tell
-      // whether this particular path is still indexing or excluded.
+      // A search miss does not distinguish indexing, filter, parse, and absent-file
+      // states. Ask Miyo for the source classification without converting the
+      // vault-relative path to the absolute path used by related search.
       // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
-      await withTimeout(
-        () => miyoClient.getFolder(baseUrl, folderName),
-        MIYO_FOLDER_LOOKUP_TIMEOUT_MS,
-        "Relevant Notes Miyo folder lookup"
+      const fileStatus = await withTimeout(
+        () => miyoClient.fileStatus(baseUrl, folderName, filePath),
+        MIYO_FILE_STATUS_TIMEOUT_MS,
+        "Relevant Notes Miyo file status"
       );
-      return { scoreByPath: new Map(), status: "not-indexed" };
-    } catch (folderError) {
-      // Without a successful folder probe, Copilot cannot distinguish an
-      // unindexed note from a broken Miyo setup, so recovery must stay generic.
+      switch (fileStatus.status) {
+        case "indexed":
+          return {
+            scoreByPath: new Map(),
+            status: fileStatus.total_chunks === 0 ? "no-text" : "no-matches",
+          };
+        case "pending":
+        case "not_scanned":
+        case "missing":
+          return { scoreByPath: new Map(), status: "indexing" };
+        case "error":
+          return {
+            scoreByPath: new Map(),
+            status: "index-error",
+            details: { errorMessage: fileStatus.error_message },
+          };
+        case "excluded":
+          return {
+            scoreByPath: new Map(),
+            status: "excluded",
+            details: {
+              exclusionReason: fileStatus.reason,
+              exclusionRule: fileStatus.rule,
+            },
+          };
+        default:
+          // Unknown classifications must not expose graph-only rows as if Miyo
+          // had confirmed a healthy state.
+          // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+          logError(
+            `RelevantNotes(Miyo): unknown file status for file_path=${filePath} folder_name=${folderName}: ${String(fileStatus.status)}`
+          );
+          return { scoreByPath: new Map(), status: "unavailable" };
+      }
+    } catch (statusError) {
+      // Old Miyo builds use this exact structured response for unknown routes.
+      // Other 501s are real failures and must not be misreported as compatibility.
       // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
+      if (
+        statusError instanceof MiyoRequestError &&
+        statusError.status === 501 &&
+        statusError.errorCode === "not_implemented"
+      ) {
+        return { scoreByPath: new Map(), status: "not-indexed" };
+      }
       logError(
-        `RelevantNotes(Miyo): source has no indexed chunks and folder lookup failed for folder_name=${folderName}: ${(folderError as Error).message}`
+        `RelevantNotes(Miyo): source has no indexed chunks and file status failed for file_path=${filePath} folder_name=${folderName}: ${(statusError as Error).message}`
       );
       return { scoreByPath: new Map(), status: "unavailable" };
     }
@@ -147,12 +188,23 @@ export type RelevantNotesSearchStatus =
   | "disabled"
   | "matches"
   | "no-matches"
+  | "no-text"
+  | "indexing"
+  | "index-error"
+  | "excluded"
   | "not-indexed"
   | "unavailable";
+
+export interface RelevantNotesStatusDetails {
+  errorMessage?: string;
+  exclusionReason?: MiyoFileStatusReason;
+  exclusionRule?: string;
+}
 
 interface RelatedNotesSearchResult {
   scoreByPath: Map<string, number>;
   status: RelevantNotesSearchStatus;
+  details?: RelevantNotesStatusDetails;
 }
 
 /**
@@ -198,6 +250,7 @@ export interface RelevantNoteEntry {
 export interface RelevantNotesResult {
   notes: readonly RelevantNoteEntry[];
   status: RelevantNotesSearchStatus;
+  details?: RelevantNotesStatusDetails;
 }
 
 const EMPTY_RELEVANT_NOTES: readonly RelevantNoteEntry[] = Object.freeze([]);
@@ -241,13 +294,17 @@ export async function findRelevantNotes({
     return { notes: EMPTY_RELEVANT_NOTES, status: "unavailable" };
   }
 
-  const { scoreByPath, status } = await searchRelatedNotesWithMiyo(app, filePath, settings);
+  const { scoreByPath, status, details } = await searchRelatedNotesWithMiyo(
+    app,
+    filePath,
+    settings
+  );
   // Every result row must come from Miyo. Showing link-only rows for any empty
   // search state makes Relevant Notes look partially functional without the
   // index that defines relevance.
   // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
   if (status !== "matches") {
-    return { notes: EMPTY_RELEVANT_NOTES, status };
+    return { notes: EMPTY_RELEVANT_NOTES, status, details };
   }
   const noteLinks = getNoteLinks(app, file);
 
@@ -272,5 +329,5 @@ export async function findRelevantNotes({
       };
     })
     .filter((entry) => entry !== null);
-  return { notes: notes.length === 0 ? EMPTY_RELEVANT_NOTES : notes, status };
+  return { notes: notes.length === 0 ? EMPTY_RELEVANT_NOTES : notes, status, details };
 }


### PR DESCRIPTION
Fixes Brevilabs/obsidian-copilot-private#280

## Why

When Miyo cannot find indexed chunks for the active note, Relevant Notes currently shows one ambiguous message. The note may still be indexing, contain no readable text, have failed during indexing, or be excluded by a folder filter. Those cases need different explanations and recovery actions.

Older Miyo builds do not expose this detail and must keep working without a forced upgrade.

## What

After a related-search miss, Copilot asks Miyo for the active file's status using Miyo's public `FolderName/path/to/file` format and renders the matching card. If indexing completes between the miss and status response, Copilot retries related search once so newly available matches are not hidden.

| Miyo state | Result | Action |
| --- | --- | --- |
| Indexed with no text | **Miyo found no text in this note** | **Refresh** |
| Pending, not scanned, or missing | **Miyo is still indexing this note** | **Refresh** |
| Indexing error | **Miyo couldn't index this note** with Miyo's message | **Open Miyo** locally; host-machine guidance remotely |
| Excluded | **This note is excluded in Miyo** with the matching rule | **Open folder settings in Miyo** locally; host-machine guidance remotely |
| Endpoint unavailable on an older build | **This note isn't indexed in Miyo** with update guidance | **Refresh** and the existing local or remote review action |

Links and backlinks remain visible after Miyo classifies the missing note. A failed status request remains an unavailable state with no partial rows.

## Non goal

- Changing Miyo's API, indexing rules, or folder filters.
- Polling Miyo, starting a scan, or caching endpoint capability.
- Changing ranking, result limits, or link and backlink collection.
- Applying Copilot's inclusion or exclusion patterns to Relevant Notes.

## Screenshot

Captured in Obsidian 1.13.7 with Copilot build `1e04de41-clean-483dcd973c56`, Miyo 0.2.23 (`02b5654`), and Miyo `main@8dade30` after Brevilabs/miyo#551 and Brevilabs/miyo#552.

| Older Miyo 0.2.23 | New Miyo: not scanned |
| --- | --- |
| ![Older Miyo falls back to the update guidance card](https://github.com/user-attachments/assets/7e902b20-4fa2-4a0d-8f3c-73e88c02f562) | ![New Miyo identifies the same note as still indexing](https://github.com/user-attachments/assets/8c75eec0-595d-43e1-bb5e-738417f10eeb) |

| New Miyo: indexed with no text | New Miyo: excluded locally |
| --- | --- |
| ![An empty indexed note shows the no-text card](https://github.com/user-attachments/assets/832613dc-5b48-4cae-a8cf-87b827e9c53e) | ![An excluded note shows its matching rule and local Miyo action](https://github.com/user-attachments/assets/534f2081-b928-4ac3-841a-f632614bdf71) |

| Remote Miyo | Status request unavailable |
| --- | --- |
| ![A remote endpoint shows host-machine guidance without a local action](https://github.com/user-attachments/assets/ea9a3736-5d60-4ebe-97e7-978f8096338b) | ![A failed status request shows setup guidance and hides graph rows](https://github.com/user-attachments/assets/edcf2896-b797-44bd-8f3a-41ebb3154b6c) |

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Client, search, presentation, pane, and container tests cover every introduced state and action |
| A defect would fail CI or be obvious on first use | ✅ | Contract tests cover old and new responses, and a mismatch surfaces on the next Relevant Notes miss |
| A revert fully restores prior state, including persisted data | ✅ | The change does not write or migrate persisted data |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | The pane now renders Miyo-provided error messages and exclusion rules |
| No public API, plugin API, message, or on-disk contract changes | ✅ | The new status and detail types stay inside the plugin |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | The optional Relevant Notes miss path extends its existing bounded request flow |
| No hot-path behavior lacks deterministic coverage | ✅ | Status, timeout, unknown response, stale request, retry, and old-build fallback paths are covered |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | The cards and deep-link destination appear on the next Relevant Notes request |

Review: inspect `MiyoClient.fileStatus()` and `MiyoClient.requestJson()` in `src/miyo/MiyoClient.ts`, `searchRelatedNotesWithMiyo()` in `src/search/findRelevantNotes.ts`, and the `index-error` and `excluded` cases in `RelevantNotesPane()` in `src/components/chat-components/ui/RelevantNotesPane.tsx` line by line; then run Verification steps 2–6, including the path-bearing error, unknown-status, and failed-status variants.

## Verification

1. Load this branch in an isolated Obsidian test vault and connect a Miyo build containing Brevilabs/miyo#551 and Brevilabs/miyo#552.
2. Open an indexed note with zero chunks and confirm **Miyo found no text in this note** appears with **Refresh**.
3. Open pending, not-scanned, and newly missing notes and confirm each shows **Miyo is still indexing this note** while retaining link and backlink rows.
4. Force an indexing error whose message contains a machine path and an exclusion rule containing punctuation. Confirm both render as inert text, and the local actions open the registered vault's folder settings in Miyo.
5. Repeat the error and exclusion cases with a remote endpoint or mobile device. Confirm Copilot shows host-machine guidance and no local-app action.
6. Connect a Miyo build predating Brevilabs/miyo#551. Confirm the old-build card includes **Update Miyo to see why**. Then return an unknown status and fail the status request; confirm both show **Check your Miyo setup** with no rows.

## Note

Miyo parser errors can contain absolute host paths, and Copilot currently displays that text verbatim in the indexing-error card. With a remote Miyo endpoint, this exposes host-specific usernames and directories to the connected Copilot client; screenshots or support captures can expose them further. The error-state screenshot is intentionally omitted above.
