### PR TITLE
[Miyo-only search] - Step 5: Retire legacy index settings

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -22,6 +22,7 @@ Symposium is now [OpenArtifacts](https://openartifacts.ai). Every new page your 
 ## ✨ Enhancements
 
 - **Quick Chat now has two clear modes.** Chat (free) answers from context you attach, while Copilot Plus can search your vault with Miyo when it is enabled or keyword search when it is disabled. The retired Vault QA mode now opens as Chat (free), and Free Chat and Copilot Plus remain separate experiences. (@zeroliu)
+- **Old Copilot index files are cleaned up automatically.** Copilot no longer keeps settings or files for its retired local embedding index. On upgrade, it removes only recognized index artifacts and leaves every other vault and Obsidian configuration file alone. (@zeroliu)
 - **Browse all Recent Chats in one place.** The searchable list now loads older chats as you scroll instead of opening a second **View all chats** window. ([#3040](https://github.com/logancyang/obsidian-copilot/issues/3040), [#3041](https://github.com/logancyang/obsidian-copilot/pull/3041), @logancyang)
 - **Questions and permission requests stay in view.** Agent Chat keeps actions above the composer even when you are reading earlier output, and concurrent Claude chats no longer show another session's request. ([#2948](https://github.com/logancyang/obsidian-copilot/issues/2948), [#3067](https://github.com/logancyang/obsidian-copilot/pull/3067), @brevilabs-agent-bot)
 

--- a/docs/vault-search-and-indexing.md
+++ b/docs/vault-search-and-indexing.md
@@ -8,6 +8,8 @@ Miyo is a local-first knowledge service built for more than one plugin. It can s
 
 Semantic search from Copilot V3 has moved to Miyo. Connect Miyo and enable its semantic-search Skill for a more powerful local-first path. Copilot no longer exposes controls for its old in-plugin index.
 
+When you upgrade, Copilot removes its retired index settings and recognized index files. It deletes only files that match Copilot's exact legacy index naming scheme. Other files in your vault and Obsidian configuration folder are left alone. If cleanup fails, Copilot names the folder so you can remove the old index files manually.
+
 ## How Agent Chat searches
 
 Agent Chat can combine three kinds of search:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -505,8 +505,6 @@ export const BUILTIN_CHAT_MODELS: CustomModel[] = [
   },
 ];
 
-const EMPTY_EMBEDDING_MODELS = Object.freeze([]) as unknown as CustomModel[];
-
 export type Provider = ChatModelProviders;
 
 export type SettingKeyProviders = Exclude<
@@ -783,11 +781,9 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   siliconflowApiKey: "",
   defaultChainType: ChainType.LLM_CHAIN,
   defaultModelKey: ChatModels.OPENROUTER_GEMINI_2_5_FLASH + "|" + ChatModelProviders.OPENROUTERAI,
-  embeddingModelKey: "",
   contextTurns: 15,
   userSystemPrompt: "",
   openAIProxyBaseUrl: "",
-  openAIEmbeddingProxyBaseUrl: "",
   stream: true,
   copilotFolder: DEFAULT_COPILOT_FOLDER,
   // Every folder ever activated as the Copilot root (seeded with the legacy
@@ -804,22 +800,15 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   defaultOpenArea: DEFAULT_OPEN_AREA.VIEW,
   defaultSendShortcut: SEND_SHORTCUT.ENTER,
   customPromptsFolder: DEFAULT_CUSTOM_PROMPTS_FOLDER,
-  indexVaultToVectorStore: "ON MODE SWITCH",
   qaExclusions: DEFAULT_QA_EXCLUSIONS_SETTING,
   qaInclusions: "",
   chatNoteContextPath: "",
   chatNoteContextTags: [],
-  enableIndexSync: true,
   debug: false,
   maxSourceChunks: DEFAULT_MAX_SOURCE_CHUNKS,
   enableInlineCitations: true,
   groqApiKey: "",
   activeModels: BUILTIN_CHAT_MODELS,
-  activeEmbeddingModels: EMPTY_EMBEDDING_MODELS,
-  embeddingRequestsPerMin: 60,
-  embeddingBatchSize: 16,
-  disableIndexOnMobile: true,
-  numPartitions: 1,
   lexicalSearchRamLimit: 100, // Default 100 MB
   promptUsageTimestamps: {},
   promptSortStrategy: PromptSortStrategy.TIMESTAMP,
@@ -833,7 +822,6 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   passMarkdownImages: true,
   enableAutonomousAgent: true,
   enableCustomPromptTemplating: true,
-  enableSemanticSearchV3: false,
   enableSelfHostMode: false,
   enableMiyo: false,
   enableMiyoSearchSkill: false,

--- a/src/main.ts
+++ b/src/main.ts
@@ -263,7 +263,15 @@ export default class CopilotPlugin extends Plugin {
     // agent/model-discovery init below — so migrated BYOK providers are present
     // when OpenCode first enumerates models. Awaited for deterministic ordering;
     // it's a fast, one-time, no-op for already-migrated/fresh vaults.
-    await runSettingsMigrations(this.modelManagement);
+    await runSettingsMigrations(this.modelManagement, {
+      adapter: this.app.vault.adapter,
+      configDir: this.app.vault.configDir,
+      notifyFailure: (folder) => {
+        new Notice(
+          `Copilot couldn't remove old index files from ${folder}. Remove them manually if you want to reclaim the space.`
+        );
+      },
+    });
     const isLegacyUpgrade = getSettings().upgradedToV8FromLegacy;
     this.addSettingTab(new CopilotSettingTab(this.app, this));
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,6 +61,10 @@ import {
 } from "@/services/webViewerService/webViewerServiceSingleton";
 import { WebSelectionTracker } from "@/services/webViewerService/webViewerServiceSelection";
 import { runSettingsMigrations } from "@/settings/migrations";
+import {
+  cleanupLegacyIndexArtifacts,
+  LEGACY_INDEX_CLEANUP_STORAGE_KEY,
+} from "@/settings/migrations/legacyIndexRemovalMigration";
 import { CopilotSettingTab } from "@/settings/SettingsPage";
 import {
   type CopilotSettings,
@@ -263,9 +267,18 @@ export default class CopilotPlugin extends Plugin {
     // agent/model-discovery init below — so migrated BYOK providers are present
     // when OpenCode first enumerates models. Awaited for deterministic ordering;
     // it's a fast, one-time, no-op for already-migrated/fresh vaults.
-    await runSettingsMigrations(this.modelManagement, {
+    await runSettingsMigrations(this.modelManagement);
+    // Remnants of the retired index pipeline live on this device, not in the
+    // synced settings, so they are gated by a device-local marker instead of
+    // `settingsVersion`. Not awaited: nothing below reads its result.
+    // https://github.com/logancyang/obsidian-copilot/pull/3094#discussion_r3926692787
+    void cleanupLegacyIndexArtifacts({
       adapter: this.app.vault.adapter,
       configDir: this.app.vault.configDir,
+      hasRun: () => this.app.loadLocalStorage(LEGACY_INDEX_CLEANUP_STORAGE_KEY) === "done",
+      markRun: () => this.app.saveLocalStorage(LEGACY_INDEX_CLEANUP_STORAGE_KEY, "done"),
+      removeRetiredEmbeddingSecrets: () =>
+        KeychainService.getInstance().removeRetiredEmbeddingSecrets(),
       notifyFailure: (folder) => {
         new Notice(
           `Copilot couldn't remove old index files from ${folder}. Remove them manually if you want to reclaim the space.`

--- a/src/miyo/miyoRuntimePolicy.ts
+++ b/src/miyo/miyoRuntimePolicy.ts
@@ -31,9 +31,6 @@ export function getMiyoCustomUrl(settings: CopilotSettings): string {
  * Miyo is free: there is no self-host license / validation gate here anymore
  * (Layer C — "open Miyo"). On desktop, enabling Miyo is all it takes.
  *
- * The legacy `enableSemanticSearchV3` setting does not participate in runtime
- * routing; it remains persisted only until the settings cleanup migration.
- *
  * @param settings - Current Copilot settings.
  */
 export function shouldUseMiyo(settings: CopilotSettings): boolean {

--- a/src/search/RetrieverFactory.test.ts
+++ b/src/search/RetrieverFactory.test.ts
@@ -48,10 +48,8 @@ describe("RetrieverFactory", () => {
         });
       });
 
-      it("uses lexical search even when a legacy semantic flag remains https://github.com/Brevilabs/obsidian-copilot-private/issues/281", async () => {
-        const result = await RetrieverFactory.createRetriever(app, options, {
-          enableSemanticSearchV3: true,
-        });
+      it("uses lexical search when Miyo is not the active backend", async () => {
+        const result = await RetrieverFactory.createRetriever(app, options);
 
         expect(result).toEqual({
           retriever: lexicalRetriever,
@@ -83,7 +81,7 @@ describe("RetrieverFactory", () => {
         jest.mocked(getSearchBackend).mockReturnValueOnce("miyo").mockReturnValueOnce("keyword");
 
         expect(RetrieverFactory.getRetrieverType()).toBe("semantic");
-        expect(RetrieverFactory.getRetrieverType({ enableSemanticSearchV3: true })).toBe("lexical");
+        expect(RetrieverFactory.getRetrieverType()).toBe("lexical");
       });
     });
 

--- a/src/services/keychainService.test.ts
+++ b/src/services/keychainService.test.ts
@@ -534,6 +534,35 @@ describe("keychainService", () => {
     // clearAllVaultSecrets — partial-failure surface area
     // ---------------------------------------------------------------------------
 
+    describe("removeRetiredEmbeddingSecrets()", () => {
+      it("deletes only this vault's embedding-scoped model credentials (https://github.com/logancyang/obsidian-copilot/pull/3094#discussion_r3926692782)", () => {
+        const secretStorage = makeSecretStorage();
+        const service = KeychainService.getInstance(makeApp({ secretStorage }));
+        const vaultId = service.getVaultId();
+        const retired = `copilot-v${vaultId}-model-api-key-embedding-text-embedding-3-small`;
+        secretStorage.listSecrets.mockReturnValue([
+          retired,
+          `copilot-v${vaultId}-model-api-key-chat-gpt-4o`,
+          `copilot-v${vaultId}-open-a-i-api-key`,
+          "copilot-vother000-model-api-key-embedding-text-embedding-3-small",
+        ]);
+
+        service.removeRetiredEmbeddingSecrets();
+
+        expect(secretStorage.deleteSecret).toHaveBeenCalledTimes(1);
+        expect(secretStorage.deleteSecret).toHaveBeenCalledWith(retired);
+      });
+
+      it("leaves entries alone when the build cannot enumerate them", () => {
+        const secretStorage = makeSecretStorage();
+        (secretStorage as unknown as { listSecrets: unknown }).listSecrets = undefined;
+        const service = KeychainService.getInstance(makeApp({ secretStorage }));
+
+        expect(() => service.removeRetiredEmbeddingSecrets()).not.toThrow();
+        expect(secretStorage.deleteSecret).not.toHaveBeenCalled();
+      });
+    });
+
     describe("clearAllVaultSecrets()", () => {
       it("clears what it can, then throws aggregating the count of failed entries", () => {
         const secretStorage = makeSecretStorage();

--- a/src/services/keychainService.test.ts
+++ b/src/services/keychainService.test.ts
@@ -80,11 +80,6 @@ jest.mock("@/services/settingsSecretTransforms", () => ({
         apiKey: "",
       }));
     }
-    if (Array.isArray(out.activeEmbeddingModels)) {
-      out.activeEmbeddingModels = (out.activeEmbeddingModels as Array<Record<string, unknown>>).map(
-        (m) => ({ ...m, apiKey: "" })
-      );
-    }
     return out;
   }),
   cleanupLegacyFields: jest.fn((settings: Record<string, unknown>) => ({ ...settings })),
@@ -100,7 +95,6 @@ import { KeychainService, isSecretKey } from "./keychainService";
 function makeSettings(overrides: Partial<CopilotSettings> = {}): CopilotSettings {
   return {
     activeModels: [],
-    activeEmbeddingModels: [],
     ...overrides,
   } as unknown as CopilotSettings;
 }
@@ -366,7 +360,6 @@ describe("keychainService", () => {
           openAIApiKey: "sk-current",
           googleApiKey: "",
           activeModels: [makeModel({ name: "kept", provider: "openai", apiKey: "chat-secret" })],
-          activeEmbeddingModels: [],
         });
 
         const prev = makeSettings({
@@ -375,9 +368,6 @@ describe("keychainService", () => {
           activeModels: [
             makeModel({ name: "kept", provider: "openai", apiKey: "chat-prev" }),
             makeModel({ name: "deleted", provider: "openai", apiKey: "del-secret" }),
-          ],
-          activeEmbeddingModels: [
-            makeModel({ name: "del-embed", provider: "openai", apiKey: "embed-secret" }),
           ],
         });
 
@@ -393,10 +383,6 @@ describe("keychainService", () => {
         expect(result.keychainIdsToDelete.some((id) => id.includes("model-api-key-chat"))).toBe(
           true
         );
-        expect(
-          result.keychainIdsToDelete.some((id) => id.includes("model-api-key-embedding"))
-        ).toBe(true);
-
         // Reason: persistSecrets must not mutate the input settings objects
         expect(current.openAIApiKey).toBe("sk-current");
         expect(current.activeModels[0].apiKey).toBe("chat-secret");

--- a/src/services/keychainService.ts
+++ b/src/services/keychainService.ts
@@ -468,6 +468,35 @@ export class KeychainService {
   }
 
   // ---------------------------------------------------------------------------
+  // removeRetiredEmbeddingSecrets — drop credentials the embedding pipeline owned
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Delete this vault's embedding-scoped model credentials.
+   *
+   * The retired `activeEmbeddingModels` rows are stripped from settings on
+   * load, so no later save can name those identities to tombstone them. Their
+   * keychain entries carry the embedding scope in their ID, which stays
+   * enumerable after the rows are gone.
+   * https://github.com/logancyang/obsidian-copilot/pull/3094#discussion_r3926692782
+   */
+  removeRetiredEmbeddingSecrets(): void {
+    // Older Obsidian builds cannot enumerate entries. Nothing else can identify
+    // them once the rows are stripped, so leave them rather than guessing.
+    if (typeof this.storage.listSecrets !== "function") return;
+
+    const retiredPrefix = `copilot-v${this.vaultId}-model-api-key-embedding-`;
+    for (const id of this.storage.listSecrets()) {
+      if (!id.startsWith(retiredPrefix)) continue;
+      try {
+        this.removeSecret(id);
+      } catch (error) {
+        logWarn(`Keychain: failed to remove retired embedding secret ${id}`, error);
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
   // clearAllVaultSecrets — wipe all keychain entries for this vault
   // ---------------------------------------------------------------------------
 

--- a/src/services/keychainService.ts
+++ b/src/services/keychainService.ts
@@ -25,12 +25,10 @@ const EXTRA_SECRET_KEYS: readonly string[] = [];
 type ModelSecretField = (typeof MODEL_SECRET_FIELDS)[number];
 
 /**
- * Scope distinguishing chat models from embedding models in keychain IDs.
- * Reason: `activeModels` and `activeEmbeddingModels` can contain models with
- * the same `name|provider` identity but different API keys. Without scope,
- * they'd collide in the keychain namespace.
+ * Scope retained in keychain IDs so existing chat-model credentials keep their
+ * stable namespace after the embedding pipeline's removal.
  */
-type ModelScope = "chat" | "embedding";
+type ModelScope = "chat";
 
 /**
  * Check whether a settings key should be stored in the OS keychain.
@@ -412,13 +410,6 @@ export class KeychainService {
     hydrated.activeModels = modelResult.models;
     hadFailures = hadFailures || modelResult.hadFailures;
 
-    const embeddingResult = await this.hydrateModelSecrets(
-      "embedding",
-      hydrated.activeEmbeddingModels ?? []
-    );
-    hydrated.activeEmbeddingModels = embeddingResult.models;
-    hadFailures = hadFailures || embeddingResult.hadFailures;
-
     if (hadFailures) {
       logWarn("Keychain hydrate: some keychain reads failed — values left as-is.");
     }
@@ -463,25 +454,12 @@ export class KeychainService {
       prevSettings?.activeModels,
       clearedSecretIds
     );
-    this.collectModelSecrets(
-      "embedding",
-      settings.activeEmbeddingModels,
-      secretEntries,
-      prevSettings?.activeEmbeddingModels,
-      clearedSecretIds
-    );
-
     // Find deleted models to clean up
     const keychainIdsToDelete = [
       ...this.getDeletedModelKeysForScope(
         "chat",
         prevSettings?.activeModels,
         settings.activeModels
-      ),
-      ...this.getDeletedModelKeysForScope(
-        "embedding",
-        prevSettings?.activeEmbeddingModels,
-        settings.activeEmbeddingModels
       ),
       ...clearedSecretIds,
     ];

--- a/src/services/settingsPersistence.test.ts
+++ b/src/services/settingsPersistence.test.ts
@@ -9,7 +9,6 @@ if (typeof window.structuredClone === "undefined") {
 function makeSettings(overrides: Partial<CopilotSettings> = {}): CopilotSettings {
   return {
     activeModels: [],
-    activeEmbeddingModels: [],
     openAIApiKey: "",
     ...overrides,
   } as unknown as CopilotSettings;
@@ -151,7 +150,6 @@ describe("settingsPersistence", () => {
           _keychainOnly: false,
           openAIApiKey: "enc_desk_legacy",
           activeModels: [{ name: "custom", provider: "openai", apiKey: "plaintext-disk-key" }],
-          activeEmbeddingModels: [],
         },
         saveData,
         backedUp

--- a/src/services/settingsSecretTransforms.test.ts
+++ b/src/services/settingsSecretTransforms.test.ts
@@ -10,7 +10,6 @@ import {
 function makeSettings(overrides: Partial<CopilotSettings> = {}): CopilotSettings {
   return {
     activeModels: [],
-    activeEmbeddingModels: [],
     ...overrides,
   } as unknown as CopilotSettings;
 }
@@ -54,9 +53,9 @@ describe("settingsSecretTransforms", () => {
         expected: true,
       },
       {
-        name: "detects an embedding-model secret",
+        name: "detects a secret in a retired model list (https://github.com/Brevilabs/obsidian-copilot-private/issues/283)",
         rawData: {
-          activeEmbeddingModels: [{ name: "embed", provider: "openai", apiKey: "secret" }],
+          retiredModels: [{ name: "embed", provider: "openai", apiKey: "secret" }],
         },
         expected: true,
       },
@@ -64,7 +63,7 @@ describe("settingsSecretTransforms", () => {
         name: "ignores malformed model entries and non-secret fields",
         rawData: {
           activeModels: [null, "bad-entry", { name: "gpt-4", provider: "openai" }],
-          activeEmbeddingModels: [{ name: "embed", provider: "openai", apiKey: "" }],
+          retiredModels: [{ name: "embed", provider: "openai", apiKey: "" }],
         },
         expected: false,
       },
@@ -79,9 +78,6 @@ describe("settingsSecretTransforms", () => {
         openAIApiKey: "sk-123",
         defaultModelKey: "gpt-4|openai",
         activeModels: [{ name: "gpt-4", provider: "openai", apiKey: "chat-secret", enabled: true }],
-        activeEmbeddingModels: [
-          { name: "embed", provider: "openai", apiKey: "embed-secret", enabled: true },
-        ],
       });
 
       const result = stripKeychainFields(settings);
@@ -90,7 +86,6 @@ describe("settingsSecretTransforms", () => {
       expect(result.openAIApiKey).toBe("");
       expect(result.defaultModelKey).toBe("gpt-4|openai");
       expect(result.activeModels[0].apiKey).toBe("");
-      expect(result.activeEmbeddingModels[0].apiKey).toBe("");
       expect(settings.openAIApiKey).toBe("sk-123");
       expect(settings.activeModels[0].apiKey).toBe("chat-secret");
     });
@@ -101,7 +96,6 @@ describe("settingsSecretTransforms", () => {
 
       expect(record.openAIApiKey).toBe("");
       expect(record.activeModels).toBeUndefined();
-      expect(record.activeEmbeddingModels).toBeUndefined();
     });
   });
 

--- a/src/services/settingsSecretTransforms.ts
+++ b/src/services/settingsSecretTransforms.ts
@@ -10,6 +10,7 @@
  */
 
 import { DEFAULT_SETTINGS } from "@/constants";
+import { stripLegacyIndexSettings } from "@/settings/migrations/legacyIndexSettings";
 import { type CopilotSettings } from "@/settings/model";
 import { type CustomModel } from "@/aiParams";
 // Reason: do NOT import from @/logger here. The logger depends on getSettings(),
@@ -72,9 +73,10 @@ export function hasPersistedSecrets(rawData: Record<string, unknown>): boolean {
     if (typeof value === "string" && value.length > 0) return true;
   }
 
-  // Check model-level secrets
-  for (const listKey of ["activeModels", "activeEmbeddingModels"] as const) {
-    const models = rawData[listKey];
+  // Scan every top-level model-like list so credentials in a retired list are
+  // backed up before the migration strips that list from persisted settings.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/283
+  for (const models of Object.values(rawData)) {
     if (!Array.isArray(models)) continue;
     for (const model of models) {
       if (!model || typeof model !== "object") continue;
@@ -120,10 +122,6 @@ export function stripKeychainFields(settings: CopilotSettings): CopilotSettings 
   if ("activeModels" in out) {
     out.activeModels = stripModelSecrets(settings.activeModels ?? []);
   }
-  if ("activeEmbeddingModels" in out) {
-    out.activeEmbeddingModels = stripModelSecrets(settings.activeEmbeddingModels ?? []);
-  }
-
   return out as unknown as CopilotSettings;
 }
 
@@ -155,7 +153,7 @@ function stripModelSecrets(models: CustomModel[]): CustomModel[] {
  * Returns a new object — does NOT mutate the input.
  */
 export function cleanupLegacyFields(settings: CopilotSettings): CopilotSettings {
-  const out = asRecord({ ...settings });
+  const out = asRecord(stripLegacyIndexSettings(settings));
   // Reason: these fields are from earlier dev iterations and should not persist.
   delete out.enableEncryption;
   delete out._keychainMigrated;

--- a/src/settings/migrations/azureRemovalMigration.test.ts
+++ b/src/settings/migrations/azureRemovalMigration.test.ts
@@ -79,8 +79,15 @@ function configuredModel(configuredModelId: string, providerId: string): Configu
   };
 }
 
-function settingsWith(overrides: Partial<CopilotSettings> = {}): CopilotSettings {
+function settingsWith(
+  overrides: Partial<CopilotSettings> & Record<string, unknown> = {}
+): CopilotSettings {
   return { ...DEFAULT_SETTINGS, ...overrides };
+}
+
+function embeddingSelection(plan: ReturnType<typeof planAzureRemoval>): string | undefined {
+  return (plan?.patch as Partial<CopilotSettings> & { embeddingModelKey?: string })
+    .embeddingModelKey;
 }
 
 beforeEach(() => {
@@ -118,14 +125,14 @@ describe("azureRemovalMigration", () => {
       const plan = planAzureRemoval(
         settingsWith({ embeddingModelKey: "azure-openai|azure openai" })
       );
-      expect(plan?.patch.embeddingModelKey).toBe(DEFAULT_SETTINGS.embeddingModelKey);
+      expect(embeddingSelection(plan)).toBe("");
     });
 
     it("repoints the pre-rename `azure_openai` embedding selection too (https://github.com/logancyang/obsidian-copilot/issues/2932)", () => {
       const plan = planAzureRemoval(
         settingsWith({ embeddingModelKey: "azure-openai|azure_openai" })
       );
-      expect(plan?.patch.embeddingModelKey).toBe(DEFAULT_SETTINGS.embeddingModelKey);
+      expect(embeddingSelection(plan)).toBe("");
     });
 
     it("acts on an embedding selection even when no Azure provider row exists (https://github.com/logancyang/obsidian-copilot/issues/2932)", () => {
@@ -135,7 +142,7 @@ describe("azureRemovalMigration", () => {
         settingsWith({ providers: {}, embeddingModelKey: "azure-openai|azure openai" })
       );
       expect(plan).not.toBeNull();
-      expect(plan?.patch.embeddingModelKey).toBe(DEFAULT_SETTINGS.embeddingModelKey);
+      expect(embeddingSelection(plan)).toBe("");
     });
 
     it("leaves an embedding selection on another provider alone", () => {
@@ -145,7 +152,7 @@ describe("azureRemovalMigration", () => {
           embeddingModelKey: "text-embedding-3-small|openai",
         })
       );
-      expect(plan?.patch.embeddingModelKey).toBeUndefined();
+      expect(embeddingSelection(plan)).toBeUndefined();
     });
 
     it("removes a legacy Azure chat model and the selection naming it (https://github.com/logancyang/obsidian-copilot/issues/2932)", () => {
@@ -196,7 +203,7 @@ describe("azureRemovalMigration", () => {
         settingsWith({ embeddingModelKey: "azure-openai|azure openai" })
       );
       expect(mockSetSettings).toHaveBeenCalledWith(
-        expect.objectContaining({ embeddingModelKey: DEFAULT_SETTINGS.embeddingModelKey })
+        expect.objectContaining({ embeddingModelKey: "" })
       );
     });
 

--- a/src/settings/migrations/azureRemovalMigration.ts
+++ b/src/settings/migrations/azureRemovalMigration.ts
@@ -13,7 +13,6 @@
  *    the shared removal cascade, and deletes the legacy top-level API key.
  */
 
-import { DEFAULT_SETTINGS } from "@/constants";
 import type { ModelManagementApi } from "@/modelManagement";
 import type { CopilotSettings } from "@/settings/model";
 import {
@@ -48,6 +47,14 @@ const REMOVED_LEGACY_SECRET_FIELD = "azureOpenAIApiKey";
 /** What `planAzureRemoval` found: the rows to cascade and the patch to write. */
 export type AzureRemovalPlan = RetiredProviderRemovalPlan;
 
+interface LegacyAzureSettings extends CopilotSettings {
+  embeddingModelKey?: string;
+}
+
+interface LegacyAzurePatch extends Partial<CopilotSettings> {
+  embeddingModelKey?: string;
+}
+
 /**
  * Pure planner: what it takes to remove every Azure provider and everything
  * pointing at one, or `null` when the vault never configured Azure.
@@ -73,7 +80,8 @@ export function planAzureRemoval(settings: CopilotSettings): AzureRemovalPlan | 
     REMOVED_PROVIDER_TYPE,
     REMOVED_LEGACY_PROVIDERS
   );
-  const patch: Partial<CopilotSettings> = { ...sharedPlan?.patch };
+  const patch: LegacyAzurePatch = { ...sharedPlan?.patch };
+  const legacySettings = settings as LegacyAzureSettings;
 
   // An Azure embedding selection outlives the provider that served it, and
   // `EmbeddingManager.getEmbeddingsAPI` throws `No embedding model found for:
@@ -82,8 +90,8 @@ export function planAzureRemoval(settings: CopilotSettings): AzureRemovalPlan | 
   // that already has an OpenRouter key, and for one that does not it asks for a
   // key instead of naming a provider that no longer exists.
   // https://github.com/logancyang/obsidian-copilot/issues/2932
-  if (referencesRetiredProvider(settings.embeddingModelKey ?? "", REMOVED_LEGACY_PROVIDERS)) {
-    patch.embeddingModelKey = DEFAULT_SETTINGS.embeddingModelKey;
+  if (referencesRetiredProvider(legacySettings.embeddingModelKey ?? "", REMOVED_LEGACY_PROVIDERS)) {
+    patch.embeddingModelKey = "";
   }
 
   const providerIds = sharedPlan?.providerIds ?? [];

--- a/src/settings/migrations/index.ts
+++ b/src/settings/migrations/index.ts
@@ -20,10 +20,6 @@ import { executeAzureRemoval } from "./azureRemovalMigration";
 import { executeBedrockRemoval } from "./bedrockRemovalMigration";
 import { executeByokMigration } from "./byokMigration";
 import { executeGitHubCopilotRemoval } from "./githubCopilotRemovalMigration";
-import {
-  cleanupLegacyIndexArtifacts,
-  type LegacyIndexCleanupContext,
-} from "./legacyIndexRemovalMigration";
 import { planOptionalCustomProviderAuthMigration } from "./optionalCustomProviderAuthMigration";
 import { planRequiresApiKeyBackfill } from "./requiresApiKeyMigration";
 import { CURRENT_SETTINGS_VERSION } from "./version";
@@ -35,12 +31,8 @@ export { CURRENT_SETTINGS_VERSION } from "./version";
  * settings are already at/above the target (migrated vaults, fresh installs).
  *
  * @param api - Model-management API used by provider migrations.
- * @param legacyIndexCleanup - Vault adapter boundary used by the v13 cleanup.
  */
-export async function runSettingsMigrations(
-  api: ModelManagementApi,
-  legacyIndexCleanup: LegacyIndexCleanupContext
-): Promise<void> {
+export async function runSettingsMigrations(api: ModelManagementApi): Promise<void> {
   const fromVersion = getSettings().settingsVersion ?? 0;
   if (fromVersion >= CURRENT_SETTINGS_VERSION) return;
 
@@ -133,14 +125,6 @@ export async function runSettingsMigrations(
   // back when the stored key resolves to nothing.
   if (fromVersion < 12) {
     await executeAzureRemoval(api, getSettings());
-  }
-
-  // v13: delete only exact legacy index artifacts through the mobile-safe vault
-  // adapter. Settings fields are stripped at every persistence boundary so an
-  // older synced client cannot restore them after this one-time cleanup.
-  // https://github.com/Brevilabs/obsidian-copilot-private/issues/283
-  if (fromVersion < 13) {
-    await cleanupLegacyIndexArtifacts(legacyIndexCleanup);
   }
 
   // Bump unconditionally after the migrations so a per-provider failure can't

--- a/src/settings/migrations/index.ts
+++ b/src/settings/migrations/index.ts
@@ -20,6 +20,10 @@ import { executeAzureRemoval } from "./azureRemovalMigration";
 import { executeBedrockRemoval } from "./bedrockRemovalMigration";
 import { executeByokMigration } from "./byokMigration";
 import { executeGitHubCopilotRemoval } from "./githubCopilotRemovalMigration";
+import {
+  cleanupLegacyIndexArtifacts,
+  type LegacyIndexCleanupContext,
+} from "./legacyIndexRemovalMigration";
 import { planOptionalCustomProviderAuthMigration } from "./optionalCustomProviderAuthMigration";
 import { planRequiresApiKeyBackfill } from "./requiresApiKeyMigration";
 import { CURRENT_SETTINGS_VERSION } from "./version";
@@ -29,8 +33,14 @@ export { CURRENT_SETTINGS_VERSION } from "./version";
 /**
  * Run pending one-time migrations and stamp the new version. No-op when
  * settings are already at/above the target (migrated vaults, fresh installs).
+ *
+ * @param api - Model-management API used by provider migrations.
+ * @param legacyIndexCleanup - Vault adapter boundary used by the v13 cleanup.
  */
-export async function runSettingsMigrations(api: ModelManagementApi): Promise<void> {
+export async function runSettingsMigrations(
+  api: ModelManagementApi,
+  legacyIndexCleanup: LegacyIndexCleanupContext
+): Promise<void> {
   const fromVersion = getSettings().settingsVersion ?? 0;
   if (fromVersion >= CURRENT_SETTINGS_VERSION) return;
 
@@ -123,6 +133,14 @@ export async function runSettingsMigrations(api: ModelManagementApi): Promise<vo
   // back when the stored key resolves to nothing.
   if (fromVersion < 12) {
     await executeAzureRemoval(api, getSettings());
+  }
+
+  // v13: delete only exact legacy index artifacts through the mobile-safe vault
+  // adapter. Settings fields are stripped at every persistence boundary so an
+  // older synced client cannot restore them after this one-time cleanup.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/283
+  if (fromVersion < 13) {
+    await cleanupLegacyIndexArtifacts(legacyIndexCleanup);
   }
 
   // Bump unconditionally after the migrations so a per-provider failure can't

--- a/src/settings/migrations/legacyIndexRemovalMigration.test.ts
+++ b/src/settings/migrations/legacyIndexRemovalMigration.test.ts
@@ -1,13 +1,13 @@
 import {
   cleanupLegacyIndexArtifacts,
   type LegacyIndexCleanupAdapter,
+  type LegacyIndexCleanupContext,
 } from "./legacyIndexRemovalMigration";
 
 const HASH = "0123456789abcdef0123456789abcdef";
 
 interface MemoryAdapter extends LegacyIndexCleanupAdapter {
   remove: jest.MockedFunction<LegacyIndexCleanupAdapter["remove"]>;
-  rmdir: jest.MockedFunction<LegacyIndexCleanupAdapter["rmdir"]>;
 }
 
 function makeAdapter(
@@ -25,9 +25,6 @@ function makeAdapter(
       listing.files = listing.files.filter((file) => file !== path);
     }
   });
-  const rmdir = jest.fn(async (path: string, _recursive: boolean) => {
-    directories.delete(path);
-  });
 
   return {
     exists: async (path) => directories.has(path),
@@ -37,13 +34,37 @@ function makeAdapter(
       return { files: [...listing.files], folders: [...listing.folders] };
     },
     remove,
-    rmdir,
+  };
+}
+
+/**
+ * Build a cleanup context with an in-memory device-local marker.
+ *
+ * @param adapter - Vault adapter under test.
+ * @param overrides - Context fields the individual test controls.
+ */
+function makeContext(
+  adapter: LegacyIndexCleanupAdapter,
+  overrides: Partial<LegacyIndexCleanupContext> = {}
+): LegacyIndexCleanupContext & { marker: { done: boolean } } {
+  const marker = { done: false };
+  return {
+    adapter,
+    configDir: ".vault-config",
+    hasRun: () => marker.done,
+    markRun: () => {
+      marker.done = true;
+    },
+    removeRetiredEmbeddingSecrets: jest.fn(),
+    notifyFailure: jest.fn(),
+    marker,
+    ...overrides,
   };
 }
 
 describe("legacyIndexRemovalMigration", () => {
   describe("cleanupLegacyIndexArtifacts()", () => {
-    it("deletes exact artifacts in both folders and removes only an empty root index folder (https://github.com/Brevilabs/obsidian-copilot-private/issues/283)", async () => {
+    it("deletes exact artifacts in both folders and leaves the emptied directory in place (https://github.com/logancyang/obsidian-copilot/pull/3094#discussion_r3926692778)", async () => {
       const adapter = makeAdapter({
         ".copilot-index": {
           files: [
@@ -56,20 +77,18 @@ describe("legacyIndexRemovalMigration", () => {
           files: [`.vault-config/copilot-index-${HASH}.json`, ".vault-config/workspace.json"],
         },
       });
+      const context = makeContext(adapter);
 
-      await cleanupLegacyIndexArtifacts({
-        adapter,
-        configDir: ".vault-config",
-        notifyFailure: jest.fn(),
-      });
+      await cleanupLegacyIndexArtifacts(context);
 
       expect(adapter.remove).toHaveBeenCalledTimes(4);
       expect(adapter.remove).not.toHaveBeenCalledWith(".vault-config/workspace.json");
-      expect(adapter.rmdir).toHaveBeenCalledWith(".copilot-index", true);
-      expect(adapter.rmdir).not.toHaveBeenCalledWith(".vault-config", expect.anything());
+      expect(await adapter.exists(".copilot-index")).toBe(true);
+      expect(context.removeRetiredEmbeddingSecrets).toHaveBeenCalledTimes(1);
+      expect(context.marker.done).toBe(true);
     });
 
-    it("keeps user files, malformed names, nested paths, and a nonempty root folder (https://github.com/Brevilabs/obsidian-copilot-private/issues/283)", async () => {
+    it("keeps user files, malformed names, and nested paths (https://github.com/Brevilabs/obsidian-copilot-private/issues/283)", async () => {
       const adapter = makeAdapter({
         ".copilot-index": {
           files: [
@@ -82,45 +101,47 @@ describe("legacyIndexRemovalMigration", () => {
         ".vault-config": { files: [] },
       });
 
-      await cleanupLegacyIndexArtifacts({
-        adapter,
-        configDir: ".vault-config",
-        notifyFailure: jest.fn(),
-      });
+      await cleanupLegacyIndexArtifacts(makeContext(adapter));
 
       expect(adapter.remove).not.toHaveBeenCalled();
-      expect(adapter.rmdir).not.toHaveBeenCalled();
     });
 
-    it("never removes the folder when the vault config directory uses the legacy folder name (https://github.com/Brevilabs/obsidian-copilot-private/issues/283)", async () => {
+    it("visits the shared directory once when the vault config directory uses the legacy folder name (https://github.com/Brevilabs/obsidian-copilot-private/issues/283)", async () => {
       const adapter = makeAdapter({
         ".copilot-index": { files: [`.copilot-index/copilot-index-${HASH}.json`] },
       });
 
-      await cleanupLegacyIndexArtifacts({
-        adapter,
-        configDir: ".copilot-index",
-        notifyFailure: jest.fn(),
-      });
+      await cleanupLegacyIndexArtifacts(makeContext(adapter, { configDir: ".copilot-index" }));
 
+      expect(adapter.remove).toHaveBeenCalledTimes(1);
       expect(adapter.remove).toHaveBeenCalledWith(`.copilot-index/copilot-index-${HASH}.json`);
-      expect(adapter.rmdir).not.toHaveBeenCalled();
     });
 
-    it("reports a failed folder without blocking cleanup of the other folder (https://github.com/Brevilabs/obsidian-copilot-private/issues/283)", async () => {
+    it("reports a failed folder, cleans the other folder, and retries on the next launch (https://github.com/Brevilabs/obsidian-copilot-private/issues/283)", async () => {
       const adapter = makeAdapter({
         ".copilot-index": { files: [`.copilot-index/copilot-index-${HASH}.json`] },
         ".vault-config": { files: [`.vault-config/copilot-index-${HASH}.json`] },
       });
       adapter.remove.mockRejectedValueOnce(new Error("locked"));
-      const notifyFailure = jest.fn();
+      const context = makeContext(adapter);
 
-      await expect(
-        cleanupLegacyIndexArtifacts({ adapter, configDir: ".vault-config", notifyFailure })
-      ).resolves.toBeUndefined();
+      await expect(cleanupLegacyIndexArtifacts(context)).resolves.toBeUndefined();
 
-      expect(notifyFailure).toHaveBeenCalledWith(".copilot-index");
+      expect(context.notifyFailure).toHaveBeenCalledWith(".copilot-index");
       expect(adapter.remove).toHaveBeenCalledWith(`.vault-config/copilot-index-${HASH}.json`);
+      expect(context.marker.done).toBe(false);
+    });
+
+    it("skips a device that already recorded the cleanup (https://github.com/logancyang/obsidian-copilot/pull/3094#discussion_r3926692787)", async () => {
+      const adapter = makeAdapter({
+        ".copilot-index": { files: [`.copilot-index/copilot-index-${HASH}.json`] },
+      });
+      const context = makeContext(adapter, { hasRun: () => true });
+
+      await cleanupLegacyIndexArtifacts(context);
+
+      expect(adapter.remove).not.toHaveBeenCalled();
+      expect(context.removeRetiredEmbeddingSecrets).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/settings/migrations/legacyIndexRemovalMigration.test.ts
+++ b/src/settings/migrations/legacyIndexRemovalMigration.test.ts
@@ -1,0 +1,126 @@
+import {
+  cleanupLegacyIndexArtifacts,
+  type LegacyIndexCleanupAdapter,
+} from "./legacyIndexRemovalMigration";
+
+const HASH = "0123456789abcdef0123456789abcdef";
+
+interface MemoryAdapter extends LegacyIndexCleanupAdapter {
+  remove: jest.MockedFunction<LegacyIndexCleanupAdapter["remove"]>;
+  rmdir: jest.MockedFunction<LegacyIndexCleanupAdapter["rmdir"]>;
+}
+
+function makeAdapter(
+  initial: Record<string, { files: string[]; folders?: string[] }>
+): MemoryAdapter {
+  const directories = new Map(
+    Object.entries(initial).map(([folder, listing]) => [
+      folder,
+      { files: [...listing.files], folders: [...(listing.folders ?? [])] },
+    ])
+  );
+
+  const remove = jest.fn(async (path: string) => {
+    for (const listing of directories.values()) {
+      listing.files = listing.files.filter((file) => file !== path);
+    }
+  });
+  const rmdir = jest.fn(async (path: string, _recursive: boolean) => {
+    directories.delete(path);
+  });
+
+  return {
+    exists: async (path) => directories.has(path),
+    list: async (path) => {
+      const listing = directories.get(path);
+      if (!listing) throw new Error(`missing ${path}`);
+      return { files: [...listing.files], folders: [...listing.folders] };
+    },
+    remove,
+    rmdir,
+  };
+}
+
+describe("legacyIndexRemovalMigration", () => {
+  describe("cleanupLegacyIndexArtifacts()", () => {
+    it("deletes exact artifacts in both folders and removes only an empty root index folder (https://github.com/Brevilabs/obsidian-copilot-private/issues/283)", async () => {
+      const adapter = makeAdapter({
+        ".copilot-index": {
+          files: [
+            `.copilot-index/copilot-index-${HASH}.json`,
+            `.copilot-index/copilot-index-chunk-${HASH}-4.json`,
+            `.copilot-index/copilot-index-chunk-${HASH}-metadata.json`,
+          ],
+        },
+        ".vault-config": {
+          files: [`.vault-config/copilot-index-${HASH}.json`, ".vault-config/workspace.json"],
+        },
+      });
+
+      await cleanupLegacyIndexArtifacts({
+        adapter,
+        configDir: ".vault-config",
+        notifyFailure: jest.fn(),
+      });
+
+      expect(adapter.remove).toHaveBeenCalledTimes(4);
+      expect(adapter.remove).not.toHaveBeenCalledWith(".vault-config/workspace.json");
+      expect(adapter.rmdir).toHaveBeenCalledWith(".copilot-index", true);
+      expect(adapter.rmdir).not.toHaveBeenCalledWith(".vault-config", expect.anything());
+    });
+
+    it("keeps user files, malformed names, nested paths, and a nonempty root folder (https://github.com/Brevilabs/obsidian-copilot-private/issues/283)", async () => {
+      const adapter = makeAdapter({
+        ".copilot-index": {
+          files: [
+            ".copilot-index/notes.md",
+            `.copilot-index/copilot-index-${HASH.toUpperCase()}.json`,
+            `.copilot-index/nested/copilot-index-${HASH}.json`,
+          ],
+          folders: [".copilot-index/nested"],
+        },
+        ".vault-config": { files: [] },
+      });
+
+      await cleanupLegacyIndexArtifacts({
+        adapter,
+        configDir: ".vault-config",
+        notifyFailure: jest.fn(),
+      });
+
+      expect(adapter.remove).not.toHaveBeenCalled();
+      expect(adapter.rmdir).not.toHaveBeenCalled();
+    });
+
+    it("never removes the folder when the vault config directory uses the legacy folder name (https://github.com/Brevilabs/obsidian-copilot-private/issues/283)", async () => {
+      const adapter = makeAdapter({
+        ".copilot-index": { files: [`.copilot-index/copilot-index-${HASH}.json`] },
+      });
+
+      await cleanupLegacyIndexArtifacts({
+        adapter,
+        configDir: ".copilot-index",
+        notifyFailure: jest.fn(),
+      });
+
+      expect(adapter.remove).toHaveBeenCalledWith(`.copilot-index/copilot-index-${HASH}.json`);
+      expect(adapter.rmdir).not.toHaveBeenCalled();
+    });
+
+    it("reports a failed folder without blocking cleanup of the other folder (https://github.com/Brevilabs/obsidian-copilot-private/issues/283)", async () => {
+      const adapter = makeAdapter({
+        ".copilot-index": { files: [`.copilot-index/copilot-index-${HASH}.json`] },
+        ".vault-config": { files: [`.vault-config/copilot-index-${HASH}.json`] },
+      });
+      adapter.remove.mockRejectedValueOnce(new Error("locked"));
+      const notifyFailure = jest.fn();
+
+      await expect(
+        cleanupLegacyIndexArtifacts({ adapter, configDir: ".vault-config", notifyFailure })
+      ).resolves.toBeUndefined();
+
+      expect(notifyFailure).toHaveBeenCalledWith(".copilot-index");
+      expect(adapter.remove).toHaveBeenCalledWith(`.vault-config/copilot-index-${HASH}.json`);
+    });
+  });
+});

--- a/src/settings/migrations/legacyIndexRemovalMigration.ts
+++ b/src/settings/migrations/legacyIndexRemovalMigration.ts
@@ -1,10 +1,17 @@
 /**
- * One-time migration (settings v13): retire the client-side index settings and
- * delete only Copilot's known index artifacts.
+ * Device-local cleanup for the retired client-side index pipeline: delete only
+ * Copilot's known index artifacts and the credentials the removed embedding
+ * models owned.
  * https://github.com/Brevilabs/obsidian-copilot-private/issues/283
  */
 
 import { logWarn } from "@/logger";
+
+/**
+ * Device-local marker key recording that this device finished the cleanup.
+ * Lives in Obsidian's vault-scoped local storage, which never syncs.
+ */
+export const LEGACY_INDEX_CLEANUP_STORAGE_KEY = "obsidian-copilot:legacy-index-cleanup:v1";
 
 const LEGACY_INDEX_DIRECTORY = ".copilot-index";
 const LEGACY_INDEX_ARTIFACT_PATTERNS = [
@@ -18,13 +25,18 @@ export interface LegacyIndexCleanupAdapter {
   exists(path: string): Promise<boolean>;
   list(path: string): Promise<{ files: string[]; folders: string[] }>;
   remove(path: string): Promise<void>;
-  rmdir(path: string, recursive: boolean): Promise<void>;
 }
 
 /** Dependencies for the one-time legacy index cleanup. */
 export interface LegacyIndexCleanupContext {
   adapter: LegacyIndexCleanupAdapter;
   configDir: string;
+  /** True once this device has completed the cleanup. */
+  hasRun(): boolean;
+  /** Record that this device completed the cleanup. */
+  markRun(): void;
+  /** Drop keychain entries the removed embedding models owned. */
+  removeRetiredEmbeddingSecrets(): void;
   notifyFailure(folder: string): void;
 }
 
@@ -39,13 +51,14 @@ function isDirectLegacyArtifact(folder: string, path: string): boolean {
   );
 }
 
-async function cleanupFolder(
-  context: LegacyIndexCleanupContext,
-  folder: string,
-  removeWhenEmpty: boolean
-): Promise<void> {
+/**
+ * Delete the allowlisted artifacts directly inside one folder.
+ *
+ * @returns True when every recognized artifact was removed.
+ */
+async function cleanupFolder(context: LegacyIndexCleanupContext, folder: string): Promise<boolean> {
   try {
-    if (!(await context.adapter.exists(folder))) return;
+    if (!(await context.adapter.exists(folder))) return true;
 
     const listing = await context.adapter.list(folder);
     let failed = false;
@@ -55,48 +68,57 @@ async function cleanupFolder(
         await context.adapter.remove(path);
       } catch (error) {
         failed = true;
-        logWarn(`[settings-migration] failed to remove legacy index artifact in ${folder}`, error);
-      }
-    }
-
-    if (removeWhenEmpty && !failed) {
-      const remaining = await context.adapter.list(folder);
-      if (remaining.files.length === 0 && remaining.folders.length === 0) {
-        // Obsidian's adapter requires recursive directory removal even for an
-        // empty directory. This call is restricted to the dedicated legacy
-        // root after a second empty check; the config directory never reaches it.
-        // https://github.com/Brevilabs/obsidian-copilot-private/issues/283
-        await context.adapter.rmdir(folder, true);
+        logWarn(
+          `[legacy-index-cleanup] failed to remove legacy index artifact in ${folder}`,
+          error
+        );
       }
     }
 
     if (failed) context.notifyFailure(folder);
+    return !failed;
   } catch (error) {
-    logWarn(`[settings-migration] failed to clean legacy index folder ${folder}`, error);
+    logWarn(`[legacy-index-cleanup] failed to clean legacy index folder ${folder}`, error);
     context.notifyFailure(folder);
+    return false;
   }
 }
 
 /**
- * Delete allowlisted index artifacts directly inside the former index folders.
+ * Remove this device's remnants of the retired index pipeline: allowlisted
+ * artifacts directly inside the former index folders, plus the keychain entries
+ * the removed embedding models owned.
  *
- * The vault config directory is never removed. The root `.copilot-index`
- * directory is removed non-recursively only after a second listing proves it
- * empty.
+ * Gated by a device-local marker rather than the settings version, because
+ * `settingsVersion` syncs: a second device would otherwise arrive already
+ * stamped and never clean its own files or credentials.
+ * https://github.com/logancyang/obsidian-copilot/pull/3094#discussion_r3926692787
  *
- * @param context - Vault adapter, active config directory, and failure notifier.
+ * Emptied directories are left in place. Obsidian's adapter can only remove a
+ * directory recursively, and an emptiness check cannot be atomic with that
+ * removal, so a file another writer restores in between would be deleted
+ * despite the allowlist promise.
+ * https://github.com/logancyang/obsidian-copilot/pull/3094#discussion_r3926692778
+ *
+ * @param context - Vault adapter, active config directory, device-local marker,
+ *   credential cleanup, and failure notifier.
  */
 export async function cleanupLegacyIndexArtifacts(
   context: LegacyIndexCleanupContext
 ): Promise<void> {
+  if (context.hasRun()) return;
+
   const configDir = context.configDir.replace(/\/+$/, "");
-  const rootIndexIsConfigDir = configDir === LEGACY_INDEX_DIRECTORY;
-  // A vault may use a custom config-directory name. If it happens to equal the
-  // legacy index directory, it still receives the stronger config-dir promise:
-  // delete allowlisted files directly inside it, but never remove the folder.
+  let cleaned = await cleanupFolder(context, LEGACY_INDEX_DIRECTORY);
+  // A vault may use a custom config-directory name. Cleaning it twice would
+  // double-report the same failure, so only visit a distinct directory.
   // https://github.com/Brevilabs/obsidian-copilot-private/issues/283
-  await cleanupFolder(context, LEGACY_INDEX_DIRECTORY, !rootIndexIsConfigDir);
-  if (!rootIndexIsConfigDir) {
-    await cleanupFolder(context, configDir, false);
+  if (configDir !== LEGACY_INDEX_DIRECTORY) {
+    cleaned = (await cleanupFolder(context, configDir)) && cleaned;
   }
+
+  context.removeRetiredEmbeddingSecrets();
+
+  // A failed pass stays unmarked so the next launch retries it.
+  if (cleaned) context.markRun();
 }

--- a/src/settings/migrations/legacyIndexRemovalMigration.ts
+++ b/src/settings/migrations/legacyIndexRemovalMigration.ts
@@ -1,0 +1,102 @@
+/**
+ * One-time migration (settings v13): retire the client-side index settings and
+ * delete only Copilot's known index artifacts.
+ * https://github.com/Brevilabs/obsidian-copilot-private/issues/283
+ */
+
+import { logWarn } from "@/logger";
+
+const LEGACY_INDEX_DIRECTORY = ".copilot-index";
+const LEGACY_INDEX_ARTIFACT_PATTERNS = [
+  /^copilot-index-[a-f0-9]{32}\.json$/,
+  /^copilot-index-chunk-[a-f0-9]{32}-\d+\.json$/,
+  /^copilot-index-chunk-[a-f0-9]{32}-metadata\.json$/,
+] as const;
+
+/** Mobile-safe subset of Obsidian's vault adapter used by the cleanup. */
+export interface LegacyIndexCleanupAdapter {
+  exists(path: string): Promise<boolean>;
+  list(path: string): Promise<{ files: string[]; folders: string[] }>;
+  remove(path: string): Promise<void>;
+  rmdir(path: string, recursive: boolean): Promise<void>;
+}
+
+/** Dependencies for the one-time legacy index cleanup. */
+export interface LegacyIndexCleanupContext {
+  adapter: LegacyIndexCleanupAdapter;
+  configDir: string;
+  notifyFailure(folder: string): void;
+}
+
+function isDirectLegacyArtifact(folder: string, path: string): boolean {
+  const prefix = `${folder.replace(/\/+$/, "")}/`;
+  if (!path.startsWith(prefix)) return false;
+
+  const filename = path.slice(prefix.length);
+  return (
+    !filename.includes("/") &&
+    LEGACY_INDEX_ARTIFACT_PATTERNS.some((pattern) => pattern.test(filename))
+  );
+}
+
+async function cleanupFolder(
+  context: LegacyIndexCleanupContext,
+  folder: string,
+  removeWhenEmpty: boolean
+): Promise<void> {
+  try {
+    if (!(await context.adapter.exists(folder))) return;
+
+    const listing = await context.adapter.list(folder);
+    let failed = false;
+    for (const path of listing.files) {
+      if (!isDirectLegacyArtifact(folder, path)) continue;
+      try {
+        await context.adapter.remove(path);
+      } catch (error) {
+        failed = true;
+        logWarn(`[settings-migration] failed to remove legacy index artifact in ${folder}`, error);
+      }
+    }
+
+    if (removeWhenEmpty && !failed) {
+      const remaining = await context.adapter.list(folder);
+      if (remaining.files.length === 0 && remaining.folders.length === 0) {
+        // Obsidian's adapter requires recursive directory removal even for an
+        // empty directory. This call is restricted to the dedicated legacy
+        // root after a second empty check; the config directory never reaches it.
+        // https://github.com/Brevilabs/obsidian-copilot-private/issues/283
+        await context.adapter.rmdir(folder, true);
+      }
+    }
+
+    if (failed) context.notifyFailure(folder);
+  } catch (error) {
+    logWarn(`[settings-migration] failed to clean legacy index folder ${folder}`, error);
+    context.notifyFailure(folder);
+  }
+}
+
+/**
+ * Delete allowlisted index artifacts directly inside the former index folders.
+ *
+ * The vault config directory is never removed. The root `.copilot-index`
+ * directory is removed non-recursively only after a second listing proves it
+ * empty.
+ *
+ * @param context - Vault adapter, active config directory, and failure notifier.
+ */
+export async function cleanupLegacyIndexArtifacts(
+  context: LegacyIndexCleanupContext
+): Promise<void> {
+  const configDir = context.configDir.replace(/\/+$/, "");
+  const rootIndexIsConfigDir = configDir === LEGACY_INDEX_DIRECTORY;
+  // A vault may use a custom config-directory name. If it happens to equal the
+  // legacy index directory, it still receives the stronger config-dir promise:
+  // delete allowlisted files directly inside it, but never remove the folder.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/283
+  await cleanupFolder(context, LEGACY_INDEX_DIRECTORY, !rootIndexIsConfigDir);
+  if (!rootIndexIsConfigDir) {
+    await cleanupFolder(context, configDir, false);
+  }
+}

--- a/src/settings/migrations/legacyIndexSettings.test.ts
+++ b/src/settings/migrations/legacyIndexSettings.test.ts
@@ -1,0 +1,74 @@
+import { Platform } from "obsidian";
+
+import { stripLegacyIndexSettings } from "./legacyIndexSettings";
+
+describe("legacyIndexSettings", () => {
+  describe("stripLegacyIndexSettings()", () => {
+    it.each([
+      { name: "index enabled", enableSemanticSearchV3: true, activeEmbeddingModels: [{}] },
+      { name: "index disabled", enableSemanticSearchV3: false, activeEmbeddingModels: [] },
+      { name: "no embedding rows", enableSemanticSearchV3: true },
+    ])(
+      "removes retired fields from a vault with $name (https://github.com/Brevilabs/obsidian-copilot-private/issues/283)",
+      ({ name: _name, ...legacyFields }) => {
+        const cleaned = stripLegacyIndexSettings({
+          keep: "value",
+          embeddingModelKey: "embed|openai",
+          embeddingRequestsPerMin: 60,
+          embeddingBatchSize: 16,
+          numPartitions: 2,
+          enableIndexSync: true,
+          disableIndexOnMobile: true,
+          indexVaultToVectorStore: "ON MODE SWITCH",
+          openAIEmbeddingProxyBaseUrl: "https://proxy.example",
+          azureOpenAIApiEmbeddingDeploymentName: "embed",
+          ...legacyFields,
+        });
+
+        expect(cleaned).toEqual({ keep: "value" });
+      }
+    );
+
+    it("preserves shared provider credentials and BYOK rows byte-identically (https://github.com/Brevilabs/obsidian-copilot-private/issues/283)", () => {
+      const providers = {
+        custom: {
+          providerId: "custom",
+          providerType: "openai-compatible",
+          apiKeyKeychainId: "copilot-v12345678-provider-custom",
+          extras: { headers: { "X-Custom": "value" } },
+        },
+      };
+      const configuredModels = [
+        { configuredModelId: "model-1", providerId: "custom", info: { id: "model-wire" } },
+      ];
+      const before = JSON.stringify({ providers, configuredModels });
+
+      const cleaned = stripLegacyIndexSettings({
+        providers,
+        configuredModels,
+        openAIApiKey: "shared-chat-key",
+        activeEmbeddingModels: [{ apiKey: "retired-embedding-key" }],
+      });
+
+      expect(
+        JSON.stringify({
+          providers: cleaned.providers,
+          configuredModels: cleaned.configuredModels,
+        })
+      ).toBe(before);
+      expect(cleaned.openAIApiKey).toBe("shared-chat-key");
+    });
+
+    it("does not depend on the platform when stripping synced settings (https://github.com/Brevilabs/obsidian-copilot-private/issues/283)", () => {
+      const original = Platform.isMobile;
+      const raw = { keep: true, enableIndexSync: false, activeEmbeddingModels: [] };
+      Platform.isMobile = false;
+      const desktop = stripLegacyIndexSettings(raw);
+      Platform.isMobile = true;
+      const mobile = stripLegacyIndexSettings(raw);
+      Platform.isMobile = original;
+
+      expect(mobile).toEqual(desktop);
+    });
+  });
+});

--- a/src/settings/migrations/legacyIndexSettings.ts
+++ b/src/settings/migrations/legacyIndexSettings.ts
@@ -1,0 +1,33 @@
+/**
+ * Settings that existed only for the removed embedding and index runtime.
+ * https://github.com/Brevilabs/obsidian-copilot-private/issues/283
+ */
+const LEGACY_INDEX_SETTING_FIELDS = [
+  "enableSemanticSearchV3",
+  "embeddingModelKey",
+  "activeEmbeddingModels",
+  "embeddingRequestsPerMin",
+  "embeddingBatchSize",
+  "numPartitions",
+  "enableIndexSync",
+  "disableIndexOnMobile",
+  "indexVaultToVectorStore",
+  "openAIEmbeddingProxyBaseUrl",
+  "azureOpenAIApiEmbeddingDeploymentName",
+] as const;
+
+/**
+ * Return a detached settings object without fields owned by the removed index.
+ *
+ * This runs on every load and save in addition to the versioned migration so a
+ * settings sync from an older Copilot version cannot restore retired keys.
+ *
+ * @param settings - Settings record to clean without mutating its input.
+ */
+export function stripLegacyIndexSettings<T extends object>(settings: T): T {
+  const cleaned = { ...settings } as T & Record<string, unknown>;
+  for (const field of LEGACY_INDEX_SETTING_FIELDS) {
+    delete cleaned[field];
+  }
+  return cleaned;
+}

--- a/src/settings/migrations/runSettingsMigrations.test.ts
+++ b/src/settings/migrations/runSettingsMigrations.test.ts
@@ -10,7 +10,10 @@ import type { ModelManagementApi, ProviderType } from "@/modelManagement";
 import { getSettings, setSettings, type CopilotSettings } from "@/settings/model";
 import { Platform } from "obsidian";
 
-import { CURRENT_SETTINGS_VERSION, runSettingsMigrations } from "./index";
+import {
+  CURRENT_SETTINGS_VERSION,
+  runSettingsMigrations as runSettingsMigrationsWithCleanup,
+} from "./index";
 
 jest.mock("@/logger", () => ({
   logInfo: jest.fn(),
@@ -35,8 +38,26 @@ jest.mock("@/settings/model", () => {
 const mockGetSettings = getSettings as jest.MockedFunction<typeof getSettings>;
 const mockSetSettings = setSettings as jest.MockedFunction<typeof setSettings>;
 
+const noLegacyIndexCleanup = {
+  adapter: {
+    exists: async () => false,
+    list: async () => ({ files: [], folders: [] }),
+    remove: async () => undefined,
+    rmdir: async () => undefined,
+  },
+  configDir: ".vault-config",
+  notifyFailure: jest.fn(),
+};
+
+function runSettingsMigrations(
+  api: ModelManagementApi,
+  cleanup = noLegacyIndexCleanup
+): Promise<void> {
+  return runSettingsMigrationsWithCleanup(api, cleanup);
+}
+
 function settings(
-  overrides: Partial<CopilotSettings>,
+  overrides: Partial<CopilotSettings> & Record<string, unknown>,
   models: CustomModel[] = []
 ): CopilotSettings {
   return { ...DEFAULT_SETTINGS, activeModels: models, ...overrides };
@@ -434,8 +455,29 @@ describe("runSettingsMigrations()", () => {
     await runSettingsMigrations(api);
 
     expect(mockSetSettings).toHaveBeenCalledWith(
-      expect.objectContaining({ embeddingModelKey: DEFAULT_SETTINGS.embeddingModelKey })
+      expect.objectContaining({ embeddingModelKey: "" })
     );
+  });
+
+  it("v13: cleans both legacy index locations for a v12 vault (https://github.com/Brevilabs/obsidian-copilot-private/issues/283)", async () => {
+    mockGetSettings.mockReturnValue(settings({ settingsVersion: 12 }));
+    const { api } = makeApi();
+    const adapter = {
+      exists: jest.fn(async () => false),
+      list: jest.fn(),
+      remove: jest.fn(),
+      rmdir: jest.fn(),
+    };
+
+    await runSettingsMigrations(api, {
+      adapter,
+      configDir: ".vault-config",
+      notifyFailure: jest.fn(),
+    });
+
+    expect(adapter.exists).toHaveBeenNthCalledWith(1, ".copilot-index");
+    expect(adapter.exists).toHaveBeenNthCalledWith(2, ".vault-config");
+    expect(mockSetSettings).toHaveBeenCalledWith({ settingsVersion: CURRENT_SETTINGS_VERSION });
   });
 
   it("v11: leaves a saved Bedrock provider alone for a vault already at the current version", async () => {

--- a/src/settings/migrations/runSettingsMigrations.test.ts
+++ b/src/settings/migrations/runSettingsMigrations.test.ts
@@ -10,10 +10,7 @@ import type { ModelManagementApi, ProviderType } from "@/modelManagement";
 import { getSettings, setSettings, type CopilotSettings } from "@/settings/model";
 import { Platform } from "obsidian";
 
-import {
-  CURRENT_SETTINGS_VERSION,
-  runSettingsMigrations as runSettingsMigrationsWithCleanup,
-} from "./index";
+import { CURRENT_SETTINGS_VERSION, runSettingsMigrations } from "./index";
 
 jest.mock("@/logger", () => ({
   logInfo: jest.fn(),
@@ -37,24 +34,6 @@ jest.mock("@/settings/model", () => {
 
 const mockGetSettings = getSettings as jest.MockedFunction<typeof getSettings>;
 const mockSetSettings = setSettings as jest.MockedFunction<typeof setSettings>;
-
-const noLegacyIndexCleanup = {
-  adapter: {
-    exists: async () => false,
-    list: async () => ({ files: [], folders: [] }),
-    remove: async () => undefined,
-    rmdir: async () => undefined,
-  },
-  configDir: ".vault-config",
-  notifyFailure: jest.fn(),
-};
-
-function runSettingsMigrations(
-  api: ModelManagementApi,
-  cleanup = noLegacyIndexCleanup
-): Promise<void> {
-  return runSettingsMigrationsWithCleanup(api, cleanup);
-}
 
 function settings(
   overrides: Partial<CopilotSettings> & Record<string, unknown>,
@@ -457,27 +436,6 @@ describe("runSettingsMigrations()", () => {
     expect(mockSetSettings).toHaveBeenCalledWith(
       expect.objectContaining({ embeddingModelKey: "" })
     );
-  });
-
-  it("v13: cleans both legacy index locations for a v12 vault (https://github.com/Brevilabs/obsidian-copilot-private/issues/283)", async () => {
-    mockGetSettings.mockReturnValue(settings({ settingsVersion: 12 }));
-    const { api } = makeApi();
-    const adapter = {
-      exists: jest.fn(async () => false),
-      list: jest.fn(),
-      remove: jest.fn(),
-      rmdir: jest.fn(),
-    };
-
-    await runSettingsMigrations(api, {
-      adapter,
-      configDir: ".vault-config",
-      notifyFailure: jest.fn(),
-    });
-
-    expect(adapter.exists).toHaveBeenNthCalledWith(1, ".copilot-index");
-    expect(adapter.exists).toHaveBeenNthCalledWith(2, ".vault-config");
-    expect(mockSetSettings).toHaveBeenCalledWith({ settingsVersion: CURRENT_SETTINGS_VERSION });
   });
 
   it("v11: leaves a saved Bedrock provider alone for a vault already at the current version", async () => {

--- a/src/settings/migrations/version.ts
+++ b/src/settings/migrations/version.ts
@@ -23,5 +23,6 @@
  *         Amazon Bedrock chat provider.
  *   12  → the same for the removed Azure OpenAI provider, plus repointing an
  *         embedding selection that named it.
+ *   13  → drop retired index settings and remove allowlisted index artifacts.
  */
-export const CURRENT_SETTINGS_VERSION = 12;
+export const CURRENT_SETTINGS_VERSION = 13;

--- a/src/settings/migrations/version.ts
+++ b/src/settings/migrations/version.ts
@@ -23,6 +23,8 @@
  *         Amazon Bedrock chat provider.
  *   12  → the same for the removed Azure OpenAI provider, plus repointing an
  *         embedding selection that named it.
- *   13  → drop retired index settings and remove allowlisted index artifacts.
+ *   13  → drop the retired index settings. The device-local artifact and
+ *          credential cleanup is gated separately, in
+ *          `legacyIndexRemovalMigration`, because this version is synced.
  */
 export const CURRENT_SETTINGS_VERSION = 13;

--- a/src/settings/model.test.ts
+++ b/src/settings/model.test.ts
@@ -1160,7 +1160,6 @@ describe("model", () => {
         azureOpenAIApiInstanceName: "my-instance",
         azureOpenAIApiDeploymentName: "chat-deploy",
         azureOpenAIApiVersion: "2025-01-01-preview",
-        azureOpenAIApiEmbeddingDeploymentName: "embed-deploy",
       };
       settingsStore.set(settingsAtom, { ...DEFAULT_SETTINGS, ...vendorConfig });
 

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -66,13 +66,11 @@ export interface CopilotSettings {
   siliconflowApiKey: string;
   defaultChainType: ChainType;
   defaultModelKey: string;
-  embeddingModelKey: string;
   contextTurns: number;
   lastDismissedVersion: string | null;
   // DEPRECATED: Do not use this directly, migrated to file-based system prompts
   userSystemPrompt: string;
   openAIProxyBaseUrl: string;
-  openAIEmbeddingProxyBaseUrl: string;
   stream: boolean;
   /** Configurable root folder all Copilot sub-folders derive from (default: "copilot"). */
   copilotFolder: string;
@@ -106,10 +104,8 @@ export interface CopilotSettings {
   autosaveChat: boolean;
   autoAddActiveContentToContext: boolean;
   customPromptsFolder: string;
-  indexVaultToVectorStore: string;
   chatNoteContextPath: string;
   chatNoteContextTags: string[];
-  enableIndexSync: boolean;
   debug: boolean;
   maxSourceChunks: number;
   enableInlineCitations: boolean;
@@ -117,18 +113,13 @@ export interface CopilotSettings {
   qaInclusions: string;
   groqApiKey: string;
   activeModels: Array<CustomModel>;
-  activeEmbeddingModels: Array<CustomModel>;
   promptUsageTimestamps: Record<string, number>;
   promptSortStrategy: string;
   chatHistorySortStrategy: SortStrategy;
   /** Projects config root folder in vault (default: "copilot/projects"). */
   projectsFolder: string;
-  embeddingRequestsPerMin: number;
-  embeddingBatchSize: number;
   defaultOpenArea: DEFAULT_OPEN_AREA;
   defaultSendShortcut: SEND_SHORTCUT;
-  disableIndexOnMobile: boolean;
-  numPartitions: number;
   defaultConversationNoteName: string;
   // Any valid paid license (Lite and above). undefined means never checked.
   isPaidUser: boolean | undefined;
@@ -148,16 +139,13 @@ export interface CopilotSettings {
   passMarkdownImages: boolean;
   enableAutonomousAgent: boolean;
   enableCustomPromptTemplating: boolean;
-  /** Enable semantic search using Orama for meaning-based document retrieval */
-  enableSemanticSearchV3: boolean;
   /** Enable self-host mode (e.g., Miyo) - uses self-hosted services for search, LLMs, OCR, etc. */
   enableSelfHostMode: boolean;
   /** Enable Miyo-backed indexing and semantic search when self-host mode is active */
   enableMiyo: boolean;
   /**
-   * User-controlled install of the `miyo-search` agent skill (path B: agent tool +
-   * system-prompt steering). Independent of `enableSemanticSearchV3` (path A: the
-   * Copilot chat/QA vector retrieval), which stays owned by Miyo Connect/Disconnect.
+   * User-controlled install of the `miyo-search` agent skill. This agent-tool
+   * integration is independent of the Miyo backend used by Copilot search.
    */
   enableMiyoSearchSkill: boolean;
   /** When true, omit folder_name from Miyo search requests so all indexed content is searched */
@@ -856,9 +844,6 @@ export function resetSettings(): void {
       BUILTIN_CHAT_MODELS.map((model) => ({ ...model, enabled: true })),
       current.activeModels ?? []
     ),
-    // The client-side embedding pipeline is gone, but its persisted fields stay
-    // untouched until the dedicated settings migration removes them.
-    activeEmbeddingModels: current.activeEmbeddingModels ?? DEFAULT_SETTINGS.activeEmbeddingModels,
     providers: preservedProviders,
     configuredModels: preserveConfiguredModelsForProviders(
       current.configuredModels,
@@ -910,10 +895,6 @@ export function sanitizeSettings(settings: CopilotSettings): CopilotSettings {
     settingsToSanitize.userId = uuidv4();
   }
 
-  if (!settingsToSanitize.activeEmbeddingModels) {
-    settingsToSanitize.activeEmbeddingModels = DEFAULT_SETTINGS.activeEmbeddingModels;
-  }
-
   const sanitizedSettings: CopilotSettings = { ...settingsToSanitize };
   const sanitizedSettingsRecord = sanitizedSettings as unknown as Record<string, unknown>;
   delete sanitizedSettingsRecord.miyoRemoteVaultPath;
@@ -924,14 +905,13 @@ export function sanitizeSettings(settings: CopilotSettings): CopilotSettings {
   // https://github.com/logancyang/obsidian-copilot/issues/2928
   delete sanitizedSettingsRecord.amazonBedrockApiKey;
   delete sanitizedSettingsRecord.amazonBedrockRegion;
-  // Azure OpenAI is no longer a chat or embedding provider, so a stored key and
-  // its routing fields would only address a service Copilot cannot reach.
+  // Azure OpenAI is no longer a chat provider, so a stored key and its routing
+  // fields would only address a service Copilot cannot reach.
   // https://github.com/logancyang/obsidian-copilot/issues/2932
   delete sanitizedSettingsRecord.azureOpenAIApiKey;
   delete sanitizedSettingsRecord.azureOpenAIApiInstanceName;
   delete sanitizedSettingsRecord.azureOpenAIApiDeploymentName;
   delete sanitizedSettingsRecord.azureOpenAIApiVersion;
-  delete sanitizedSettingsRecord.azureOpenAIApiEmbeddingDeploymentName;
   // Copilot no longer limits how long an answer may be, so a stored limit
   // would only cut off answers the model was willing to finish.
   // https://github.com/logancyang/obsidian-copilot-preview/issues/312
@@ -968,16 +948,6 @@ export function sanitizeSettings(settings: CopilotSettings): CopilotSettings {
   sanitizedSettings.contextTurns = isNaN(contextTurns)
     ? DEFAULT_SETTINGS.contextTurns
     : contextTurns;
-
-  const embeddingRequestsPerMin = Number(settingsToSanitize.embeddingRequestsPerMin);
-  sanitizedSettings.embeddingRequestsPerMin = isNaN(embeddingRequestsPerMin)
-    ? DEFAULT_SETTINGS.embeddingRequestsPerMin
-    : embeddingRequestsPerMin;
-
-  const embeddingBatchSize = Number(settingsToSanitize.embeddingBatchSize);
-  sanitizedSettings.embeddingBatchSize = isNaN(embeddingBatchSize)
-    ? DEFAULT_SETTINGS.embeddingBatchSize
-    : embeddingBatchSize;
 
   // Sanitize lexicalSearchRamLimit (20-1000 MB range)
   const lexicalSearchRamLimit = Number(settingsToSanitize.lexicalSearchRamLimit);

--- a/src/settings/v2/SettingsMainV2.tsx
+++ b/src/settings/v2/SettingsMainV2.tsx
@@ -24,13 +24,11 @@ import { SelfHostSettings } from "./components/SelfHostSettings";
 // (see designdocs/SETTINGS_REDESIGN_V4.md and SETTINGS_V4_PR_PLAN.md); the
 // underlying fields are NOT dropped yet so existing data remains loadable:
 // vaults:
-//   - enableSemanticSearchV3 — the Miyo connect flow (MiyoSettings) drives it
 //     implicitly. Its old Advanced-tab switch is gone because the built-in
 //     semantic index is no longer a user-facing product surface.
 //   - qaInclusions/qaExclusions — still consumed (Miyo registration snapshot);
 //     their edit UI is deferred per issue #195 ("defer include/exclude").
 //   - maxSourceChunks / enableInlineCitations — still read by search and chat.
-//   - embeddingModelKey / activeEmbeddingModels / indexing limits — inert
 //     compatibility fields awaiting their dedicated settings migration.
 const LazySkillsSettings = React.lazy(() =>
   import("@/agentMode").then((module) => ({ default: module.SkillsSettings }))

--- a/src/settings/v2/components/MiyoSettings.searchSkill.test.tsx
+++ b/src/settings/v2/components/MiyoSettings.searchSkill.test.tsx
@@ -451,13 +451,12 @@ describe("Connect — two-phase commit rolls back on a failed health check", () 
     currentSettings = {
       ...DEFAULT_SETTINGS,
       enableMiyo: false,
-      enableSemanticSearchV3: false,
     };
   });
 
-  it("rolls back enableMiyo + enableSemanticSearchV3 when Miyo drops before the enable refresh", async () => {
+  it("rolls back Miyo without writing retired index settings when the enable refresh fails (https://github.com/Brevilabs/obsidian-copilot-private/issues/283)", async () => {
     // Reachable + registered, so the flow reaches enableMiyoBackend and writes
-    // both flags true — but the post-enable refresh reports NOT available.
+    // the Miyo flag true — but the post-enable refresh reports NOT available.
     mockReachable = true;
     mockRegistration = "registered";
     mockRefreshBackend = "unavailable";
@@ -465,12 +464,11 @@ describe("Connect — two-phase commit rolls back on a failed health check", () 
 
     fireEvent.click(await screen.findByText("Connect"));
 
-    // Both flags flip on, then revert once the health check comes back unavailable
+    // The flag flips on, then reverts once the health check comes back unavailable
     // — otherwise search routing would key off a stranded enableMiyo=true.
     await waitFor(() => expect(updateSetting).toHaveBeenCalledWith("enableMiyo", false));
     expect(updateSetting).toHaveBeenCalledWith("enableMiyo", true);
-    expect(updateSetting).toHaveBeenCalledWith("enableSemanticSearchV3", true);
-    expect(updateSetting).toHaveBeenCalledWith("enableSemanticSearchV3", false);
+    expect(updateSetting).toHaveBeenCalledTimes(2);
   });
 
   it("does NOT roll back when the enable refresh confirms available", async () => {
@@ -482,30 +480,8 @@ describe("Connect — two-phase commit rolls back on a failed health check", () 
     fireEvent.click(await screen.findByText("Connect"));
 
     await waitFor(() => expect(updateSetting).toHaveBeenCalledWith("enableMiyo", true));
-    // A successful connect must leave the flags on — no revert write.
+    // A successful connect must leave the flag on — no revert write.
     expect(updateSetting).not.toHaveBeenCalledWith("enableMiyo", false);
-    expect(updateSetting).not.toHaveBeenCalledWith("enableSemanticSearchV3", false);
-  });
-
-  it("preserves a user's pre-existing enableSemanticSearchV3 on rollback", async () => {
-    // The user already had semantic search on (for non-Miyo use). A failed Miyo
-    // connect must revert enableMiyo but MUST NOT clobber their semantic setting.
-    currentSettings = {
-      ...DEFAULT_SETTINGS,
-      enableMiyo: false,
-      enableSemanticSearchV3: true,
-    };
-    mockReachable = true;
-    mockRegistration = "registered";
-    mockRefreshBackend = "unavailable";
-    render(<MiyoSettings />);
-
-    fireEvent.click(await screen.findByText("Connect"));
-
-    await waitFor(() => expect(updateSetting).toHaveBeenCalledWith("enableMiyo", false));
-    // We never flipped enableSemanticSearchV3 (it was already true), so we must
-    // never write it false on rollback.
-    expect(updateSetting).not.toHaveBeenCalledWith("enableSemanticSearchV3", false);
   });
 
   it("rolls back an optimistic enable when the attempt is superseded mid-refresh, even if it comes back available", async () => {

--- a/src/settings/v2/components/MiyoSettings.tsx
+++ b/src/settings/v2/components/MiyoSettings.tsx
@@ -367,21 +367,13 @@ export const MiyoSettings: React.FC = () => {
     }
   }, [settings, beginBusy, endBusy]);
 
-  // Enable Miyo, then refresh the store so the pill flips to Connected. This is
-  // the write the legacy Miyo toggle owned; the redesign moved the affordance
-  // here but the enable action still has to persist the flag.
-  //
-  // Keep writing the legacy `enableSemanticSearchV3` field alongside `enableMiyo`
-  // until the settings migration removes the old semantic-index fields. Runtime
-  // search routing now depends on `enableMiyo` alone.
+  // Enable Miyo, then refresh the store so the pill flips to Connected.
   //
   // Two-phase commit: enabling persists `enableMiyo`, but search routing keys off
   // that persisted flag alone (shouldUseMiyo), so a flag left `true` after a
   // failed health check would route retrieval to a dead Miyo — silent empty
   // results with no self-heal until the next manual reconnect. So we roll back
-  // exactly the fields this call flipped — always `enableMiyo`, and
-  // `enableSemanticSearchV3` only if WE turned it on (a user who had it on for
-  // non-Miyo semantic search keeps it) — whenever this call must not commit:
+  // `enableMiyo` whenever this call must not commit:
   //   - the post-enable refresh reports NOT available (dead Miyo), OR
   //   - a newer attempt / cancel / unmount superseded this one mid-refresh.
   //
@@ -399,22 +391,15 @@ export const MiyoSettings: React.FC = () => {
     async (superseded: () => boolean) => {
       const txn = (enableTxnRef.current += 1);
       const prevEnableMiyo = settings.enableMiyo;
-      const flippedSemantic = !settings.enableSemanticSearchV3;
       updateSetting("enableMiyo", true);
-      if (flippedSemantic) {
-        updateSetting("enableSemanticSearchV3", true);
-      }
       const available = await refresh(true);
       const stillOwner = enableTxnRef.current === txn;
       if (stillOwner && (!available || superseded())) {
         updateSetting("enableMiyo", prevEnableMiyo);
-        if (flippedSemantic) {
-          updateSetting("enableSemanticSearchV3", false);
-        }
       }
       return available;
     },
-    [settings.enableMiyo, settings.enableSemanticSearchV3, refresh]
+    [settings.enableMiyo, refresh]
   );
 
   // Register this vault with Miyo when it isn't known yet, so Connect adds it for
@@ -663,20 +648,16 @@ export const MiyoSettings: React.FC = () => {
     // "connected": pill flips via the store; "error": Notice already surfaced.
   }, [handleEvaluate, openConnectModal]);
 
-  // Disconnect: turn Miyo off — the symmetric undo of enableMiyoBackend. Keep
-  // clearing the legacy semantic flag until the settings migration removes it.
-  // The store's subscription invalidates the snapshot; refresh(true) then
-  // reflects the disconnected state.
+  // Disconnect: turn Miyo off — the symmetric undo of enableMiyoBackend. The
+  // store's subscription invalidates the snapshot; refresh(true) then reflects
+  // the disconnected state.
   const handleDisconnect = useCallback(async () => {
     // Invalidate any in-flight connect attempt so a late-resolving probe can't
     // re-enable Miyo right after the user turned it off.
     connectAttemptRef.current += 1;
     updateSetting("enableMiyo", false);
-    if (settings.enableSemanticSearchV3) {
-      updateSetting("enableSemanticSearchV3", false);
-    }
     await refresh(true);
-  }, [settings.enableSemanticSearchV3, refresh]);
+  }, [refresh]);
 
   // Install / remove the `miyo-search` agent skill (path B) — independent of the
   // Miyo connection (path A) above. We AWAIT the disk op and read its real


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#283

## Why

After the Orama runtime and Vault QA were removed, Copilot still loaded, saved, and documented eleven settings that existed only for the retired client-side semantic index. Old index artifacts could also remain in the vault root or Obsidian config directory indefinitely.

## What

Settings schema version 13 removes the retired semantic-index, embedding, partitioning, sync, mobile-indexing, proxy, and Azure embedding-deployment fields. The same allowlist-based cleanup runs on every load and save, so settings synced from an older Copilot installation cannot resurrect them. Shared provider, BYOK, chat, QA, and Miyo settings remain unchanged.

A device-local cleanup deletes only exact legacy artifact names directly inside `.copilot-index` and the active Obsidian config directory:

- `copilot-index-<32 lowercase hex>.json`
- `copilot-index-chunk-<32 lowercase hex>-<number>.json`
- `copilot-index-chunk-<32 lowercase hex>-metadata.json`

Malformed names, uppercase hashes, nested paths, and unrelated files are retained. No directory is ever removed: Obsidian's adapter can only remove a directory recursively, and an emptiness check cannot be atomic with that removal, so a file another writer restored in between would be deleted despite the allowlist promise. The emptied `.copilot-index` folder is a hidden dot-directory and stays in place.

The same pass removes the keychain entries the retired embedding models owned. Their identities are gone from settings once the load path strips `activeEmbeddingModels`, but the embedding scope is part of the keychain ID, so this vault's `copilot-v<id>-model-api-key-embedding-*` entries stay enumerable and are deleted. Obsidian builds whose `SecretStorage` cannot enumerate entries are left untouched.

This cleanup is gated by a device-local marker in Obsidian's vault-scoped local storage rather than by `settingsVersion`, which syncs: a second device arriving already stamped at v13, or a reinstall after `data.json` was removed, would otherwise never clean its own files or credentials. Per-folder failures are logged, surfaced through a notice, and leave the pass unmarked so the next launch retries it.

The v12 Azure settings migration remains backward-compatible with already-written data. Keychain backup detection continues to recognize secret-bearing legacy arrays before retired fields are stripped.

Documentation and release notes now describe Miyo as the only semantic backend and lexical search as the non-Miyo fallback.

## Non goal

- No agent access-control work.
- No merge of Free Chat and Copilot Plus chat.
- No change to Miyo connection, registration, scope, search, or document processing.
- No removal of QA prompt/configuration fields that remain shared by surviving chat behavior.
- No broad deletion by prefix, no directory removal, and no cleanup outside the two named directories.

## Screenshot

Not applicable. This PR changes persisted settings and migration behavior; the user-visible legacy controls were removed earlier in the stack.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Schema cleanup, exact artifact matching, failure isolation, and settings preservation have deterministic coverage |
| A defect would fail CI or be obvious on first use | ❌ | Over-broad artifact deletion could be silent, so the exact clean build was also exercised against a real Obsidian vault |
| A revert fully restores prior state, including persisted data | ❌ | The migration intentionally deletes obsolete settings and exact legacy index artifacts |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Existing keychain backup behavior is retained and Miyo authentication is untouched |
| No public API, plugin API, message, or on-disk contract changes | ❌ | The persisted settings schema advances to v13 and retires eleven fields |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Cleanup is a versioned startup migration with isolated sequential folder operations |
| No hot-path behavior lacks deterministic coverage | ✅ | Load/save stripping and the migration runner are covered; no retrieval hot path changes |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Real-vault verification is limited to migration output and filesystem preservation |

Review `legacyIndexSettings.ts` first for the exact eleven-field boundary, then `legacyIndexRemovalMigration.ts` for the filename allowlist and the device-local marker gate. Finally inspect `KeychainService.removeRetiredEmbeddingSecrets()`, `runSettingsMigrations.ts`, keychain backup detection, and the v12 Azure compatibility types before running Verification steps 1-4.

## Verification

1. Run `npm test -- --runInBand`; all 474 suites and 6,468 tests should pass.
2. Run `npm run format`, `npm run lint`, `npm run build`, `npm run test:mobile-load`, and `npm run review:obsidian`. Lint/review should report only the repository's existing settings-search warning and fixture diagnostics.
3. Load exact clean build `7b3f8e03-clean-65575caa714e` in a real Obsidian vault with settings version 12, all eleven retired keys, provider/BYOK/QA/Miyo sentinels, exact legacy artifacts in both cleanup directories, and unrelated sentinel files. Reload Copilot: settings should advance to v13, all retired keys and exact artifacts should disappear, and every unrelated setting/file should remain byte-identical.
4. Reload again with the marker already set: no artifact should be touched. Then clear the `obsidian-copilot:legacy-index-cleanup:v1` local-storage key with `settingsVersion` left at 13, restore the controlled artifacts, and reload: the cleanup should run, proving the gate is device-local rather than synced. Confirm the `.copilot-index` and config directories both remain, malformed/uppercase/nested/user files are never deleted, and that a Keychain entry named `copilot-v<vault id>-model-api-key-embedding-*` is gone while the chat-scoped entries remain.

