### PR TITLE
Re-rank Relevant Notes while the user writes

### DIFF
--- a/docs/vault-search-and-indexing.md
+++ b/docs/vault-search-and-indexing.md
@@ -78,7 +78,7 @@ Links and backlinks do not create rows in any of these empty states. Copilot's o
 
 #### Live update
 
-The **Live** switch at the top right of the pane keeps Relevant Notes in step with the note you are writing. While it is on, the list re-ranks itself a few seconds after each change lands: notes that become more relevant rise and their relevance bar grows, newly relevant notes fade in, and notes that no longer relate fade out. Turning it off freezes the pane until you open another note or reconnect Miyo, and turning it back on brings it up to date at once. The switch is on by default and your choice is remembered.
+The **Live** switch at the top right of the pane keeps Relevant Notes in step with the note you are writing. While it is on, the list re-ranks itself a few seconds after each change lands: notes that become more relevant rise and their relevance bar grows, newly relevant notes fade in, and notes that no longer relate fade out. Turning it off freezes the pane until you open another note or reconnect Miyo, and turning it back on catches it up on whatever you wrote while it was off. The switch is on by default and your choice is remembered.
 
 Updates follow what Miyo has indexed rather than the text on screen, so they arrive a few seconds behind your typing. A note you are not editing costs nothing, and a change that does not move the ranking leaves the list alone. If your system is set to reduce motion, the list still updates but nothing animates.
 

--- a/docs/vault-search-and-indexing.md
+++ b/docs/vault-search-and-indexing.md
@@ -76,6 +76,12 @@ For a remote Miyo or mobile device, error and exclusion cards tell you to review
 
 Links and backlinks do not create rows in any of these empty states. Copilot's own inclusion and exclusion patterns do not filter Relevant Notes; Miyo's folder filters are the only scope there.
 
+#### Live update
+
+The **Live** switch at the top right of the pane keeps Relevant Notes in step with the note you are writing. While it is on, the list re-ranks itself a few seconds after each change lands: notes that become more relevant rise and their relevance bar grows, newly relevant notes fade in, and notes that no longer relate fade out. Turning it off freezes the pane until you open another note or reconnect Miyo, and turning it back on brings it up to date at once. The switch is on by default and your choice is remembered.
+
+Updates follow what Miyo has indexed rather than the text on screen, so they arrive a few seconds behind your typing. A note you are not editing costs nothing, and a change that does not move the ranking leaves the list alone. If your system is set to reduce motion, the list still updates but nothing animates.
+
 ## Search conversations and process documents
 
 Miyo can also index supported ChatGPT and Claude chat histories. Configure those sources in Miyo, then use the **Search chat** row in Copilot to see their status and open Miyo's management screen. Chat-history search is separate from vault search.

--- a/src/components/chat-components/RelevantNotes.test.tsx
+++ b/src/components/chat-components/RelevantNotes.test.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @eslint-react/hooks-extra/no-unnecessary-use-prefix -- Mock exports must preserve production hook names. */
 import { RelevantNotes } from "@/components/chat-components/RelevantNotes";
 import { useActiveFile } from "@/hooks/useActiveFile";
+import { LIVE_REFRESH_INTERVAL_MS } from "@/hooks/useLiveRelevantNotesRefresh";
 import { findRelevantNotes } from "@/search/findRelevantNotes";
 import { openCopilotSettings } from "@/settings/openSettings";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
@@ -9,25 +10,30 @@ import React from "react";
 
 const mockOpenFile = jest.fn().mockResolvedValue(undefined);
 const mockGetLeaf = jest.fn(() => ({ openFile: mockOpenFile }));
+let vaultModifyHandlers: ((file: unknown) => void)[] = [];
 const mockApp = {
   vault: {
     getAbstractFileByPath: jest.fn(),
     cachedRead: jest.fn().mockResolvedValue(""),
     getName: jest.fn(() => "Work Vault"),
+    on: jest.fn((event: string, handler: (file: unknown) => void) => {
+      if (event === "modify") vaultModifyHandlers.push(handler);
+      return { handler };
+    }),
+    offref: jest.fn((ref: { handler: (file: unknown) => void }) => {
+      vaultModifyHandlers = vaultModifyHandlers.filter((handler) => handler !== ref.handler);
+    }),
   },
   workspace: {
     getLeaf: mockGetLeaf,
   },
 };
-let mockSettings: {
-  enableMiyo: boolean;
-  miyoServerUrl: string;
-  plusLicenseKey: string;
-  qaExclusions?: string;
-} = {
+const mockUpdateSetting = jest.fn();
+let mockSettings = {
   enableMiyo: true,
   miyoServerUrl: "",
   plusLicenseKey: "old-license",
+  relevantNotesLiveUpdate: true,
 };
 let mockMiyoBackend = "unknown";
 let indexChangedListener: (() => void) | null = null;
@@ -49,6 +55,7 @@ jest.mock("@/miyo/useMiyoStatus", () => ({
 }));
 
 jest.mock("@/search/findRelevantNotes", () => ({
+  ...jest.requireActual<typeof import("@/search/findRelevantNotes")>("@/search/findRelevantNotes"),
   findRelevantNotes: jest.fn(),
 }));
 
@@ -63,6 +70,9 @@ jest.mock("@/miyo/miyoIndex", () => ({
 
 jest.mock("@/settings/model", () => ({
   useSettingsValue: () => mockSettings,
+  updateSetting: (...args: unknown[]) => {
+    mockUpdateSetting(...args);
+  },
 }));
 
 jest.mock("@/settings/openSettings", () => ({ openCopilotSettings: jest.fn() }));
@@ -83,9 +93,11 @@ describe("RelevantNotes", () => {
       enableMiyo: true,
       miyoServerUrl: "",
       plusLicenseKey: "old-license",
+      relevantNotesLiveUpdate: true,
     };
     mockMiyoBackend = "unknown";
     indexChangedListener = null;
+    vaultModifyHandlers = [];
     const sourceFile = makeMarkdownFile("Source.md");
     const targetFile = makeMarkdownFile("Target.md");
     mockUseActiveFile.mockReturnValue(sourceFile);
@@ -480,6 +492,139 @@ describe("RelevantNotes", () => {
       });
 
       expect(screen.getByText("Current")).toBeTruthy();
+    });
+
+    it("keeps the settled rows on screen while a live re-query runs (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", async () => {
+      jest.useFakeTimers();
+      try {
+        render(<RelevantNotes onAddToChat={jest.fn()} />);
+        await act(async () => {});
+        expect(screen.getByText("Target")).toBeTruthy();
+        let releaseLiveQuery: (() => void) | null = null;
+        mockFindRelevantNotes.mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              releaseLiveQuery = () =>
+                resolve({
+                  notes: [
+                    {
+                      note: { path: "Target.md", title: "Target" },
+                      metadata: { score: 0.9, hasOutgoingLinks: false, hasBacklinks: false },
+                    },
+                  ],
+                  status: "matches",
+                });
+            })
+        );
+
+        act(() => {
+          vaultModifyHandlers.forEach((handler) => handler(makeMarkdownFile("Source.md")));
+        });
+        act(() => {
+          jest.advanceTimersByTime(LIVE_REFRESH_INTERVAL_MS);
+        });
+
+        expect(screen.queryByText("Finding relevant notes…")).toBeNull();
+        expect(screen.getByText("Target")).toBeTruthy();
+        await act(async () => releaseLiveQuery?.());
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it("re-ranks the rows when a live re-query returns a new order (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", async () => {
+      jest.useFakeTimers();
+      try {
+        render(<RelevantNotes onAddToChat={jest.fn()} />);
+        await act(async () => {});
+        mockFindRelevantNotes.mockResolvedValue({
+          notes: [
+            {
+              note: { path: "Source Two.md", title: "Source Two" },
+              metadata: { score: 0.95, hasOutgoingLinks: false, hasBacklinks: false },
+            },
+            {
+              note: { path: "Target.md", title: "Target" },
+              metadata: { score: 0.2, hasOutgoingLinks: false, hasBacklinks: false },
+            },
+          ],
+          status: "matches",
+        });
+
+        act(() => {
+          vaultModifyHandlers.forEach((handler) => handler(makeMarkdownFile("Source.md")));
+        });
+        await act(async () => {
+          jest.advanceTimersByTime(LIVE_REFRESH_INTERVAL_MS);
+        });
+
+        expect(screen.getByText("Source Two")).toBeTruthy();
+        expect(screen.getByText("95%")).toBeTruthy();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it("never re-queries while live update is switched off (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", async () => {
+      jest.useFakeTimers();
+      mockSettings = { ...mockSettings, relevantNotesLiveUpdate: false };
+      try {
+        render(<RelevantNotes onAddToChat={jest.fn()} />);
+        await act(async () => {});
+        mockFindRelevantNotes.mockClear();
+
+        act(() => {
+          vaultModifyHandlers.forEach((handler) => handler(makeMarkdownFile("Source.md")));
+          jest.advanceTimersByTime(LIVE_REFRESH_INTERVAL_MS * 4);
+        });
+
+        expect(vaultModifyHandlers).toHaveLength(0);
+        expect(mockFindRelevantNotes).not.toHaveBeenCalled();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it("persists the live update choice so it survives a reload (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", async () => {
+      render(<RelevantNotes onAddToChat={jest.fn()} />);
+      await act(async () => {});
+
+      fireEvent.click(screen.getByRole("switch"));
+
+      expect(mockUpdateSetting).toHaveBeenCalledWith("relevantNotesLiveUpdate", false);
+    });
+
+    it("catches the pane up on writes made while live update was off (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", async () => {
+      mockSettings = { ...mockSettings, relevantNotesLiveUpdate: false };
+      render(<RelevantNotes onAddToChat={jest.fn()} />);
+      await act(async () => {});
+      mockFindRelevantNotes.mockClear();
+
+      fireEvent.click(screen.getByRole("switch"));
+      await act(async () => {});
+
+      expect(mockUpdateSetting).toHaveBeenCalledWith("relevantNotesLiveUpdate", true);
+      expect(mockFindRelevantNotes).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not re-query when live update is switched off (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", async () => {
+      render(<RelevantNotes onAddToChat={jest.fn()} />);
+      await act(async () => {});
+      mockFindRelevantNotes.mockClear();
+
+      fireEvent.click(screen.getByRole("switch"));
+      await act(async () => {});
+
+      expect(mockFindRelevantNotes).not.toHaveBeenCalled();
+    });
+
+    it("offers no live update control while Miyo is disabled (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", async () => {
+      mockSettings = { ...mockSettings, enableMiyo: false };
+
+      render(<RelevantNotes onAddToChat={jest.fn()} />);
+      await act(async () => {});
+
+      expect(screen.queryByRole("switch")).toBeNull();
     });
   });
 });

--- a/src/components/chat-components/RelevantNotes.test.tsx
+++ b/src/components/chat-components/RelevantNotes.test.tsx
@@ -596,26 +596,119 @@ describe("RelevantNotes", () => {
 
     it("catches the pane up on writes made while live update was off (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", async () => {
       mockSettings = { ...mockSettings, relevantNotesLiveUpdate: false };
-      render(<RelevantNotes onAddToChat={jest.fn()} />);
+      const { rerender } = render(<RelevantNotes onAddToChat={jest.fn()} />);
       await act(async () => {});
       mockFindRelevantNotes.mockClear();
 
       fireEvent.click(screen.getByRole("switch"));
+      expect(mockUpdateSetting).toHaveBeenCalledWith("relevantNotesLiveUpdate", true);
+      mockSettings = { ...mockSettings, relevantNotesLiveUpdate: true };
+      rerender(<RelevantNotes onAddToChat={jest.fn()} />);
       await act(async () => {});
 
-      expect(mockUpdateSetting).toHaveBeenCalledWith("relevantNotesLiveUpdate", true);
       expect(mockFindRelevantNotes).toHaveBeenCalledTimes(1);
     });
 
     it("does not re-query when live update is switched off (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", async () => {
-      render(<RelevantNotes onAddToChat={jest.fn()} />);
+      const { rerender } = render(<RelevantNotes onAddToChat={jest.fn()} />);
       await act(async () => {});
       mockFindRelevantNotes.mockClear();
 
       fireEvent.click(screen.getByRole("switch"));
+      expect(mockUpdateSetting).toHaveBeenCalledWith("relevantNotesLiveUpdate", false);
+      mockSettings = { ...mockSettings, relevantNotesLiveUpdate: false };
+      rerender(<RelevantNotes onAddToChat={jest.fn()} />);
       await act(async () => {});
 
       expect(mockFindRelevantNotes).not.toHaveBeenCalled();
+    });
+
+    it("keeps the ranking the reader froze when live update goes off mid-query (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", async () => {
+      jest.useFakeTimers();
+      try {
+        const { rerender } = render(<RelevantNotes onAddToChat={jest.fn()} />);
+        await act(async () => {});
+        expect(screen.getByText("Target")).toBeTruthy();
+        let releaseLiveQuery: (() => void) | null = null;
+        mockFindRelevantNotes.mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              releaseLiveQuery = () =>
+                resolve({
+                  notes: [
+                    {
+                      note: { path: "Late.md", title: "Late" },
+                      metadata: { score: 0.9, hasOutgoingLinks: false, hasBacklinks: false },
+                    },
+                  ],
+                  status: "matches",
+                });
+            })
+        );
+        act(() => {
+          vaultModifyHandlers.forEach((handler) => handler(makeMarkdownFile("Source.md")));
+        });
+        act(() => {
+          jest.advanceTimersByTime(LIVE_REFRESH_INTERVAL_MS);
+        });
+
+        mockSettings = { ...mockSettings, relevantNotesLiveUpdate: false };
+        rerender(<RelevantNotes onAddToChat={jest.fn()} />);
+        await act(async () => releaseLiveQuery?.());
+
+        expect(screen.queryByText("Late")).toBeNull();
+        expect(screen.getByText("Target")).toBeTruthy();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it("starts no second live search while the previous one is still open (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", async () => {
+      jest.useFakeTimers();
+      try {
+        render(<RelevantNotes onAddToChat={jest.fn()} />);
+        await act(async () => {});
+        mockFindRelevantNotes.mockClear();
+        mockFindRelevantNotes.mockReturnValue(new Promise(() => undefined));
+
+        act(() => {
+          vaultModifyHandlers.forEach((handler) => handler(makeMarkdownFile("Source.md")));
+        });
+        act(() => {
+          jest.advanceTimersByTime(LIVE_REFRESH_INTERVAL_MS);
+        });
+        act(() => {
+          jest.advanceTimersByTime(LIVE_REFRESH_INTERVAL_MS);
+        });
+        act(() => {
+          jest.advanceTimersByTime(LIVE_REFRESH_INTERVAL_MS);
+        });
+
+        expect(mockFindRelevantNotes).toHaveBeenCalledTimes(1);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it("offers no live update and follows no writes where Miyo cannot run (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", async () => {
+      (Platform as { isMobile: boolean }).isMobile = true;
+      mockSettings = { ...mockSettings, miyoServerUrl: "" };
+      jest.useFakeTimers();
+      try {
+        render(<RelevantNotes onAddToChat={jest.fn()} />);
+        await act(async () => {});
+        mockFindRelevantNotes.mockClear();
+
+        act(() => {
+          jest.advanceTimersByTime(LIVE_REFRESH_INTERVAL_MS * 4);
+        });
+
+        expect(screen.queryByRole("switch")).toBeNull();
+        expect(vaultModifyHandlers).toHaveLength(0);
+        expect(mockFindRelevantNotes).not.toHaveBeenCalled();
+      } finally {
+        jest.useRealTimers();
+      }
     });
 
     it("offers no live update control while Miyo is disabled (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", async () => {

--- a/src/components/chat-components/RelevantNotes.tsx
+++ b/src/components/chat-components/RelevantNotes.tsx
@@ -1,5 +1,4 @@
-import { Button } from "@/components/ui/button";
-import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
+import { RelevantNoteRow } from "@/components/chat-components/ui/RelevantNoteRow";
 import { RelevantNotesPane } from "@/components/chat-components/ui/RelevantNotesPane";
 import { RelevantNotesToolbar } from "@/components/chat-components/ui/RelevantNotesToolbar";
 import { useRelevantNoteRowTransitions } from "@/components/chat-components/ui/useRelevantNoteRowTransitions";
@@ -7,11 +6,15 @@ import { MIYO_HOMEPAGE_URL } from "@/constants";
 import { useApp } from "@/context";
 import { useActiveFile } from "@/hooks/useActiveFile";
 import { useLiveRelevantNotesRefresh } from "@/hooks/useLiveRelevantNotesRefresh";
-import { useNoteDrag } from "@/hooks/useNoteDrag";
 import { useReducedMotion } from "@/hooks/useReducedMotion";
 import { cn } from "@/lib/utils";
 import { logError, logWarn } from "@/logger";
-import { getMiyoFolderName, isLocalMiyoUrl, MIYO_DEEPLINK_URL } from "@/miyo/miyoUtils";
+import {
+  getMiyoFolderName,
+  isLocalMiyoUrl,
+  MIYO_DEEPLINK_URL,
+  shouldUseMiyo,
+} from "@/miyo/miyoUtils";
 import { useMiyoStatus } from "@/miyo/useMiyoStatus";
 import {
   findRelevantNotes,
@@ -22,9 +25,8 @@ import { onMiyoIndexChanged } from "@/miyo/miyoIndex";
 import { openCopilotSettings } from "@/settings/openSettings";
 import { updateSetting, useSettingsValue } from "@/settings/model";
 import { sha256 } from "@/utils/hash";
-import { ArrowRight, FileInput, FileOutput, FileText, PlusCircle } from "lucide-react";
 import { Platform, TFile } from "obsidian";
-import React, { memo, useCallback, useEffect, useState } from "react";
+import React, { memo, useCallback, useEffect, useRef, useState } from "react";
 
 const EMPTY_RELEVANT_NOTES: readonly RelevantNoteEntry[] = Object.freeze([]);
 const IDLE_RELEVANT_NOTES_RESULT = Object.freeze({
@@ -76,27 +78,64 @@ function nextSettledRequest(
     : { requestKey, result };
 }
 
-function useRelevantNotes(
-  enableMiyo: boolean,
-  miyoServerUrl: string,
-  miyoBackendAvailable: boolean,
-  miyoCredentialIdentity: string
-) {
+/**
+ * The re-query the pane is currently running or about to run.
+ *
+ * `restart` enters the request key, so bumping it drops the settled rows and
+ * shows the loading state. A live re-query asks the same question again while
+ * the reader watches, so it keeps `restart` and only replaces the object: the
+ * rows stay on screen instead of blanking on every keystroke pause.
+ * https://github.com/Brevilabs/obsidian-copilot-private/issues/362
+ */
+interface RelevantNotesRequery {
+  restart: number;
+  live: boolean;
+}
+
+const INITIAL_REQUERY: RelevantNotesRequery = Object.freeze({ restart: 0, live: false });
+
+interface UseRelevantNotesOptions {
+  enableMiyo: boolean;
+  miyoServerUrl: string;
+  miyoBackendAvailable: boolean;
+  miyoCredentialIdentity: string;
+  /** Whether the reader has live update switched on for the pane. */
+  liveUpdateEnabled: boolean;
+}
+
+function useRelevantNotes({
+  enableMiyo,
+  miyoServerUrl,
+  miyoBackendAvailable,
+  miyoCredentialIdentity,
+  liveUpdateEnabled,
+}: UseRelevantNotesOptions) {
   const app = useApp();
   const [settledRequest, setSettledRequest] = useState<SettledRelevantNotesRequest | null>(null);
-  const [signalTick, setSignalTick] = useState(0);
-  const [liveTick, setLiveTick] = useState(0);
+  const [requery, setRequery] = useState<RelevantNotesRequery>(INITIAL_REQUERY);
   const activeFile = useActiveFile();
+  // Switching live update off must freeze a re-query that is already open, and
+  // the effect below closes over the value it started with.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/362
+  const liveUpdateEnabledRef = useRef(liveUpdateEnabled);
+  liveUpdateEnabledRef.current = liveUpdateEnabled;
+  const searchOpenRef = useRef(false);
   // Non-Markdown leaves do not provide a note Miyo can relate, so they share
   // the neutral no-source state instead of showing setup guidance.
   // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
   const activeFilePath = activeFile?.extension === "md" ? activeFile.path : undefined;
-  const refresh = useCallback(() => setSignalTick((tick) => tick + 1), []);
-  // A live re-query asks the same question again, so it must not enter the
-  // request key: the settled rows stay on screen while it runs instead of being
-  // replaced by the loading state on every keystroke pause.
-  // https://github.com/Brevilabs/obsidian-copilot-private/issues/362
-  const liveRefresh = useCallback(() => setLiveTick((tick) => tick + 1), []);
+  const refresh = useCallback(
+    () => setRequery((current) => ({ restart: current.restart + 1, live: false })),
+    []
+  );
+  const liveRefresh = useCallback(() => {
+    // Miyo can take longer to answer than the live interval when it is remote
+    // or busy. Starting a second search for the same question would leave both
+    // in flight and throw one answer away, so the tick is skipped instead.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/362
+    if (searchOpenRef.current) return;
+    setRequery((current) => ({ ...current, live: true }));
+  }, []);
   // Without an active note there is nothing to search, so setup state must not
   // replace the pane's neutral empty state.
   // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
@@ -108,7 +147,7 @@ function useRelevantNotes(
           miyoServerUrl,
           miyoBackendAvailable,
           miyoCredentialIdentity,
-          signalTick,
+          requery.restart,
         ])
       : null;
 
@@ -133,20 +172,33 @@ function useRelevantNotes(
       // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
       // https://github.com/Brevilabs/obsidian-copilot-private/issues/362
       setSettledRequest((settled) => (settled?.requestKey === requestKey ? settled : null));
+      // Switching live update off freezes the ranking the reader is looking at,
+      // so a live re-query that was still open when they switched it off must
+      // not re-rank it on arrival.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/362
+      const frozen = (settled: SettledRelevantNotesRequest | null) =>
+        requery.live && !liveUpdateEnabledRef.current && settled?.requestKey === requestKey;
+      searchOpenRef.current = true;
       try {
         const result = await findRelevantNotes({ app, filePath: activeFilePath });
         // A settings or active-note change can supersede an in-flight Miyo
         // request. Its older result must not replace the newer pane state.
         // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
         if (!cancelled)
-          setSettledRequest((settled) => nextSettledRequest(settled, requestKey, result));
+          setSettledRequest((settled) =>
+            frozen(settled) ? settled : nextSettledRequest(settled, requestKey, result)
+          );
       } catch (error) {
         if (!cancelled) {
           logWarn("Failed to fetch relevant notes", error);
           setSettledRequest((settled) =>
-            nextSettledRequest(settled, requestKey, UNAVAILABLE_RELEVANT_NOTES_RESULT)
+            frozen(settled)
+              ? settled
+              : nextSettledRequest(settled, requestKey, UNAVAILABLE_RELEVANT_NOTES_RESULT)
           );
         }
+      } finally {
+        searchOpenRef.current = false;
       }
     }
 
@@ -154,7 +206,7 @@ function useRelevantNotes(
     return () => {
       cancelled = true;
     };
-  }, [app, activeFilePath, requestKey, requestStatus, liveTick]);
+  }, [app, activeFilePath, requestKey, requestStatus, requery]);
 
   const result: RelevantNotesViewResult =
     requestStatus === "disabled"
@@ -166,301 +218,6 @@ function useRelevantNotes(
           : LOADING_RELEVANT_NOTES_RESULT;
 
   return { result, refresh, liveRefresh };
-}
-
-/** Map a 0–1 similarity score directly to the meter fill width (70% → 70%). */
-function meterWidth(score: number): string {
-  return `${Math.max(0, Math.min(100, score * 100))}%`;
-}
-
-/** Color-grade the meter: stronger matches lean fully into the theme accent. */
-function meterColor(score: number): string {
-  const pct = score * 100;
-  const k = Math.max(0, Math.min(1, (pct - 30) / 45));
-  return `color-mix(in srgb, var(--interactive-accent) ${Math.round(40 + 60 * k)}%, var(--text-faint))`;
-}
-
-function RelevanceMeter({
-  score,
-  animated,
-  className,
-}: {
-  score: number;
-  /** False when the reader has asked for reduced motion. */
-  animated: boolean;
-  className?: string;
-}) {
-  return (
-    <div
-      className={cn(
-        "tw-h-[3px] tw-w-full tw-overflow-hidden tw-rounded-full tw-bg-modifier-hover",
-        className
-      )}
-    >
-      <div
-        className={cn(
-          "copilot-relevance-meter-fill tw-h-full tw-rounded-full",
-          // A live re-rank rewrites the score, and growing or shrinking the bar
-          // is what makes a note's rising relevance readable as it happens.
-          // https://github.com/Brevilabs/obsidian-copilot-private/issues/362
-          animated && "tw-transition-[width,background-color] tw-duration-500 tw-ease-out"
-        )}
-        style={
-          {
-            "--relevance-meter-fill": meterWidth(score),
-            "--relevance-meter-color": meterColor(score),
-          } as React.CSSProperties
-        }
-      />
-    </div>
-  );
-}
-
-function LinkBadge({ icon, label }: { icon: React.ReactNode; label: string }) {
-  return (
-    <span
-      title={label}
-      className="tw-flex tw-items-center tw-justify-center tw-rounded-sm tw-bg-modifier-hover tw-p-1 tw-text-faint"
-    >
-      {icon}
-    </span>
-  );
-}
-
-function RelevantNoteHoverCard({
-  note,
-  animated,
-  onAddToChat,
-  onNavigateToNote,
-  children,
-}: {
-  note: RelevantNoteEntry;
-  animated: boolean;
-  onAddToChat: () => void;
-  onNavigateToNote: () => void;
-  children: React.ReactNode;
-}) {
-  const app = useApp();
-  const [open, setOpen] = useState(false);
-  const [fileContent, setFileContent] = useState<string | null>(null);
-  const similarity = note.metadata.score;
-
-  const loadContent = useCallback(async () => {
-    if (fileContent) return; // Don't reload once cached
-    const file = app.vault.getAbstractFileByPath(note.note.path);
-    if (file instanceof TFile) {
-      const content = await app.vault.cachedRead(file);
-
-      // Remove YAML frontmatter if it exists
-      let cleanContent = content;
-      if (content.startsWith("---")) {
-        const endOfFrontmatter = content.indexOf("---", 3);
-        if (endOfFrontmatter !== -1) {
-          cleanContent = content.slice(endOfFrontmatter + 3).trim();
-        }
-      }
-
-      setFileContent(cleanContent);
-    }
-  }, [app, fileContent, note.note.path]);
-
-  useEffect(() => {
-    if (open) {
-      void loadContent();
-    }
-  }, [open, loadContent]);
-
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverAnchor asChild>
-        <div onMouseEnter={() => setOpen(true)} onMouseLeave={() => setOpen(false)}>
-          {children}
-        </div>
-      </PopoverAnchor>
-      <PopoverContent
-        side="left"
-        align="start"
-        sideOffset={0}
-        onMouseEnter={() => setOpen(true)}
-        onMouseLeave={() => setOpen(false)}
-        onOpenAutoFocus={(e) => e.preventDefault()}
-        className="tw-flex tw-w-fit tw-min-w-72 tw-max-w-96 tw-flex-col tw-gap-3 tw-overflow-hidden tw-p-3"
-      >
-        <div className="tw-flex tw-flex-col tw-gap-1">
-          <span className="tw-text-sm tw-font-semibold tw-text-normal">{note.note.title}</span>
-          <span className="tw-flex tw-items-center tw-gap-1.5 tw-text-xs tw-text-faint">
-            <FileText className="tw-size-3.5 tw-shrink-0" />
-            <span className="tw-truncate">{note.note.path}</span>
-          </span>
-        </div>
-
-        {fileContent && (
-          <p className="tw-m-0 tw-max-h-64 tw-overflow-y-auto tw-whitespace-pre-line tw-text-xs tw-leading-normal tw-text-muted">
-            {fileContent}
-          </p>
-        )}
-
-        <div className="tw-flex tw-items-center tw-gap-2">
-          <span className="tw-shrink-0 tw-text-xs tw-text-faint">Similarity</span>
-          <RelevanceMeter score={similarity} animated={animated} className="tw-h-1 tw-flex-1" />
-          <span className="tw-shrink-0 tw-text-xs tw-font-medium tw-tabular-nums tw-text-normal">
-            {(similarity * 100).toFixed(1)}%
-          </span>
-        </div>
-
-        {(note.metadata.hasOutgoingLinks || note.metadata.hasBacklinks) && (
-          <div className="tw-flex tw-items-center tw-gap-4 tw-text-xs tw-text-faint">
-            {note.metadata.hasOutgoingLinks && (
-              <span className="tw-flex tw-items-center tw-gap-1">
-                <FileOutput className="tw-size-3.5" />
-                Outgoing links
-              </span>
-            )}
-            {note.metadata.hasBacklinks && (
-              <span className="tw-flex tw-items-center tw-gap-1">
-                <FileInput className="tw-size-3.5" />
-                Backlinks
-              </span>
-            )}
-          </div>
-        )}
-
-        <div className="tw-flex tw-gap-2">
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={onAddToChat}
-            className="tw-flex-1 tw-gap-1.5"
-          >
-            <PlusCircle className="tw-size-4" />
-            Add to Chat
-          </Button>
-          <Button
-            variant="default"
-            size="sm"
-            onClick={onNavigateToNote}
-            className="tw-flex-1 tw-gap-1.5"
-          >
-            Open note
-            <ArrowRight className="tw-size-4" />
-          </Button>
-        </div>
-      </PopoverContent>
-    </Popover>
-  );
-}
-
-function RelevantNoteRow({
-  note,
-  exiting,
-  entering,
-  animated,
-  rowRef,
-  onAddToChat,
-  onNavigateToNote,
-}: {
-  note: RelevantNoteEntry;
-  /** True while the note is mounted only to play its removal. */
-  exiting: boolean;
-  /** True while the note should play its arrival. */
-  entering: boolean;
-  /** False when the reader has asked for reduced motion. */
-  animated: boolean;
-  rowRef: (node: HTMLElement | null) => void;
-  onAddToChat: () => void;
-  onNavigateToNote: () => void;
-}) {
-  const app = useApp();
-  const handleDragStart = useNoteDrag();
-  const similarity = note.metadata.score;
-
-  return (
-    <RelevantNoteHoverCard
-      note={note}
-      animated={animated}
-      onAddToChat={onAddToChat}
-      onNavigateToNote={onNavigateToNote}
-    >
-      <div
-        ref={rowRef}
-        className={cn(
-          "tw-group tw-rounded-md tw-px-2.5 tw-py-1.5 tw-transition-colors hover:tw-bg-modifier-hover",
-          // A note that arrives or drops out mid-sentence is easy to miss if it
-          // simply appears or vanishes between two frames.
-          // https://github.com/Brevilabs/obsidian-copilot-private/issues/362
-          entering && "tw-duration-200 tw-animate-in tw-fade-in-0 tw-slide-in-from-top-1",
-          exiting && "tw-pointer-events-none tw-opacity-0",
-          exiting && animated && "tw-transition-opacity tw-duration-200"
-        )}
-      >
-        <div className="tw-flex tw-min-h-6 tw-items-center tw-gap-2">
-          <a
-            draggable
-            onDragStart={(e) => {
-              const file = app.vault.getAbstractFileByPath(note.note.path);
-              if (file instanceof TFile) {
-                handleDragStart(e, file);
-              }
-            }}
-            onClick={(e) => {
-              e.preventDefault();
-              onNavigateToNote();
-            }}
-            onAuxClick={(e) => {
-              if (e.button === 1) {
-                e.preventDefault();
-                onNavigateToNote();
-              }
-            }}
-            className="tw-min-w-0 tw-flex-1 tw-cursor-pointer tw-truncate tw-text-sm tw-font-medium tw-text-normal !tw-no-underline"
-          >
-            {note.note.title}
-          </a>
-
-          <div className="tw-flex tw-shrink-0 tw-items-center tw-gap-1.5 group-hover:tw-hidden">
-            {note.metadata.hasOutgoingLinks && (
-              <LinkBadge icon={<FileOutput className="tw-size-3" />} label="Outgoing link" />
-            )}
-            {note.metadata.hasBacklinks && (
-              <LinkBadge icon={<FileInput className="tw-size-3" />} label="Backlink" />
-            )}
-            <span className="tw-text-xs tw-font-medium tw-tabular-nums tw-text-muted">
-              {Math.round(similarity * 100)}%
-            </span>
-          </div>
-
-          <div className="tw-hidden tw-shrink-0 tw-items-center tw-gap-0.5 group-hover:tw-flex">
-            <Button
-              variant="ghost2"
-              size="icon"
-              title="Add to Chat"
-              className="tw-size-6 tw-p-0"
-              onClick={(e) => {
-                e.stopPropagation();
-                onAddToChat();
-              }}
-            >
-              <PlusCircle className="tw-size-4" />
-            </Button>
-            <Button
-              variant="ghost2"
-              size="icon"
-              title="Open note"
-              className="tw-size-6 tw-p-0"
-              onClick={(e) => {
-                e.stopPropagation();
-                onNavigateToNote();
-              }}
-            >
-              <ArrowRight className="tw-size-4" />
-            </Button>
-          </div>
-        </div>
-
-        <RelevanceMeter score={similarity} animated={animated} className="tw-mt-1.5" />
-      </div>
-    </RelevantNoteHoverCard>
-  );
 }
 
 interface RelevantNotesProps {
@@ -479,12 +236,18 @@ export const RelevantNotes = memo(
     // credential itself in request state.
     // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
     const miyoCredentialIdentity = sha256(settings.plusLicenseKey);
-    const { result, refresh, liveRefresh } = useRelevantNotes(
-      settings.enableMiyo,
-      settings.miyoServerUrl,
+    // Mobile without a remote server cannot reach Miyo at all, so following its
+    // index there would only poll a backend every search is refused by.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/362
+    const canFollowMiyoIndex = shouldUseMiyo(settings);
+    const liveUpdateEnabled = canFollowMiyoIndex && settings.relevantNotesLiveUpdate;
+    const { result, refresh, liveRefresh } = useRelevantNotes({
+      enableMiyo: settings.enableMiyo,
+      miyoServerUrl: settings.miyoServerUrl,
       miyoBackendAvailable,
-      miyoCredentialIdentity
-    );
+      miyoCredentialIdentity,
+      liveUpdateEnabled,
+    });
     // The toolbar must name only a source the search contract accepts; showing
     // an attachment name would imply that Miyo searched it.
     // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
@@ -499,7 +262,7 @@ export const RelevantNotes = memo(
 
     useLiveRelevantNotesRefresh({
       app,
-      enabled: settings.enableMiyo && settings.relevantNotesLiveUpdate,
+      enabled: liveUpdateEnabled,
       filePath: activeFilePath,
       onRefresh: liveRefresh,
     });
@@ -531,17 +294,10 @@ export const RelevantNotes = memo(
           // while the pane is showing Miyo setup guidance instead of results.
           // https://github.com/Brevilabs/obsidian-copilot-private/issues/362
           liveUpdate={
-            settings.enableMiyo
+            canFollowMiyoIndex
               ? {
                   enabled: settings.relevantNotesLiveUpdate,
-                  onChange: (enabled) => {
-                    updateSetting("relevantNotesLiveUpdate", enabled);
-                    // Writes made while live update was off left the pane
-                    // behind, so switching it on catches it up instead of
-                    // waiting for the next keystroke.
-                    // https://github.com/Brevilabs/obsidian-copilot-private/issues/362
-                    if (enabled) liveRefresh();
-                  },
+                  onChange: (enabled) => updateSetting("relevantNotesLiveUpdate", enabled),
                 }
               : undefined
           }

--- a/src/components/chat-components/RelevantNotes.tsx
+++ b/src/components/chat-components/RelevantNotes.tsx
@@ -353,6 +353,7 @@ function RelevantNoteHoverCard({
 function RelevantNoteRow({
   note,
   exiting,
+  entering,
   animated,
   rowRef,
   onAddToChat,
@@ -361,6 +362,8 @@ function RelevantNoteRow({
   note: RelevantNoteEntry;
   /** True while the note is mounted only to play its removal. */
   exiting: boolean;
+  /** True while the note should play its arrival. */
+  entering: boolean;
   /** False when the reader has asked for reduced motion. */
   animated: boolean;
   rowRef: (node: HTMLElement | null) => void;
@@ -385,7 +388,7 @@ function RelevantNoteRow({
           // A note that arrives or drops out mid-sentence is easy to miss if it
           // simply appears or vanishes between two frames.
           // https://github.com/Brevilabs/obsidian-copilot-private/issues/362
-          animated && "tw-duration-200 tw-animate-in tw-fade-in-0 tw-slide-in-from-top-1",
+          entering && "tw-duration-200 tw-animate-in tw-fade-in-0 tw-slide-in-from-top-1",
           exiting && "tw-pointer-events-none tw-opacity-0",
           exiting && animated && "tw-transition-opacity tw-duration-200"
         )}
@@ -486,13 +489,18 @@ export const RelevantNotes = memo(
     // an attachment name would imply that Miyo searched it.
     // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
     const activeFileName = activeFile?.extension === "md" ? activeFile.basename : undefined;
+    const activeFilePath = activeFile?.extension === "md" ? activeFile.path : undefined;
     const animated = !useReducedMotion();
-    const { rows, registerRow } = useRelevantNoteRowTransitions(result.notes, animated);
+    const { rows, registerRow } = useRelevantNoteRowTransitions(
+      result.notes,
+      activeFilePath,
+      animated
+    );
 
     useLiveRelevantNotesRefresh({
       app,
       enabled: settings.enableMiyo && settings.relevantNotesLiveUpdate,
-      filePath: activeFile?.extension === "md" ? activeFile.path : undefined,
+      filePath: activeFilePath,
       onRefresh: liveRefresh,
     });
 
@@ -548,6 +556,7 @@ export const RelevantNotes = memo(
                   key={row.note.note.path}
                   note={row.note}
                   exiting={row.exiting}
+                  entering={row.entering}
                   animated={animated}
                   rowRef={registerRow(row.note.note.path)}
                   onAddToChat={() => addToChat(row.note.note.title)}

--- a/src/components/chat-components/RelevantNotes.tsx
+++ b/src/components/chat-components/RelevantNotes.tsx
@@ -1,18 +1,26 @@
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
 import { RelevantNotesPane } from "@/components/chat-components/ui/RelevantNotesPane";
+import { RelevantNotesToolbar } from "@/components/chat-components/ui/RelevantNotesToolbar";
+import { useRelevantNoteRowTransitions } from "@/components/chat-components/ui/useRelevantNoteRowTransitions";
 import { MIYO_HOMEPAGE_URL } from "@/constants";
 import { useApp } from "@/context";
 import { useActiveFile } from "@/hooks/useActiveFile";
+import { useLiveRelevantNotesRefresh } from "@/hooks/useLiveRelevantNotesRefresh";
 import { useNoteDrag } from "@/hooks/useNoteDrag";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
 import { cn } from "@/lib/utils";
 import { logError, logWarn } from "@/logger";
 import { getMiyoFolderName, isLocalMiyoUrl, MIYO_DEEPLINK_URL } from "@/miyo/miyoUtils";
 import { useMiyoStatus } from "@/miyo/useMiyoStatus";
-import { findRelevantNotes, type RelevantNoteEntry } from "@/search/findRelevantNotes";
+import {
+  findRelevantNotes,
+  isSameRelevantNotesResult,
+  type RelevantNoteEntry,
+} from "@/search/findRelevantNotes";
 import { onMiyoIndexChanged } from "@/miyo/miyoIndex";
 import { openCopilotSettings } from "@/settings/openSettings";
-import { useSettingsValue } from "@/settings/model";
+import { updateSetting, useSettingsValue } from "@/settings/model";
 import { sha256 } from "@/utils/hash";
 import { ArrowRight, FileInput, FileOutput, FileText, PlusCircle } from "lucide-react";
 import { Platform, TFile } from "obsidian";
@@ -52,6 +60,22 @@ interface SettledRelevantNotesRequest {
   result: Awaited<ReturnType<typeof findRelevantNotes>> | typeof UNAVAILABLE_RELEVANT_NOTES_RESULT;
 }
 
+/**
+ * Keep the settled request untouched when a live re-query reproduces it.
+ *
+ * Returning the same object leaves React's state unchanged, so an unchanged
+ * ranking cannot restart the row animations while the user is still typing.
+ */
+function nextSettledRequest(
+  settled: SettledRelevantNotesRequest | null,
+  requestKey: string,
+  result: SettledRelevantNotesRequest["result"]
+): SettledRelevantNotesRequest {
+  return settled?.requestKey === requestKey && isSameRelevantNotesResult(settled.result, result)
+    ? settled
+    : { requestKey, result };
+}
+
 function useRelevantNotes(
   enableMiyo: boolean,
   miyoServerUrl: string,
@@ -61,12 +85,18 @@ function useRelevantNotes(
   const app = useApp();
   const [settledRequest, setSettledRequest] = useState<SettledRelevantNotesRequest | null>(null);
   const [signalTick, setSignalTick] = useState(0);
+  const [liveTick, setLiveTick] = useState(0);
   const activeFile = useActiveFile();
   // Non-Markdown leaves do not provide a note Miyo can relate, so they share
   // the neutral no-source state instead of showing setup guidance.
   // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
   const activeFilePath = activeFile?.extension === "md" ? activeFile.path : undefined;
   const refresh = useCallback(() => setSignalTick((tick) => tick + 1), []);
+  // A live re-query asks the same question again, so it must not enter the
+  // request key: the settled rows stay on screen while it runs instead of being
+  // replaced by the loading state on every keystroke pause.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/362
+  const liveRefresh = useCallback(() => setLiveTick((tick) => tick + 1), []);
   // Without an active note there is nothing to search, so setup state must not
   // replace the pane's neutral empty state.
   // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
@@ -98,18 +128,24 @@ function useRelevantNotes(
 
       // A request key can recur after visiting another note. Clear its earlier
       // result so the repeated request cannot render stale rows while loading.
+      // A result already settled under this key belongs to a live re-query and
+      // is kept, because dropping it would blank the pane while the user types.
       // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
-      setSettledRequest(null);
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/362
+      setSettledRequest((settled) => (settled?.requestKey === requestKey ? settled : null));
       try {
         const result = await findRelevantNotes({ app, filePath: activeFilePath });
         // A settings or active-note change can supersede an in-flight Miyo
         // request. Its older result must not replace the newer pane state.
         // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
-        if (!cancelled) setSettledRequest({ requestKey, result });
+        if (!cancelled)
+          setSettledRequest((settled) => nextSettledRequest(settled, requestKey, result));
       } catch (error) {
         if (!cancelled) {
           logWarn("Failed to fetch relevant notes", error);
-          setSettledRequest({ requestKey, result: UNAVAILABLE_RELEVANT_NOTES_RESULT });
+          setSettledRequest((settled) =>
+            nextSettledRequest(settled, requestKey, UNAVAILABLE_RELEVANT_NOTES_RESULT)
+          );
         }
       }
     }
@@ -118,7 +154,7 @@ function useRelevantNotes(
     return () => {
       cancelled = true;
     };
-  }, [app, activeFilePath, requestKey, requestStatus]);
+  }, [app, activeFilePath, requestKey, requestStatus, liveTick]);
 
   const result: RelevantNotesViewResult =
     requestStatus === "disabled"
@@ -129,7 +165,7 @@ function useRelevantNotes(
           ? settledRequest.result
           : LOADING_RELEVANT_NOTES_RESULT;
 
-  return { result, refresh };
+  return { result, refresh, liveRefresh };
 }
 
 /** Map a 0–1 similarity score directly to the meter fill width (70% → 70%). */
@@ -144,7 +180,16 @@ function meterColor(score: number): string {
   return `color-mix(in srgb, var(--interactive-accent) ${Math.round(40 + 60 * k)}%, var(--text-faint))`;
 }
 
-function RelevanceMeter({ score, className }: { score: number; className?: string }) {
+function RelevanceMeter({
+  score,
+  animated,
+  className,
+}: {
+  score: number;
+  /** False when the reader has asked for reduced motion. */
+  animated: boolean;
+  className?: string;
+}) {
   return (
     <div
       className={cn(
@@ -153,7 +198,13 @@ function RelevanceMeter({ score, className }: { score: number; className?: strin
       )}
     >
       <div
-        className={cn("copilot-relevance-meter-fill tw-h-full tw-rounded-full")}
+        className={cn(
+          "copilot-relevance-meter-fill tw-h-full tw-rounded-full",
+          // A live re-rank rewrites the score, and growing or shrinking the bar
+          // is what makes a note's rising relevance readable as it happens.
+          // https://github.com/Brevilabs/obsidian-copilot-private/issues/362
+          animated && "tw-transition-[width,background-color] tw-duration-500 tw-ease-out"
+        )}
         style={
           {
             "--relevance-meter-fill": meterWidth(score),
@@ -178,11 +229,13 @@ function LinkBadge({ icon, label }: { icon: React.ReactNode; label: string }) {
 
 function RelevantNoteHoverCard({
   note,
+  animated,
   onAddToChat,
   onNavigateToNote,
   children,
 }: {
   note: RelevantNoteEntry;
+  animated: boolean;
   onAddToChat: () => void;
   onNavigateToNote: () => void;
   children: React.ReactNode;
@@ -249,7 +302,7 @@ function RelevantNoteHoverCard({
 
         <div className="tw-flex tw-items-center tw-gap-2">
           <span className="tw-shrink-0 tw-text-xs tw-text-faint">Similarity</span>
-          <RelevanceMeter score={similarity} className="tw-h-1 tw-flex-1" />
+          <RelevanceMeter score={similarity} animated={animated} className="tw-h-1 tw-flex-1" />
           <span className="tw-shrink-0 tw-text-xs tw-font-medium tw-tabular-nums tw-text-normal">
             {(similarity * 100).toFixed(1)}%
           </span>
@@ -299,10 +352,18 @@ function RelevantNoteHoverCard({
 
 function RelevantNoteRow({
   note,
+  exiting,
+  animated,
+  rowRef,
   onAddToChat,
   onNavigateToNote,
 }: {
   note: RelevantNoteEntry;
+  /** True while the note is mounted only to play its removal. */
+  exiting: boolean;
+  /** False when the reader has asked for reduced motion. */
+  animated: boolean;
+  rowRef: (node: HTMLElement | null) => void;
   onAddToChat: () => void;
   onNavigateToNote: () => void;
 }) {
@@ -313,10 +374,22 @@ function RelevantNoteRow({
   return (
     <RelevantNoteHoverCard
       note={note}
+      animated={animated}
       onAddToChat={onAddToChat}
       onNavigateToNote={onNavigateToNote}
     >
-      <div className="tw-group tw-rounded-md tw-px-2.5 tw-py-1.5 tw-transition-colors hover:tw-bg-modifier-hover">
+      <div
+        ref={rowRef}
+        className={cn(
+          "tw-group tw-rounded-md tw-px-2.5 tw-py-1.5 tw-transition-colors hover:tw-bg-modifier-hover",
+          // A note that arrives or drops out mid-sentence is easy to miss if it
+          // simply appears or vanishes between two frames.
+          // https://github.com/Brevilabs/obsidian-copilot-private/issues/362
+          animated && "tw-duration-200 tw-animate-in tw-fade-in-0 tw-slide-in-from-top-1",
+          exiting && "tw-pointer-events-none tw-opacity-0",
+          exiting && animated && "tw-transition-opacity tw-duration-200"
+        )}
+      >
         <div className="tw-flex tw-min-h-6 tw-items-center tw-gap-2">
           <a
             draggable
@@ -381,27 +454,9 @@ function RelevantNoteRow({
           </div>
         </div>
 
-        <RelevanceMeter score={similarity} className="tw-mt-1.5" />
+        <RelevanceMeter score={similarity} animated={animated} className="tw-mt-1.5" />
       </div>
     </RelevantNoteHoverCard>
-  );
-}
-
-function RelevantNotesToolbar({ activeFileName }: { activeFileName: string | undefined }) {
-  return (
-    <div className="tw-flex tw-flex-none tw-items-center tw-gap-2 tw-border-0 tw-border-b tw-border-solid tw-border-border tw-px-3 tw-py-2">
-      <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-1.5 tw-text-xs tw-text-faint">
-        <span className="tw-shrink-0">Relevant to</span>
-        {activeFileName ? (
-          <span className="tw-flex tw-min-w-0 tw-items-center tw-gap-1 tw-text-muted">
-            <FileText className="tw-size-3.5 tw-shrink-0" />
-            <span className="tw-truncate tw-font-medium tw-text-normal">{activeFileName}</span>
-          </span>
-        ) : (
-          <span className="tw-text-muted">—</span>
-        )}
-      </div>
-    </div>
   );
 }
 
@@ -421,17 +476,25 @@ export const RelevantNotes = memo(
     // credential itself in request state.
     // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
     const miyoCredentialIdentity = sha256(settings.plusLicenseKey);
-    const { result, refresh } = useRelevantNotes(
+    const { result, refresh, liveRefresh } = useRelevantNotes(
       settings.enableMiyo,
       settings.miyoServerUrl,
       miyoBackendAvailable,
       miyoCredentialIdentity
     );
-    const relevantNotes = result.notes;
     // The toolbar must name only a source the search contract accepts; showing
     // an attachment name would imply that Miyo searched it.
     // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
     const activeFileName = activeFile?.extension === "md" ? activeFile.basename : undefined;
+    const animated = !useReducedMotion();
+    const { rows, registerRow } = useRelevantNoteRowTransitions(result.notes, animated);
+
+    useLiveRelevantNotesRefresh({
+      app,
+      enabled: settings.enableMiyo && settings.relevantNotesLiveUpdate,
+      filePath: activeFile?.extension === "md" ? activeFile.path : undefined,
+      onRefresh: liveRefresh,
+    });
 
     const navigateToNote = (notePath: string) => {
       const file = app.vault.getAbstractFileByPath(notePath);
@@ -454,18 +517,41 @@ export const RelevantNotes = memo(
 
     return (
       <div className={cn("tw-flex tw-min-h-full tw-w-full tw-flex-1 tw-flex-col", className)}>
-        <RelevantNotesToolbar activeFileName={activeFileName} />
+        <RelevantNotesToolbar
+          activeFileName={activeFileName}
+          // Live update follows the Miyo index, so the control is meaningless
+          // while the pane is showing Miyo setup guidance instead of results.
+          // https://github.com/Brevilabs/obsidian-copilot-private/issues/362
+          liveUpdate={
+            settings.enableMiyo
+              ? {
+                  enabled: settings.relevantNotesLiveUpdate,
+                  onChange: (enabled) => {
+                    updateSetting("relevantNotesLiveUpdate", enabled);
+                    // Writes made while live update was off left the pane
+                    // behind, so switching it on catches it up instead of
+                    // waiting for the next keystroke.
+                    // https://github.com/Brevilabs/obsidian-copilot-private/issues/362
+                    if (enabled) liveRefresh();
+                  },
+                }
+              : undefined
+          }
+        />
         <div className="tw-relative tw-min-h-0 tw-flex-1">
           <div className="tw-absolute tw-inset-0 tw-overflow-y-auto tw-p-2">
             <RelevantNotesPane
               status={result.status}
               details={result.details}
-              noteRows={relevantNotes.map((note) => (
+              noteRows={rows.map((row) => (
                 <RelevantNoteRow
-                  key={note.note.path}
-                  note={note}
-                  onAddToChat={() => addToChat(note.note.title)}
-                  onNavigateToNote={() => navigateToNote(note.note.path)}
+                  key={row.note.note.path}
+                  note={row.note}
+                  exiting={row.exiting}
+                  animated={animated}
+                  rowRef={registerRow(row.note.note.path)}
+                  onAddToChat={() => addToChat(row.note.note.title)}
+                  onNavigateToNote={() => navigateToNote(row.note.note.path)}
                 />
               ))}
               actions={{

--- a/src/components/chat-components/ui/RelevantNoteRow.stories.tsx
+++ b/src/components/chat-components/ui/RelevantNoteRow.stories.tsx
@@ -1,0 +1,108 @@
+import { Button } from "@/components/ui/button";
+import {
+  RelevantNoteRow,
+  type RelevantNoteRowProps,
+} from "@/components/chat-components/ui/RelevantNoteRow";
+import { useRelevantNoteRowTransitions } from "@/components/chat-components/ui/useRelevantNoteRowTransitions";
+import type { Meta, StoryObj } from "@/lib/story";
+import type { RelevantNoteEntry } from "@/search/findRelevantNotes";
+import React, { useState } from "react";
+
+function entry(title: string, score: number, links: Partial<RelevantNoteEntry["metadata"]> = {}) {
+  return {
+    note: { path: `${title}.md`, title },
+    metadata: { score, hasOutgoingLinks: false, hasBacklinks: false, ...links },
+  } satisfies RelevantNoteEntry;
+}
+
+const baseArgs: RelevantNoteRowProps = {
+  note: entry("Design principles", 0.86),
+  exiting: false,
+  entering: false,
+  animated: true,
+  rowRef: () => undefined,
+  onAddToChat: () => undefined,
+  onNavigateToNote: () => undefined,
+};
+
+/** Two rankings of the same notes, so the re-rank can be replayed on demand. */
+const RANKINGS: RelevantNoteEntry[][] = [
+  [
+    entry("Design principles", 0.86),
+    entry("Product research", 0.62),
+    entry("Interview notes", 0.4),
+  ],
+  [entry("Product research", 0.91), entry("Weekly review", 0.55), entry("Design principles", 0.31)],
+];
+
+/**
+ * Replays what a live re-query does to the list: rows slide to their new rank,
+ * scores grow or shrink, an arriving note fades in and a departing one fades
+ * out. Only the button advances it, so a screenshot is never mid-animation by
+ * accident.
+ */
+function LiveRerank(): React.ReactElement {
+  const [ranking, setRanking] = useState(0);
+  const { rows, registerRow } = useRelevantNoteRowTransitions(
+    RANKINGS[ranking % RANKINGS.length],
+    "Weekly review.md",
+    true
+  );
+
+  return (
+    <div className="tw-flex tw-flex-col tw-gap-2">
+      <Button variant="secondary" size="sm" onClick={() => setRanking((value) => value + 1)}>
+        Re-rank
+      </Button>
+      {rows.map((row) => (
+        <RelevantNoteRow
+          key={row.note.note.path}
+          note={row.note}
+          exiting={row.exiting}
+          entering={row.entering}
+          animated
+          rowRef={registerRow(row.note.note.path)}
+          onAddToChat={() => undefined}
+          onNavigateToNote={() => undefined}
+        />
+      ))}
+    </div>
+  );
+}
+
+const meta = {
+  title: "Chat/Relevant Note Row",
+  component: RelevantNoteRow,
+  args: baseArgs,
+  parameters: { gallery: { host: "leaf", layout: "padded" } },
+} satisfies Meta<RelevantNoteRowProps>;
+
+export default meta;
+
+export const StrongMatch: StoryObj<RelevantNoteRowProps> = {};
+
+export const WeakMatch: StoryObj<RelevantNoteRowProps> = {
+  args: { note: entry("Interview notes", 0.28) },
+};
+
+export const LinkedBothWays: StoryObj<RelevantNoteRowProps> = {
+  args: {
+    note: entry("Product research", 0.72, { hasOutgoingLinks: true, hasBacklinks: true }),
+  },
+};
+
+export const Arriving: StoryObj<RelevantNoteRowProps> = {
+  args: { entering: true },
+};
+
+export const Leaving: StoryObj<RelevantNoteRowProps> = {
+  args: { exiting: true },
+};
+
+export const ReducedMotion: StoryObj<RelevantNoteRowProps> = {
+  args: { animated: false, entering: false },
+};
+
+export const LiveReranking: StoryObj<RelevantNoteRowProps> = {
+  render: LiveRerank,
+};

--- a/src/components/chat-components/ui/RelevantNoteRow.test.tsx
+++ b/src/components/chat-components/ui/RelevantNoteRow.test.tsx
@@ -1,0 +1,107 @@
+/* eslint-disable @eslint-react/hooks-extra/no-unnecessary-use-prefix -- Mock exports must preserve production hook names. */
+import { RelevantNoteRow } from "@/components/chat-components/ui/RelevantNoteRow";
+import type { RelevantNoteEntry } from "@/search/findRelevantNotes";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+const mockApp = {
+  vault: {
+    getAbstractFileByPath: jest.fn(() => null),
+    cachedRead: jest.fn().mockResolvedValue(""),
+  },
+};
+
+jest.mock("@/context", () => ({
+  useApp: () => mockApp,
+}));
+
+jest.mock("@/hooks/useNoteDrag", () => ({
+  useNoteDrag: () => jest.fn(),
+}));
+
+function entry(overrides: Partial<RelevantNoteEntry["metadata"]> = {}): RelevantNoteEntry {
+  return {
+    note: { path: "Design principles.md", title: "Design principles" },
+    metadata: { score: 0.86, hasOutgoingLinks: false, hasBacklinks: false, ...overrides },
+  };
+}
+
+function renderRow(props: Partial<React.ComponentProps<typeof RelevantNoteRow>> = {}) {
+  return render(
+    <RelevantNoteRow
+      note={entry()}
+      exiting={false}
+      entering={false}
+      animated
+      rowRef={() => undefined}
+      onAddToChat={() => undefined}
+      onNavigateToNote={() => undefined}
+      {...props}
+    />
+  );
+}
+
+describe("RelevantNoteRow", () => {
+  describe("RelevantNoteRow()", () => {
+    it("names the note and states how strongly it matches", () => {
+      renderRow();
+
+      expect(screen.getByText("Design principles")).toBeTruthy();
+      expect(screen.getByText("86%")).toBeTruthy();
+    });
+
+    it("marks a note that is linked in either direction", () => {
+      renderRow({ note: entry({ hasOutgoingLinks: true, hasBacklinks: true }) });
+
+      expect(screen.getByTitle("Outgoing link")).toBeTruthy();
+      expect(screen.getByTitle("Backlink")).toBeTruthy();
+    });
+
+    it("opens the note when its title is clicked", () => {
+      const onNavigateToNote = jest.fn();
+      renderRow({ onNavigateToNote });
+
+      fireEvent.click(screen.getByText("Design principles"));
+
+      expect(onNavigateToNote).toHaveBeenCalledTimes(1);
+    });
+
+    it("adds the note to the chat from its row action", () => {
+      const onAddToChat = jest.fn();
+      renderRow({ onAddToChat });
+
+      fireEvent.click(screen.getByTitle("Add to Chat"));
+
+      expect(onAddToChat).toHaveBeenCalledTimes(1);
+    });
+
+    it("registers its element so a rank change can be slid into place (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", () => {
+      const rowRef = jest.fn();
+      renderRow({ rowRef });
+
+      expect(rowRef).toHaveBeenCalledWith(expect.any(HTMLElement));
+    });
+
+    it("plays an arrival for a note joining the results (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", () => {
+      const rowRef = jest.fn();
+      renderRow({ entering: true, rowRef });
+
+      expect(rowRef.mock.calls[0][0].className).toContain("tw-animate-in");
+    });
+
+    it("holds a departing note behind while its removal plays (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", () => {
+      const rowRef = jest.fn();
+      renderRow({ exiting: true, rowRef });
+
+      expect(rowRef.mock.calls[0][0].className).toContain("tw-pointer-events-none");
+      expect(rowRef.mock.calls[0][0].className).toContain("tw-transition-opacity");
+    });
+
+    it("removes a departing note without a fade when the reader has asked for reduced motion (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", () => {
+      const rowRef = jest.fn();
+      renderRow({ exiting: true, animated: false, rowRef });
+
+      expect(rowRef.mock.calls[0][0].className).not.toContain("tw-transition-opacity");
+    });
+  });
+});

--- a/src/components/chat-components/ui/RelevantNoteRow.tsx
+++ b/src/components/chat-components/ui/RelevantNoteRow.tsx
@@ -1,0 +1,322 @@
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
+import { useApp } from "@/context";
+import { useNoteDrag } from "@/hooks/useNoteDrag";
+import { cn } from "@/lib/utils";
+import { type RelevantNoteEntry } from "@/search/findRelevantNotes";
+import { ArrowRight, FileInput, FileOutput, FileText, PlusCircle } from "lucide-react";
+import { TFile } from "obsidian";
+import React, { useCallback, useEffect, useState } from "react";
+
+/** Map a 0–1 similarity score directly to the meter fill width (70% → 70%). */
+function meterWidth(score: number): string {
+  return `${Math.max(0, Math.min(100, score * 100))}%`;
+}
+
+/** Color-grade the meter: stronger matches lean fully into the theme accent. */
+function meterColor(score: number): string {
+  const pct = score * 100;
+  const k = Math.max(0, Math.min(1, (pct - 30) / 45));
+  return `color-mix(in srgb, var(--interactive-accent) ${Math.round(40 + 60 * k)}%, var(--text-faint))`;
+}
+
+function RelevanceMeter({
+  score,
+  animated,
+  className,
+}: {
+  score: number;
+  /** False when the reader has asked for reduced motion. */
+  animated: boolean;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "tw-h-[3px] tw-w-full tw-overflow-hidden tw-rounded-full tw-bg-modifier-hover",
+        className
+      )}
+    >
+      <div
+        className={cn(
+          "copilot-relevance-meter-fill tw-h-full tw-rounded-full",
+          // A live re-rank rewrites the score, and growing or shrinking the bar
+          // is what makes a note's rising relevance readable as it happens.
+          // https://github.com/Brevilabs/obsidian-copilot-private/issues/362
+          animated && "tw-transition-[width,background-color] tw-duration-500 tw-ease-out"
+        )}
+        style={
+          {
+            "--relevance-meter-fill": meterWidth(score),
+            "--relevance-meter-color": meterColor(score),
+          } as React.CSSProperties
+        }
+      />
+    </div>
+  );
+}
+
+function LinkBadge({ icon, label }: { icon: React.ReactNode; label: string }) {
+  return (
+    <span
+      title={label}
+      className="tw-flex tw-items-center tw-justify-center tw-rounded-sm tw-bg-modifier-hover tw-p-1 tw-text-faint"
+    >
+      {icon}
+    </span>
+  );
+}
+
+function RelevantNoteHoverCard({
+  note,
+  animated,
+  onAddToChat,
+  onNavigateToNote,
+  children,
+}: {
+  note: RelevantNoteEntry;
+  animated: boolean;
+  onAddToChat: () => void;
+  onNavigateToNote: () => void;
+  children: React.ReactNode;
+}) {
+  const app = useApp();
+  const [open, setOpen] = useState(false);
+  const [fileContent, setFileContent] = useState<string | null>(null);
+  const similarity = note.metadata.score;
+
+  const loadContent = useCallback(async () => {
+    if (fileContent) return; // Don't reload once cached
+    const file = app.vault.getAbstractFileByPath(note.note.path);
+    if (file instanceof TFile) {
+      const content = await app.vault.cachedRead(file);
+
+      // Remove YAML frontmatter if it exists
+      let cleanContent = content;
+      if (content.startsWith("---")) {
+        const endOfFrontmatter = content.indexOf("---", 3);
+        if (endOfFrontmatter !== -1) {
+          cleanContent = content.slice(endOfFrontmatter + 3).trim();
+        }
+      }
+
+      setFileContent(cleanContent);
+    }
+  }, [app, fileContent, note.note.path]);
+
+  useEffect(() => {
+    if (open) {
+      void loadContent();
+    }
+  }, [open, loadContent]);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverAnchor asChild>
+        <div onMouseEnter={() => setOpen(true)} onMouseLeave={() => setOpen(false)}>
+          {children}
+        </div>
+      </PopoverAnchor>
+      <PopoverContent
+        side="left"
+        align="start"
+        sideOffset={0}
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        className="tw-flex tw-w-fit tw-min-w-72 tw-max-w-96 tw-flex-col tw-gap-3 tw-overflow-hidden tw-p-3"
+      >
+        <div className="tw-flex tw-flex-col tw-gap-1">
+          <span className="tw-text-sm tw-font-semibold tw-text-normal">{note.note.title}</span>
+          <span className="tw-flex tw-items-center tw-gap-1.5 tw-text-xs tw-text-faint">
+            <FileText className="tw-size-3.5 tw-shrink-0" />
+            <span className="tw-truncate">{note.note.path}</span>
+          </span>
+        </div>
+
+        {fileContent && (
+          <p className="tw-m-0 tw-max-h-64 tw-overflow-y-auto tw-whitespace-pre-line tw-text-xs tw-leading-normal tw-text-muted">
+            {fileContent}
+          </p>
+        )}
+
+        <div className="tw-flex tw-items-center tw-gap-2">
+          <span className="tw-shrink-0 tw-text-xs tw-text-faint">Similarity</span>
+          <RelevanceMeter score={similarity} animated={animated} className="tw-h-1 tw-flex-1" />
+          <span className="tw-shrink-0 tw-text-xs tw-font-medium tw-tabular-nums tw-text-normal">
+            {(similarity * 100).toFixed(1)}%
+          </span>
+        </div>
+
+        {(note.metadata.hasOutgoingLinks || note.metadata.hasBacklinks) && (
+          <div className="tw-flex tw-items-center tw-gap-4 tw-text-xs tw-text-faint">
+            {note.metadata.hasOutgoingLinks && (
+              <span className="tw-flex tw-items-center tw-gap-1">
+                <FileOutput className="tw-size-3.5" />
+                Outgoing links
+              </span>
+            )}
+            {note.metadata.hasBacklinks && (
+              <span className="tw-flex tw-items-center tw-gap-1">
+                <FileInput className="tw-size-3.5" />
+                Backlinks
+              </span>
+            )}
+          </div>
+        )}
+
+        <div className="tw-flex tw-gap-2">
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={onAddToChat}
+            className="tw-flex-1 tw-gap-1.5"
+          >
+            <PlusCircle className="tw-size-4" />
+            Add to Chat
+          </Button>
+          <Button
+            variant="default"
+            size="sm"
+            onClick={onNavigateToNote}
+            className="tw-flex-1 tw-gap-1.5"
+          >
+            Open note
+            <ArrowRight className="tw-size-4" />
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export interface RelevantNoteRowProps {
+  note: RelevantNoteEntry;
+  /** True while the note is mounted only to play its removal. */
+  exiting: boolean;
+  /** True while the note should play its arrival. */
+  entering: boolean;
+  /** False when the reader has asked for reduced motion. */
+  animated: boolean;
+  /** Registers the rendered row so a rank change can be slid into place. */
+  rowRef: (node: HTMLElement | null) => void;
+  onAddToChat: () => void;
+  onNavigateToNote: () => void;
+}
+
+/**
+ * One relevant note: its title, how strongly it matches, and its row actions.
+ *
+ * The row owns how a re-rank reads to a note taker who is still writing, so it
+ * renders the arrival, removal, and score change its caller hands it rather
+ * than deciding when a ranking has moved.
+ *
+ * @param note - Note to render, with the score and link flags behind it.
+ * @param exiting - True while the note is mounted only to play its removal.
+ * @param entering - True while the note should play its arrival.
+ * @param animated - False when the reader has asked for reduced motion.
+ * @param rowRef - Registers the row element for the caller's move animation.
+ * @param onAddToChat - Inserts the note into the chat input.
+ * @param onNavigateToNote - Opens the note.
+ */
+export function RelevantNoteRow({
+  note,
+  exiting,
+  entering,
+  animated,
+  rowRef,
+  onAddToChat,
+  onNavigateToNote,
+}: RelevantNoteRowProps): React.ReactElement {
+  const app = useApp();
+  const handleDragStart = useNoteDrag();
+  const similarity = note.metadata.score;
+
+  return (
+    <RelevantNoteHoverCard
+      note={note}
+      animated={animated}
+      onAddToChat={onAddToChat}
+      onNavigateToNote={onNavigateToNote}
+    >
+      <div
+        ref={rowRef}
+        className={cn(
+          "tw-group tw-rounded-md tw-px-2.5 tw-py-1.5 tw-transition-colors hover:tw-bg-modifier-hover",
+          // A note that arrives or drops out mid-sentence is easy to miss if it
+          // simply appears or vanishes between two frames.
+          // https://github.com/Brevilabs/obsidian-copilot-private/issues/362
+          entering && "tw-duration-200 tw-animate-in tw-fade-in-0 tw-slide-in-from-top-1",
+          exiting && "tw-pointer-events-none tw-opacity-0",
+          exiting && animated && "tw-transition-opacity tw-duration-200"
+        )}
+      >
+        <div className="tw-flex tw-min-h-6 tw-items-center tw-gap-2">
+          <a
+            draggable
+            onDragStart={(e) => {
+              const file = app.vault.getAbstractFileByPath(note.note.path);
+              if (file instanceof TFile) {
+                handleDragStart(e, file);
+              }
+            }}
+            onClick={(e) => {
+              e.preventDefault();
+              onNavigateToNote();
+            }}
+            onAuxClick={(e) => {
+              if (e.button === 1) {
+                e.preventDefault();
+                onNavigateToNote();
+              }
+            }}
+            className="tw-min-w-0 tw-flex-1 tw-cursor-pointer tw-truncate tw-text-sm tw-font-medium tw-text-normal !tw-no-underline"
+          >
+            {note.note.title}
+          </a>
+
+          <div className="tw-flex tw-shrink-0 tw-items-center tw-gap-1.5 group-hover:tw-hidden">
+            {note.metadata.hasOutgoingLinks && (
+              <LinkBadge icon={<FileOutput className="tw-size-3" />} label="Outgoing link" />
+            )}
+            {note.metadata.hasBacklinks && (
+              <LinkBadge icon={<FileInput className="tw-size-3" />} label="Backlink" />
+            )}
+            <span className="tw-text-xs tw-font-medium tw-tabular-nums tw-text-muted">
+              {Math.round(similarity * 100)}%
+            </span>
+          </div>
+
+          <div className="tw-hidden tw-shrink-0 tw-items-center tw-gap-0.5 group-hover:tw-flex">
+            <Button
+              variant="ghost2"
+              size="icon"
+              title="Add to Chat"
+              className="tw-size-6 tw-p-0"
+              onClick={(e) => {
+                e.stopPropagation();
+                onAddToChat();
+              }}
+            >
+              <PlusCircle className="tw-size-4" />
+            </Button>
+            <Button
+              variant="ghost2"
+              size="icon"
+              title="Open note"
+              className="tw-size-6 tw-p-0"
+              onClick={(e) => {
+                e.stopPropagation();
+                onNavigateToNote();
+              }}
+            >
+              <ArrowRight className="tw-size-4" />
+            </Button>
+          </div>
+        </div>
+
+        <RelevanceMeter score={similarity} animated={animated} className="tw-mt-1.5" />
+      </div>
+    </RelevantNoteHoverCard>
+  );
+}

--- a/src/components/chat-components/ui/RelevantNotesToolbar.stories.tsx
+++ b/src/components/chat-components/ui/RelevantNotesToolbar.stories.tsx
@@ -1,0 +1,35 @@
+import {
+  RelevantNotesToolbar,
+  type RelevantNotesToolbarProps,
+} from "@/components/chat-components/ui/RelevantNotesToolbar";
+import type { Meta, StoryObj } from "@/lib/story";
+
+const meta = {
+  title: "Chat/Relevant Notes Toolbar",
+  component: RelevantNotesToolbar,
+  args: {
+    activeFileName: "2026-W18 Weekly Review",
+    liveUpdate: { enabled: true, onChange: () => undefined },
+  },
+  parameters: { gallery: { host: "leaf", layout: "fullscreen" } },
+} satisfies Meta<RelevantNotesToolbarProps>;
+
+export default meta;
+
+export const LiveUpdateOn: StoryObj<RelevantNotesToolbarProps> = {};
+
+export const LiveUpdateOff: StoryObj<RelevantNotesToolbarProps> = {
+  args: { liveUpdate: { enabled: false, onChange: () => undefined } },
+};
+
+export const MiyoDisconnected: StoryObj<RelevantNotesToolbarProps> = {
+  args: { liveUpdate: undefined },
+};
+
+export const NoActiveNote: StoryObj<RelevantNotesToolbarProps> = {
+  args: { activeFileName: undefined },
+};
+
+export const LongNoteName: StoryObj<RelevantNotesToolbarProps> = {
+  args: { activeFileName: "Notes on distributed consensus and the FLP impossibility result" },
+};

--- a/src/components/chat-components/ui/RelevantNotesToolbar.test.tsx
+++ b/src/components/chat-components/ui/RelevantNotesToolbar.test.tsx
@@ -41,6 +41,31 @@ describe("RelevantNotesToolbar", () => {
       expect(onChange).toHaveBeenCalledWith(true);
     });
 
+    it("names the switch after the word beside it so it is announced as Live (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", () => {
+      render(
+        <RelevantNotesToolbar
+          activeFileName="Weekly review"
+          liveUpdate={{ enabled: true, onChange: jest.fn() }}
+        />
+      );
+
+      expect(screen.getByRole("switch", { name: "Live" })).toBeTruthy();
+    });
+
+    it("toggles live update when the word beside the switch is clicked (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", () => {
+      const onChange = jest.fn();
+      render(
+        <RelevantNotesToolbar
+          activeFileName="Weekly review"
+          liveUpdate={{ enabled: true, onChange }}
+        />
+      );
+
+      fireEvent.click(screen.getByText("Live"));
+
+      expect(onChange).toHaveBeenCalledWith(false);
+    });
+
     it("hides live update when there is no index to follow (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", () => {
       render(<RelevantNotesToolbar activeFileName="Weekly review" />);
 

--- a/src/components/chat-components/ui/RelevantNotesToolbar.test.tsx
+++ b/src/components/chat-components/ui/RelevantNotesToolbar.test.tsx
@@ -1,0 +1,51 @@
+import { RelevantNotesToolbar } from "@/components/chat-components/ui/RelevantNotesToolbar";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+describe("RelevantNotesToolbar", () => {
+  describe("RelevantNotesToolbar()", () => {
+    it("names the note the results are relevant to", () => {
+      render(<RelevantNotesToolbar activeFileName="Weekly review" />);
+
+      expect(screen.getByText("Weekly review")).toBeTruthy();
+    });
+
+    it("shows a placeholder when no note is open", () => {
+      render(<RelevantNotesToolbar activeFileName={undefined} />);
+
+      expect(screen.getByText("—")).toBeTruthy();
+    });
+
+    it("reflects that live update is on", () => {
+      render(
+        <RelevantNotesToolbar
+          activeFileName="Weekly review"
+          liveUpdate={{ enabled: true, onChange: jest.fn() }}
+        />
+      );
+
+      expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe("true");
+    });
+
+    it("reports the requested live update state when toggled", () => {
+      const onChange = jest.fn();
+      render(
+        <RelevantNotesToolbar
+          activeFileName="Weekly review"
+          liveUpdate={{ enabled: false, onChange }}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("switch"));
+
+      expect(onChange).toHaveBeenCalledWith(true);
+    });
+
+    it("hides live update when there is no index to follow (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", () => {
+      render(<RelevantNotesToolbar activeFileName="Weekly review" />);
+
+      expect(screen.queryByRole("switch")).toBeNull();
+      expect(screen.queryByText("Live")).toBeNull();
+    });
+  });
+});

--- a/src/components/chat-components/ui/RelevantNotesToolbar.tsx
+++ b/src/components/chat-components/ui/RelevantNotesToolbar.tsx
@@ -1,7 +1,7 @@
 import { SettingSwitch } from "@/components/ui/setting-switch";
 import { cn } from "@/lib/utils";
 import { FileText } from "lucide-react";
-import React from "react";
+import React, { useId } from "react";
 
 export interface RelevantNotesToolbarProps {
   /** Basename of the note being related, or undefined when there is none. */
@@ -24,6 +24,8 @@ export function RelevantNotesToolbar({
   activeFileName,
   liveUpdate,
 }: RelevantNotesToolbarProps): React.ReactElement {
+  const labelId = useId();
+
   return (
     <div className="tw-flex tw-flex-none tw-items-center tw-gap-2 tw-border-0 tw-border-b tw-border-solid tw-border-border tw-px-3 tw-py-2">
       <div className="tw-flex tw-min-w-0 tw-flex-1 tw-items-center tw-gap-1.5 tw-text-xs tw-text-faint">
@@ -38,13 +40,31 @@ export function RelevantNotesToolbar({
         )}
       </div>
       {liveUpdate && (
-        <label
+        <div
           title="Re-rank these notes while you write"
-          className="tw-flex tw-shrink-0 tw-cursor-pointer tw-items-center tw-gap-1.5 tw-text-xs"
+          className="tw-flex tw-shrink-0 tw-items-center tw-gap-1.5 tw-text-xs"
         >
-          <span className={cn(liveUpdate.enabled ? "tw-text-normal" : "tw-text-faint")}>Live</span>
-          <SettingSwitch checked={liveUpdate.enabled} onCheckedChange={liveUpdate.onChange} />
-        </label>
+          {/*
+            The switch is a div with role="switch", which no <label> can name or
+            activate, so the visible word both names it and toggles it itself.
+            https://github.com/Brevilabs/obsidian-copilot-private/issues/362
+          */}
+          <span
+            id={labelId}
+            onClick={() => liveUpdate.onChange(!liveUpdate.enabled)}
+            className={cn(
+              "tw-cursor-pointer",
+              liveUpdate.enabled ? "tw-text-normal" : "tw-text-faint"
+            )}
+          >
+            Live
+          </span>
+          <SettingSwitch
+            aria-labelledby={labelId}
+            checked={liveUpdate.enabled}
+            onCheckedChange={liveUpdate.onChange}
+          />
+        </div>
       )}
     </div>
   );

--- a/src/components/chat-components/ui/RelevantNotesToolbar.tsx
+++ b/src/components/chat-components/ui/RelevantNotesToolbar.tsx
@@ -1,0 +1,51 @@
+import { SettingSwitch } from "@/components/ui/setting-switch";
+import { cn } from "@/lib/utils";
+import { FileText } from "lucide-react";
+import React from "react";
+
+export interface RelevantNotesToolbarProps {
+  /** Basename of the note being related, or undefined when there is none. */
+  activeFileName: string | undefined;
+  /** Omitted when Miyo is off, since there is no index to follow. */
+  liveUpdate?: {
+    enabled: boolean;
+    onChange: (enabled: boolean) => void;
+  };
+}
+
+/**
+ * Name the note Relevant Notes is searching against and expose live update.
+ *
+ * @param activeFileName - Basename shown as the search source.
+ * @param liveUpdate - Current live-update state and its setter, when offering
+ *   the control makes sense.
+ */
+export function RelevantNotesToolbar({
+  activeFileName,
+  liveUpdate,
+}: RelevantNotesToolbarProps): React.ReactElement {
+  return (
+    <div className="tw-flex tw-flex-none tw-items-center tw-gap-2 tw-border-0 tw-border-b tw-border-solid tw-border-border tw-px-3 tw-py-2">
+      <div className="tw-flex tw-min-w-0 tw-flex-1 tw-items-center tw-gap-1.5 tw-text-xs tw-text-faint">
+        <span className="tw-shrink-0">Relevant to</span>
+        {activeFileName ? (
+          <span className="tw-flex tw-min-w-0 tw-items-center tw-gap-1 tw-text-muted">
+            <FileText className="tw-size-3.5 tw-shrink-0" />
+            <span className="tw-truncate tw-font-medium tw-text-normal">{activeFileName}</span>
+          </span>
+        ) : (
+          <span className="tw-text-muted">—</span>
+        )}
+      </div>
+      {liveUpdate && (
+        <label
+          title="Re-rank these notes while you write"
+          className="tw-flex tw-shrink-0 tw-cursor-pointer tw-items-center tw-gap-1.5 tw-text-xs"
+        >
+          <span className={cn(liveUpdate.enabled ? "tw-text-normal" : "tw-text-faint")}>Live</span>
+          <SettingSwitch checked={liveUpdate.enabled} onCheckedChange={liveUpdate.onChange} />
+        </label>
+      )}
+    </div>
+  );
+}

--- a/src/components/chat-components/ui/useRelevantNoteRowTransitions.test.tsx
+++ b/src/components/chat-components/ui/useRelevantNoteRowTransitions.test.tsx
@@ -16,6 +16,18 @@ function paths(rows: readonly { note: RelevantNoteEntry; exiting: boolean }[]): 
   return rows.map((row) => `${row.note.note.path}${row.exiting ? ":exiting" : ""}`);
 }
 
+function entering(rows: readonly { note: RelevantNoteEntry; entering: boolean }[]): string[] {
+  return rows.filter((row) => row.entering).map((row) => row.note.note.path);
+}
+
+function renderTransitions(initialProps: { notes: RelevantNoteEntry[]; sourceKey: string }) {
+  return renderHook(
+    ({ notes, sourceKey }: { notes: RelevantNoteEntry[]; sourceKey: string }) =>
+      useRelevantNoteRowTransitions(notes, sourceKey, true),
+    { initialProps }
+  );
+}
+
 describe("useRelevantNoteRowTransitions", () => {
   describe("useRelevantNoteRowTransitions()", () => {
     beforeEach(() => {
@@ -28,7 +40,7 @@ describe("useRelevantNoteRowTransitions", () => {
 
     it("mirrors the results it is given on first render", () => {
       const { result } = renderHook(() =>
-        useRelevantNoteRowTransitions([entry("a.md"), entry("b.md")], true)
+        useRelevantNoteRowTransitions([entry("a.md"), entry("b.md")], "Source.md", true)
       );
 
       expect(paths(result.current.rows)).toEqual(["a.md", "b.md"]);
@@ -36,7 +48,8 @@ describe("useRelevantNoteRowTransitions", () => {
 
     it("reorders rows to match a new ranking", () => {
       const { result, rerender } = renderHook(
-        ({ notes }: { notes: RelevantNoteEntry[] }) => useRelevantNoteRowTransitions(notes, true),
+        ({ notes }: { notes: RelevantNoteEntry[] }) =>
+          useRelevantNoteRowTransitions(notes, "Source.md", true),
         { initialProps: { notes: [entry("a.md", 0.9), entry("b.md", 0.4)] } }
       );
 
@@ -47,7 +60,8 @@ describe("useRelevantNoteRowTransitions", () => {
 
     it("holds a departed note in its previous slot so its removal can be seen (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", () => {
       const { result, rerender } = renderHook(
-        ({ notes }: { notes: RelevantNoteEntry[] }) => useRelevantNoteRowTransitions(notes, true),
+        ({ notes }: { notes: RelevantNoteEntry[] }) =>
+          useRelevantNoteRowTransitions(notes, "Source.md", true),
         { initialProps: { notes: [entry("a.md"), entry("b.md"), entry("c.md")] } }
       );
 
@@ -58,7 +72,8 @@ describe("useRelevantNoteRowTransitions", () => {
 
     it("drops a departed note once its removal has played", () => {
       const { result, rerender } = renderHook(
-        ({ notes }: { notes: RelevantNoteEntry[] }) => useRelevantNoteRowTransitions(notes, true),
+        ({ notes }: { notes: RelevantNoteEntry[] }) =>
+          useRelevantNoteRowTransitions(notes, "Source.md", true),
         { initialProps: { notes: [entry("a.md"), entry("b.md")] } }
       );
       rerender({ notes: [entry("a.md")] });
@@ -72,7 +87,8 @@ describe("useRelevantNoteRowTransitions", () => {
 
     it("removes a departed note immediately when the reader has asked for reduced motion (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", () => {
       const { result, rerender } = renderHook(
-        ({ notes }: { notes: RelevantNoteEntry[] }) => useRelevantNoteRowTransitions(notes, false),
+        ({ notes }: { notes: RelevantNoteEntry[] }) =>
+          useRelevantNoteRowTransitions(notes, "Source.md", false),
         { initialProps: { notes: [entry("a.md"), entry("b.md")] } }
       );
 
@@ -83,7 +99,8 @@ describe("useRelevantNoteRowTransitions", () => {
 
     it("shows a note that returns before its removal finished as present again", () => {
       const { result, rerender } = renderHook(
-        ({ notes }: { notes: RelevantNoteEntry[] }) => useRelevantNoteRowTransitions(notes, true),
+        ({ notes }: { notes: RelevantNoteEntry[] }) =>
+          useRelevantNoteRowTransitions(notes, "Source.md", true),
         { initialProps: { notes: [entry("a.md"), entry("b.md")] } }
       );
       rerender({ notes: [entry("a.md")] });
@@ -91,6 +108,49 @@ describe("useRelevantNoteRowTransitions", () => {
       rerender({ notes: [entry("a.md"), entry("b.md")] });
 
       expect(paths(result.current.rows)).toEqual(["a.md", "b.md"]);
+    });
+
+    it("shows the results for a note the reader just opened at once (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", () => {
+      const { result, rerender } = renderTransitions({
+        notes: [entry("a.md"), entry("b.md")],
+        sourceKey: "Source.md",
+      });
+
+      rerender({ notes: [entry("c.md")], sourceKey: "Other.md" });
+
+      expect(paths(result.current.rows)).toEqual(["c.md"]);
+      expect(entering(result.current.rows)).toEqual([]);
+    });
+
+    it("shows a list filling from empty at once rather than as an arrival (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", () => {
+      const { result, rerender } = renderTransitions({ notes: [], sourceKey: "Source.md" });
+
+      rerender({ notes: [entry("a.md")], sourceKey: "Source.md" });
+
+      expect(entering(result.current.rows)).toEqual([]);
+    });
+
+    it("plays an arrival only for a note joining a list already on screen", () => {
+      const { result, rerender } = renderTransitions({
+        notes: [entry("a.md")],
+        sourceKey: "Source.md",
+      });
+
+      rerender({ notes: [entry("a.md"), entry("b.md")], sourceKey: "Source.md" });
+
+      expect(entering(result.current.rows)).toEqual(["b.md"]);
+    });
+
+    it("does not replay the arrival of a row that stays on screen through a re-rank", () => {
+      const { result, rerender } = renderTransitions({
+        notes: [entry("a.md")],
+        sourceKey: "Source.md",
+      });
+      rerender({ notes: [entry("a.md"), entry("b.md")], sourceKey: "Source.md" });
+
+      rerender({ notes: [entry("b.md"), entry("a.md")], sourceKey: "Source.md" });
+
+      expect(entering(result.current.rows)).toEqual(["b.md"]);
     });
 
     it("slides a row that changed rank from its previous position", () => {
@@ -108,7 +168,8 @@ describe("useRelevantNoteRowTransitions", () => {
         }) as unknown as HTMLElement;
 
       const { result, rerender } = renderHook(
-        ({ notes }: { notes: RelevantNoteEntry[] }) => useRelevantNoteRowTransitions(notes, true),
+        ({ notes }: { notes: RelevantNoteEntry[] }) =>
+          useRelevantNoteRowTransitions(notes, "Source.md", true),
         { initialProps: { notes: [entry("a.md"), entry("b.md")] } }
       );
       result.current.registerRow("a.md")(nodeFor("a.md"));
@@ -138,7 +199,8 @@ describe("useRelevantNoteRowTransitions", () => {
       } as unknown as HTMLElement;
 
       const { result, rerender } = renderHook(
-        ({ notes }: { notes: RelevantNoteEntry[] }) => useRelevantNoteRowTransitions(notes, false),
+        ({ notes }: { notes: RelevantNoteEntry[] }) =>
+          useRelevantNoteRowTransitions(notes, "Source.md", false),
         { initialProps: { notes: [entry("a.md"), entry("b.md")] } }
       );
       result.current.registerRow("a.md")(node);

--- a/src/components/chat-components/ui/useRelevantNoteRowTransitions.test.tsx
+++ b/src/components/chat-components/ui/useRelevantNoteRowTransitions.test.tsx
@@ -1,0 +1,153 @@
+import {
+  ROW_EXIT_MS,
+  useRelevantNoteRowTransitions,
+} from "@/components/chat-components/ui/useRelevantNoteRowTransitions";
+import type { RelevantNoteEntry } from "@/search/findRelevantNotes";
+import { act, renderHook } from "@testing-library/react";
+
+function entry(path: string, score = 0.5): RelevantNoteEntry {
+  return {
+    note: { path, title: path.replace(/\.md$/, "") },
+    metadata: { score, hasOutgoingLinks: false, hasBacklinks: false },
+  };
+}
+
+function paths(rows: readonly { note: RelevantNoteEntry; exiting: boolean }[]): string[] {
+  return rows.map((row) => `${row.note.note.path}${row.exiting ? ":exiting" : ""}`);
+}
+
+describe("useRelevantNoteRowTransitions", () => {
+  describe("useRelevantNoteRowTransitions()", () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it("mirrors the results it is given on first render", () => {
+      const { result } = renderHook(() =>
+        useRelevantNoteRowTransitions([entry("a.md"), entry("b.md")], true)
+      );
+
+      expect(paths(result.current.rows)).toEqual(["a.md", "b.md"]);
+    });
+
+    it("reorders rows to match a new ranking", () => {
+      const { result, rerender } = renderHook(
+        ({ notes }: { notes: RelevantNoteEntry[] }) => useRelevantNoteRowTransitions(notes, true),
+        { initialProps: { notes: [entry("a.md", 0.9), entry("b.md", 0.4)] } }
+      );
+
+      rerender({ notes: [entry("b.md", 0.95), entry("a.md", 0.3)] });
+
+      expect(paths(result.current.rows)).toEqual(["b.md", "a.md"]);
+    });
+
+    it("holds a departed note in its previous slot so its removal can be seen (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", () => {
+      const { result, rerender } = renderHook(
+        ({ notes }: { notes: RelevantNoteEntry[] }) => useRelevantNoteRowTransitions(notes, true),
+        { initialProps: { notes: [entry("a.md"), entry("b.md"), entry("c.md")] } }
+      );
+
+      rerender({ notes: [entry("a.md"), entry("c.md")] });
+
+      expect(paths(result.current.rows)).toEqual(["a.md", "b.md:exiting", "c.md"]);
+    });
+
+    it("drops a departed note once its removal has played", () => {
+      const { result, rerender } = renderHook(
+        ({ notes }: { notes: RelevantNoteEntry[] }) => useRelevantNoteRowTransitions(notes, true),
+        { initialProps: { notes: [entry("a.md"), entry("b.md")] } }
+      );
+      rerender({ notes: [entry("a.md")] });
+
+      act(() => {
+        jest.advanceTimersByTime(ROW_EXIT_MS);
+      });
+
+      expect(paths(result.current.rows)).toEqual(["a.md"]);
+    });
+
+    it("removes a departed note immediately when the reader has asked for reduced motion (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", () => {
+      const { result, rerender } = renderHook(
+        ({ notes }: { notes: RelevantNoteEntry[] }) => useRelevantNoteRowTransitions(notes, false),
+        { initialProps: { notes: [entry("a.md"), entry("b.md")] } }
+      );
+
+      rerender({ notes: [entry("a.md")] });
+
+      expect(paths(result.current.rows)).toEqual(["a.md"]);
+    });
+
+    it("shows a note that returns before its removal finished as present again", () => {
+      const { result, rerender } = renderHook(
+        ({ notes }: { notes: RelevantNoteEntry[] }) => useRelevantNoteRowTransitions(notes, true),
+        { initialProps: { notes: [entry("a.md"), entry("b.md")] } }
+      );
+      rerender({ notes: [entry("a.md")] });
+
+      rerender({ notes: [entry("a.md"), entry("b.md")] });
+
+      expect(paths(result.current.rows)).toEqual(["a.md", "b.md"]);
+    });
+
+    it("slides a row that changed rank from its previous position", () => {
+      const offsets = new Map<string, number>([
+        ["a.md", 0],
+        ["b.md", 48],
+      ]);
+      const animate = jest.fn();
+      const nodeFor = (path: string) =>
+        ({
+          get offsetTop() {
+            return offsets.get(path) ?? 0;
+          },
+          animate,
+        }) as unknown as HTMLElement;
+
+      const { result, rerender } = renderHook(
+        ({ notes }: { notes: RelevantNoteEntry[] }) => useRelevantNoteRowTransitions(notes, true),
+        { initialProps: { notes: [entry("a.md"), entry("b.md")] } }
+      );
+      result.current.registerRow("a.md")(nodeFor("a.md"));
+      result.current.registerRow("b.md")(nodeFor("b.md"));
+      rerender({ notes: [entry("a.md"), entry("b.md")] });
+      animate.mockClear();
+
+      offsets.set("a.md", 48);
+      offsets.set("b.md", 0);
+      rerender({ notes: [entry("b.md"), entry("a.md")] });
+
+      expect(animate).toHaveBeenCalledTimes(2);
+      expect(animate.mock.calls[0][0]).toEqual([
+        { transform: "translateY(-48px)" },
+        { transform: "translateY(0px)" },
+      ]);
+    });
+
+    it("leaves rows in place when the reader has asked for reduced motion", () => {
+      const animate = jest.fn();
+      let offsetTop = 0;
+      const node = {
+        get offsetTop() {
+          return offsetTop;
+        },
+        animate,
+      } as unknown as HTMLElement;
+
+      const { result, rerender } = renderHook(
+        ({ notes }: { notes: RelevantNoteEntry[] }) => useRelevantNoteRowTransitions(notes, false),
+        { initialProps: { notes: [entry("a.md"), entry("b.md")] } }
+      );
+      result.current.registerRow("a.md")(node);
+      rerender({ notes: [entry("a.md"), entry("b.md")] });
+
+      offsetTop = 48;
+      rerender({ notes: [entry("b.md"), entry("a.md")] });
+
+      expect(animate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/chat-components/ui/useRelevantNoteRowTransitions.ts
+++ b/src/components/chat-components/ui/useRelevantNoteRowTransitions.ts
@@ -18,11 +18,19 @@ export interface RelevantNoteRow {
   note: RelevantNoteEntry;
   /** True while the note is still mounted only to play its removal. */
   exiting: boolean;
+  /** True while the note should play its arrival. */
+  entering: boolean;
 }
 
 interface TransitionState {
+  sourceKey: string | undefined;
   notes: readonly RelevantNoteEntry[];
   rows: readonly RelevantNoteRow[];
+}
+
+/** Render a list outright, with no row held back and no arrival to play. */
+function replaceRows(notes: readonly RelevantNoteEntry[]): readonly RelevantNoteRow[] {
+  return notes.map((note) => ({ note, exiting: false, entering: false }));
 }
 
 /**
@@ -34,14 +42,22 @@ function mergeRows(
   previousRows: readonly RelevantNoteRow[],
   notes: readonly RelevantNoteEntry[]
 ): readonly RelevantNoteRow[] {
+  const previousByPath = new Map(previousRows.map((row) => [row.note.note.path, row]));
   const nextPaths = new Set(notes.map((note) => note.note.path));
-  const rows: RelevantNoteRow[] = notes.map((note) => ({ note, exiting: false }));
+  const rows: RelevantNoteRow[] = notes.map((note) => ({
+    note,
+    exiting: false,
+    // A row already on screen must keep whatever it was mounted with: turning
+    // its arrival on now would replay the animation on a row that never left.
+    entering: previousByPath.get(note.note.path)?.entering ?? true,
+  }));
 
   previousRows.forEach((previousRow, previousIndex) => {
     if (nextPaths.has(previousRow.note.note.path)) return;
     rows.splice(Math.min(previousIndex, rows.length), 0, {
       note: previousRow.note,
       exiting: true,
+      entering: previousRow.entering,
     });
   });
 
@@ -55,35 +71,46 @@ function mergeRows(
  * A live re-rank replaces the whole list at once, which reads as a flicker
  * unless the rows that moved, arrived, and left are each shown doing so. This
  * hook holds departing rows mounted long enough to fade and slides surviving
- * rows from their previous position to their new one. With motion off it just
- * mirrors the results, so nothing lingers and nothing moves.
+ * rows from their previous position to their new one. Results the reader has
+ * not seen yet, such as the list for a note they just opened, appear at once.
+ * With motion off it just mirrors the results, so nothing lingers and nothing
+ * moves.
  *
  * @param notes - Relevant notes in the order they should render.
+ * @param sourceKey - Identity of the note the results describe, or undefined
+ *   when no note is open.
  * @param animated - False when the reader has asked for reduced motion.
  * @returns The rows to render and the ref callback each row must register with.
  */
 export function useRelevantNoteRowTransitions(
   notes: readonly RelevantNoteEntry[],
+  sourceKey: string | undefined,
   animated: boolean
 ): {
   rows: readonly RelevantNoteRow[];
   registerRow: (path: string) => (node: HTMLElement | null) => void;
 } {
   const [state, setState] = useState<TransitionState>(() => ({
+    sourceKey,
     notes,
-    rows: notes.map((note) => ({ note, exiting: false })),
+    rows: replaceRows(notes),
   }));
 
   // Deriving during render keeps surviving rows mounted across a re-rank. An
   // effect would unmount a departing row before it could be held back, and
   // re-mounting it would replay its entry animation instead of its removal.
   // https://github.com/Brevilabs/obsidian-copilot-private/issues/362
-  if (state.notes !== notes) {
+  if (state.notes !== notes || state.sourceKey !== sourceKey) {
+    // Only a ranking that shifts under a list the reader is already looking at
+    // is worth animating. Opening another note replaces every row at once, and
+    // a list filling from empty is the pane loading rather than re-ranking; in
+    // both the motion would read as noise over content the reader has not seen.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/362
+    const reranking = animated && state.sourceKey === sourceKey && state.rows.length > 0;
     setState({
+      sourceKey,
       notes,
-      rows: animated
-        ? mergeRows(state.rows, notes)
-        : notes.map((note) => ({ note, exiting: false })),
+      rows: reranking ? mergeRows(state.rows, notes) : replaceRows(notes),
     });
   }
 
@@ -92,7 +119,7 @@ export function useRelevantNoteRowTransitions(
     if (!hasExitingRows) return;
     const timer = window.setTimeout(() => {
       setState((current) => ({
-        notes: current.notes,
+        ...current,
         rows: current.rows.filter((row) => !row.exiting),
       }));
     }, ROW_EXIT_MS);

--- a/src/components/chat-components/ui/useRelevantNoteRowTransitions.ts
+++ b/src/components/chat-components/ui/useRelevantNoteRowTransitions.ts
@@ -1,0 +1,142 @@
+import type { RelevantNoteEntry } from "@/search/findRelevantNotes";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+
+/** How long a row that left the results stays mounted so it can fade out. */
+export const ROW_EXIT_MS = 200;
+
+/** How long a row takes to slide to its new rank. */
+export const ROW_MOVE_MS = 280;
+
+const ROW_MOVE_EASING = "cubic-bezier(0.22, 1, 0.36, 1)";
+
+/** A sub-pixel drift is layout noise, not a rank change worth animating. */
+const MOVE_THRESHOLD_PX = 0.5;
+
+const EMPTY_ROWS: readonly RelevantNoteRow[] = Object.freeze([]);
+
+export interface RelevantNoteRow {
+  note: RelevantNoteEntry;
+  /** True while the note is still mounted only to play its removal. */
+  exiting: boolean;
+}
+
+interface TransitionState {
+  notes: readonly RelevantNoteEntry[];
+  rows: readonly RelevantNoteRow[];
+}
+
+/**
+ * Splice rows that just left the results back into their previous slot so the
+ * removal can be seen, and keep rows already on their way out until their timer
+ * drops them.
+ */
+function mergeRows(
+  previousRows: readonly RelevantNoteRow[],
+  notes: readonly RelevantNoteEntry[]
+): readonly RelevantNoteRow[] {
+  const nextPaths = new Set(notes.map((note) => note.note.path));
+  const rows: RelevantNoteRow[] = notes.map((note) => ({ note, exiting: false }));
+
+  previousRows.forEach((previousRow, previousIndex) => {
+    if (nextPaths.has(previousRow.note.note.path)) return;
+    rows.splice(Math.min(previousIndex, rows.length), 0, {
+      note: previousRow.note,
+      exiting: true,
+    });
+  });
+
+  return rows;
+}
+
+/**
+ * Keep the rendered rows in step with a result list that re-ranks itself while
+ * the user writes.
+ *
+ * A live re-rank replaces the whole list at once, which reads as a flicker
+ * unless the rows that moved, arrived, and left are each shown doing so. This
+ * hook holds departing rows mounted long enough to fade and slides surviving
+ * rows from their previous position to their new one. With motion off it just
+ * mirrors the results, so nothing lingers and nothing moves.
+ *
+ * @param notes - Relevant notes in the order they should render.
+ * @param animated - False when the reader has asked for reduced motion.
+ * @returns The rows to render and the ref callback each row must register with.
+ */
+export function useRelevantNoteRowTransitions(
+  notes: readonly RelevantNoteEntry[],
+  animated: boolean
+): {
+  rows: readonly RelevantNoteRow[];
+  registerRow: (path: string) => (node: HTMLElement | null) => void;
+} {
+  const [state, setState] = useState<TransitionState>(() => ({
+    notes,
+    rows: notes.map((note) => ({ note, exiting: false })),
+  }));
+
+  // Deriving during render keeps surviving rows mounted across a re-rank. An
+  // effect would unmount a departing row before it could be held back, and
+  // re-mounting it would replay its entry animation instead of its removal.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/362
+  if (state.notes !== notes) {
+    setState({
+      notes,
+      rows: animated
+        ? mergeRows(state.rows, notes)
+        : notes.map((note) => ({ note, exiting: false })),
+    });
+  }
+
+  const hasExitingRows = state.rows.some((row) => row.exiting);
+  useEffect(() => {
+    if (!hasExitingRows) return;
+    const timer = window.setTimeout(() => {
+      setState((current) => ({
+        notes: current.notes,
+        rows: current.rows.filter((row) => !row.exiting),
+      }));
+    }, ROW_EXIT_MS);
+    return () => window.clearTimeout(timer);
+  }, [hasExitingRows, state.rows]);
+
+  const nodesByPath = useRef(new Map<string, HTMLElement>());
+  const offsetsByPath = useRef(new Map<string, number>());
+
+  useLayoutEffect(() => {
+    const nodes = nodesByPath.current;
+    const offsets = offsetsByPath.current;
+
+    for (const [path, node] of nodes) {
+      // offsetTop is measured against the pane rather than the viewport, so
+      // scrolling the pane between renders cannot be mistaken for a rank change.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/362
+      const offset = node.offsetTop;
+      const previousOffset = offsets.get(path);
+      offsets.set(path, offset);
+      if (!animated || previousOffset === undefined) continue;
+      const delta = previousOffset - offset;
+      if (Math.abs(delta) < MOVE_THRESHOLD_PX) continue;
+      node.animate([{ transform: `translateY(${delta}px)` }, { transform: "translateY(0px)" }], {
+        duration: ROW_MOVE_MS,
+        easing: ROW_MOVE_EASING,
+      });
+    }
+
+    for (const path of [...offsets.keys()]) {
+      if (!nodes.has(path)) offsets.delete(path);
+    }
+  }, [state.rows, animated]);
+
+  const registerRow = useCallback(
+    (path: string) => (node: HTMLElement | null) => {
+      if (node) {
+        nodesByPath.current.set(path, node);
+      } else {
+        nodesByPath.current.delete(path);
+      }
+    },
+    []
+  );
+
+  return { rows: state.rows.length > 0 ? state.rows : EMPTY_ROWS, registerRow };
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -829,6 +829,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   enableMiyo: false,
   enableMiyoSearchSkill: false,
   miyoSearchAll: false,
+  relevantNotesLiveUpdate: true,
   miyoServerUrl: "",
   selfHostSearchProvider: "firecrawl",
   firecrawlApiKey: "",

--- a/src/hooks/useLiveRelevantNotesRefresh.test.tsx
+++ b/src/hooks/useLiveRelevantNotesRefresh.test.tsx
@@ -265,6 +265,51 @@ describe("useLiveRelevantNotesRefresh", () => {
       expect(second).toHaveBeenCalledTimes(1);
     });
 
+    it("asks again and keeps asking when live update is switched on (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", () => {
+      const harness = createVaultHarness();
+      const onRefresh = jest.fn();
+      const { rerender } = renderHook(
+        ({ enabled }: { enabled: boolean }) =>
+          useLiveRelevantNotesRefresh({
+            app: harness.app,
+            enabled,
+            filePath: "notes/draft.md",
+            onRefresh,
+          }),
+        { initialProps: { enabled: false } }
+      );
+
+      rerender({ enabled: true });
+      expect(onRefresh).toHaveBeenCalledTimes(1);
+      act(() => {
+        jest.advanceTimersByTime(LIVE_REFRESH_INTERVAL_MS * 2);
+      });
+
+      expect(onRefresh).toHaveBeenCalledTimes(3);
+    });
+
+    it("issues no query when the note it is already following changes", () => {
+      const harness = createVaultHarness();
+      const onRefresh = jest.fn();
+      const { rerender } = renderHook(
+        ({ filePath }: { filePath: string }) =>
+          useLiveRelevantNotesRefresh({
+            app: harness.app,
+            enabled: true,
+            filePath,
+            onRefresh,
+          }),
+        { initialProps: { filePath: "notes/draft.md" } }
+      );
+
+      rerender({ filePath: "notes/other.md" });
+      act(() => {
+        jest.advanceTimersByTime(LIVE_REFRESH_WINDOW_MS);
+      });
+
+      expect(onRefresh).not.toHaveBeenCalled();
+    });
+
     it("stops polling and unsubscribes when the pane closes", () => {
       const harness = createVaultHarness();
       const onRefresh = jest.fn();

--- a/src/hooks/useLiveRelevantNotesRefresh.test.tsx
+++ b/src/hooks/useLiveRelevantNotesRefresh.test.tsx
@@ -1,0 +1,290 @@
+import {
+  LIVE_REFRESH_INTERVAL_MS,
+  LIVE_REFRESH_WINDOW_MS,
+  useLiveRelevantNotesRefresh,
+} from "@/hooks/useLiveRelevantNotesRefresh";
+import { act, renderHook } from "@testing-library/react";
+import { TFile, type App, type EventRef } from "obsidian";
+
+type ModifyHandler = (file: unknown) => void;
+
+interface VaultHarness {
+  app: App;
+  emitModify: (file: unknown) => void;
+  offref: jest.Mock;
+  handlerCount: () => number;
+}
+
+function createVaultHarness(): VaultHarness {
+  const handlers = new Set<ModifyHandler>();
+  const offref = jest.fn((ref: EventRef) => {
+    handlers.delete((ref as unknown as { handler: ModifyHandler }).handler);
+  });
+  const app = {
+    vault: {
+      on: jest.fn((event: string, handler: ModifyHandler) => {
+        if (event === "modify") handlers.add(handler);
+        return { handler };
+      }),
+      offref,
+    },
+  } as unknown as App;
+
+  return {
+    app,
+    emitModify: (file) => act(() => handlers.forEach((handler) => handler(file))),
+    offref,
+    handlerCount: () => handlers.size,
+  };
+}
+
+function createFile(path: string): TFile {
+  const MockTFile = TFile as unknown as new (path: string) => TFile;
+  const file = new MockTFile(path);
+  file.path = path;
+  return file;
+}
+
+describe("useLiveRelevantNotesRefresh", () => {
+  describe("useLiveRelevantNotesRefresh()", () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it("issues no query while the note is left untouched (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", () => {
+      const harness = createVaultHarness();
+      const onRefresh = jest.fn();
+
+      renderHook(() =>
+        useLiveRelevantNotesRefresh({
+          app: harness.app,
+          enabled: true,
+          filePath: "notes/draft.md",
+          onRefresh,
+        })
+      );
+
+      act(() => {
+        jest.advanceTimersByTime(LIVE_REFRESH_INTERVAL_MS * 10);
+      });
+
+      expect(onRefresh).not.toHaveBeenCalled();
+    });
+
+    it("re-queries on an interval once the note is written", () => {
+      const harness = createVaultHarness();
+      const onRefresh = jest.fn();
+
+      renderHook(() =>
+        useLiveRelevantNotesRefresh({
+          app: harness.app,
+          enabled: true,
+          filePath: "notes/draft.md",
+          onRefresh,
+        })
+      );
+      harness.emitModify(createFile("notes/draft.md"));
+
+      act(() => {
+        jest.advanceTimersByTime(LIVE_REFRESH_INTERVAL_MS * 2);
+      });
+
+      expect(onRefresh).toHaveBeenCalledTimes(2);
+    });
+
+    it("keeps re-querying past the write so a slower re-embed is still picked up (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", () => {
+      const harness = createVaultHarness();
+      const onRefresh = jest.fn();
+
+      renderHook(() =>
+        useLiveRelevantNotesRefresh({
+          app: harness.app,
+          enabled: true,
+          filePath: "notes/draft.md",
+          onRefresh,
+        })
+      );
+      harness.emitModify(createFile("notes/draft.md"));
+
+      act(() => {
+        jest.advanceTimersByTime(LIVE_REFRESH_WINDOW_MS);
+      });
+
+      expect(onRefresh.mock.calls.length).toBeGreaterThan(1);
+    });
+
+    it("falls silent once the window since the last write has elapsed", () => {
+      const harness = createVaultHarness();
+      const onRefresh = jest.fn();
+
+      renderHook(() =>
+        useLiveRelevantNotesRefresh({
+          app: harness.app,
+          enabled: true,
+          filePath: "notes/draft.md",
+          onRefresh,
+        })
+      );
+      harness.emitModify(createFile("notes/draft.md"));
+
+      act(() => {
+        jest.advanceTimersByTime(LIVE_REFRESH_WINDOW_MS + LIVE_REFRESH_INTERVAL_MS * 2);
+      });
+      const settledCalls = onRefresh.mock.calls.length;
+      act(() => {
+        jest.advanceTimersByTime(LIVE_REFRESH_INTERVAL_MS * 10);
+      });
+
+      expect(onRefresh.mock.calls.length).toBe(settledCalls);
+    });
+
+    it("extends the window when the note is written again", () => {
+      const harness = createVaultHarness();
+      const onRefresh = jest.fn();
+
+      renderHook(() =>
+        useLiveRelevantNotesRefresh({
+          app: harness.app,
+          enabled: true,
+          filePath: "notes/draft.md",
+          onRefresh,
+        })
+      );
+      harness.emitModify(createFile("notes/draft.md"));
+      act(() => {
+        jest.advanceTimersByTime(LIVE_REFRESH_WINDOW_MS - LIVE_REFRESH_INTERVAL_MS);
+      });
+      harness.emitModify(createFile("notes/draft.md"));
+      const callsBefore = onRefresh.mock.calls.length;
+
+      act(() => {
+        jest.advanceTimersByTime(LIVE_REFRESH_WINDOW_MS);
+      });
+
+      expect(onRefresh.mock.calls.length).toBeGreaterThan(callsBefore + 1);
+    });
+
+    it("ignores writes to notes other than the one being related", () => {
+      const harness = createVaultHarness();
+      const onRefresh = jest.fn();
+
+      renderHook(() =>
+        useLiveRelevantNotesRefresh({
+          app: harness.app,
+          enabled: true,
+          filePath: "notes/draft.md",
+          onRefresh,
+        })
+      );
+      harness.emitModify(createFile("notes/other.md"));
+
+      act(() => {
+        jest.advanceTimersByTime(LIVE_REFRESH_WINDOW_MS);
+      });
+
+      expect(onRefresh).not.toHaveBeenCalled();
+    });
+
+    it("ignores modifications to folders", () => {
+      const harness = createVaultHarness();
+      const onRefresh = jest.fn();
+
+      renderHook(() =>
+        useLiveRelevantNotesRefresh({
+          app: harness.app,
+          enabled: true,
+          filePath: "notes/draft.md",
+          onRefresh,
+        })
+      );
+      harness.emitModify({ path: "notes/draft.md" });
+
+      act(() => {
+        jest.advanceTimersByTime(LIVE_REFRESH_WINDOW_MS);
+      });
+
+      expect(onRefresh).not.toHaveBeenCalled();
+    });
+
+    it("subscribes to nothing while live update is switched off", () => {
+      const harness = createVaultHarness();
+
+      renderHook(() =>
+        useLiveRelevantNotesRefresh({
+          app: harness.app,
+          enabled: false,
+          filePath: "notes/draft.md",
+          onRefresh: jest.fn(),
+        })
+      );
+
+      expect(harness.handlerCount()).toBe(0);
+    });
+
+    it("subscribes to nothing while no note is open", () => {
+      const harness = createVaultHarness();
+
+      renderHook(() =>
+        useLiveRelevantNotesRefresh({
+          app: harness.app,
+          enabled: true,
+          filePath: undefined,
+          onRefresh: jest.fn(),
+        })
+      );
+
+      expect(harness.handlerCount()).toBe(0);
+    });
+
+    it("calls the latest callback rather than the one captured when it subscribed", () => {
+      const harness = createVaultHarness();
+      const first = jest.fn();
+      const second = jest.fn();
+      const { rerender } = renderHook(
+        ({ onRefresh }: { onRefresh: () => void }) =>
+          useLiveRelevantNotesRefresh({
+            app: harness.app,
+            enabled: true,
+            filePath: "notes/draft.md",
+            onRefresh,
+          }),
+        { initialProps: { onRefresh: first } }
+      );
+      harness.emitModify(createFile("notes/draft.md"));
+      rerender({ onRefresh: second });
+
+      act(() => {
+        jest.advanceTimersByTime(LIVE_REFRESH_INTERVAL_MS);
+      });
+
+      expect(first).not.toHaveBeenCalled();
+      expect(second).toHaveBeenCalledTimes(1);
+    });
+
+    it("stops polling and unsubscribes when the pane closes", () => {
+      const harness = createVaultHarness();
+      const onRefresh = jest.fn();
+      const { unmount } = renderHook(() =>
+        useLiveRelevantNotesRefresh({
+          app: harness.app,
+          enabled: true,
+          filePath: "notes/draft.md",
+          onRefresh,
+        })
+      );
+      harness.emitModify(createFile("notes/draft.md"));
+
+      unmount();
+      act(() => {
+        jest.advanceTimersByTime(LIVE_REFRESH_WINDOW_MS);
+      });
+
+      expect(harness.offref).toHaveBeenCalled();
+      expect(onRefresh).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/hooks/useLiveRelevantNotesRefresh.ts
+++ b/src/hooks/useLiveRelevantNotesRefresh.ts
@@ -1,0 +1,87 @@
+import { TFile, type App } from "obsidian";
+import { useEffect, useRef } from "react";
+
+/**
+ * How often a dirty note is re-queried. Miyo answers a related search in a few
+ * milliseconds, so the interval is set by how fast its index can move rather
+ * than by request cost.
+ */
+export const LIVE_REFRESH_INTERVAL_MS = 5000;
+
+/**
+ * How long after the last write the note keeps being re-queried. Miyo debounces
+ * its file watcher for three seconds and then embeds, so a single poll placed
+ * right after a write regularly lands before the new vectors exist. The window
+ * spans several polls so the settled ranking is always picked up, then goes
+ * quiet.
+ */
+export const LIVE_REFRESH_WINDOW_MS = 20000;
+
+interface UseLiveRelevantNotesRefreshOptions {
+  app: App;
+  /** Whether the user has live update switched on for the pane. */
+  enabled: boolean;
+  /** Vault path of the note being related, or undefined when there is none. */
+  filePath: string | undefined;
+  /** Re-run the relevant-notes query without disturbing the rendered rows. */
+  onRefresh: () => void;
+}
+
+/**
+ * Re-query relevant notes while the active note is being written.
+ *
+ * Polling is gated on Obsidian actually writing the note: with no write there
+ * are no new embeddings to fetch, so an untouched note costs nothing. Each
+ * write opens a window during which the note is re-queried, because Miyo
+ * re-embeds a few seconds after the file lands on disk.
+ * https://github.com/Brevilabs/obsidian-copilot-private/issues/362
+ *
+ * @param options - Runtime access, the enablement flag, the note being related,
+ *   and the callback that re-runs the query.
+ */
+export function useLiveRelevantNotesRefresh({
+  app,
+  enabled,
+  filePath,
+  onRefresh,
+}: UseLiveRelevantNotesRefreshOptions): void {
+  // The callback identity changes on every render of the calling component, but
+  // resubscribing to vault events on each render would drop pending state.
+  const onRefreshRef = useRef(onRefresh);
+  onRefreshRef.current = onRefresh;
+
+  useEffect(() => {
+    if (!enabled || !filePath) return;
+
+    let deadline = 0;
+    let interval: number | null = null;
+
+    const stopPolling = () => {
+      if (interval === null) return;
+      window.clearInterval(interval);
+      interval = null;
+    };
+
+    const startPolling = () => {
+      if (interval !== null) return;
+      interval = window.setInterval(() => {
+        if (Date.now() > deadline) {
+          stopPolling();
+          return;
+        }
+        onRefreshRef.current();
+      }, LIVE_REFRESH_INTERVAL_MS);
+    };
+
+    const eventRef = app.vault.on("modify", (file) => {
+      if (!(file instanceof TFile) || file.path !== filePath) return;
+      deadline = Date.now() + LIVE_REFRESH_WINDOW_MS;
+      startPolling();
+    });
+
+    return () => {
+      app.vault.offref(eventRef);
+      stopPolling();
+    };
+  }, [app, enabled, filePath]);
+}

--- a/src/hooks/useLiveRelevantNotesRefresh.ts
+++ b/src/hooks/useLiveRelevantNotesRefresh.ts
@@ -33,7 +33,8 @@ interface UseLiveRelevantNotesRefreshOptions {
  * Polling is gated on Obsidian actually writing the note: with no write there
  * are no new embeddings to fetch, so an untouched note costs nothing. Each
  * write opens a window during which the note is re-queried, because Miyo
- * re-embeds a few seconds after the file lands on disk.
+ * re-embeds a few seconds after the file lands on disk, and switching live
+ * update on opens the same window so writes made while it was off are caught.
  * https://github.com/Brevilabs/obsidian-copilot-private/issues/362
  *
  * @param options - Runtime access, the enablement flag, the note being related,
@@ -49,8 +50,13 @@ export function useLiveRelevantNotesRefresh({
   // resubscribing to vault events on each render would drop pending state.
   const onRefreshRef = useRef(onRefresh);
   onRefreshRef.current = onRefresh;
+  // Only the switch turning on opens a window; the effect also re-runs when the
+  // reader opens another note, which the pane already queries on its own.
+  const wasEnabledRef = useRef(enabled);
 
   useEffect(() => {
+    const justEnabled = enabled && !wasEnabledRef.current;
+    wasEnabledRef.current = enabled;
     if (!enabled || !filePath) return;
 
     let deadline = 0;
@@ -73,11 +79,24 @@ export function useLiveRelevantNotesRefresh({
       }, LIVE_REFRESH_INTERVAL_MS);
     };
 
-    const eventRef = app.vault.on("modify", (file) => {
-      if (!(file instanceof TFile) || file.path !== filePath) return;
+    const openWindow = () => {
       deadline = Date.now() + LIVE_REFRESH_WINDOW_MS;
       startPolling();
+    };
+
+    const eventRef = app.vault.on("modify", (file) => {
+      if (!(file instanceof TFile) || file.path !== filePath) return;
+      openWindow();
     });
+
+    // Writes made while live update was off left the pane behind, and Miyo
+    // re-embeds seconds after each of them, so switching it on asks again at
+    // once and then keeps asking for as long as a write would.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/362
+    if (justEnabled) {
+      onRefreshRef.current();
+      openWindow();
+    }
 
     return () => {
       app.vault.offref(eventRef);

--- a/src/search/findRelevantNotes.test.ts
+++ b/src/search/findRelevantNotes.test.ts
@@ -674,7 +674,7 @@ describe("findRelevantNotes", () => {
       ).toBe(true);
     });
 
-    it("separates results whose scores moved", () => {
+    it("separates results whose scores moved (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", () => {
       expect(
         isSameRelevantNotesResult(
           { notes: [note("a.md", 0.7)], status: "matches" },
@@ -683,7 +683,7 @@ describe("findRelevantNotes", () => {
       ).toBe(false);
     });
 
-    it("separates results whose ranking order changed", () => {
+    it("separates results whose ranking order changed (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", () => {
       expect(
         isSameRelevantNotesResult(
           { notes: [note("a.md", 0.7), note("b.md", 0.4)], status: "matches" },
@@ -692,7 +692,7 @@ describe("findRelevantNotes", () => {
       ).toBe(false);
     });
 
-    it("separates results whose link annotations changed", () => {
+    it("separates results whose link annotations changed (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", () => {
       const linked: RelevantNoteEntry = {
         note: { path: "a.md", title: "a" },
         metadata: { score: 0.7, hasOutgoingLinks: true, hasBacklinks: false },
@@ -705,7 +705,7 @@ describe("findRelevantNotes", () => {
       ).toBe(false);
     });
 
-    it("separates results that settled on different statuses", () => {
+    it("separates results that settled on different statuses (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", () => {
       expect(
         isSameRelevantNotesResult(
           { notes: [], status: "no-matches" },
@@ -714,7 +714,7 @@ describe("findRelevantNotes", () => {
       ).toBe(false);
     });
 
-    it("separates results that differ only in their status details", () => {
+    it("separates results that differ only in their status details (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", () => {
       expect(
         isSameRelevantNotesResult(
           { notes: [], status: "excluded", details: { exclusionRule: "**/journal/**" } },
@@ -723,7 +723,7 @@ describe("findRelevantNotes", () => {
       ).toBe(false);
     });
 
-    it("separates a result that gained a note from the one before it", () => {
+    it("separates a result that gained a note from the one before it (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", () => {
       expect(
         isSameRelevantNotesResult(
           { notes: [note("a.md", 0.7)], status: "matches" },

--- a/src/search/findRelevantNotes.test.ts
+++ b/src/search/findRelevantNotes.test.ts
@@ -7,7 +7,11 @@ import {
   shouldUseMiyo,
 } from "@/miyo/miyoUtils";
 import { getBacklinkedNotes, getLinkedNotes } from "@/noteUtils";
-import { findRelevantNotes } from "@/search/findRelevantNotes";
+import {
+  findRelevantNotes,
+  isSameRelevantNotesResult,
+  type RelevantNoteEntry,
+} from "@/search/findRelevantNotes";
 import { getSettings, type CopilotSettings } from "@/settings/model";
 import { TFile } from "obsidian";
 
@@ -652,6 +656,80 @@ describe("findRelevantNotes", () => {
       expect(result.status).toBe("unavailable");
       expect(mockFileStatus).not.toHaveBeenCalled();
       expect(mockedLogError).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("isSameRelevantNotesResult()", () => {
+    const note = (path: string, score: number): RelevantNoteEntry => ({
+      note: { path, title: path.replace(/\.md$/, "") },
+      metadata: { score, hasOutgoingLinks: false, hasBacklinks: false },
+    });
+
+    it("treats two separately built results with the same ranking as identical (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", () => {
+      expect(
+        isSameRelevantNotesResult(
+          { notes: [note("a.md", 0.7), note("b.md", 0.4)], status: "matches" },
+          { notes: [note("a.md", 0.7), note("b.md", 0.4)], status: "matches" }
+        )
+      ).toBe(true);
+    });
+
+    it("separates results whose scores moved", () => {
+      expect(
+        isSameRelevantNotesResult(
+          { notes: [note("a.md", 0.7)], status: "matches" },
+          { notes: [note("a.md", 0.71)], status: "matches" }
+        )
+      ).toBe(false);
+    });
+
+    it("separates results whose ranking order changed", () => {
+      expect(
+        isSameRelevantNotesResult(
+          { notes: [note("a.md", 0.7), note("b.md", 0.4)], status: "matches" },
+          { notes: [note("b.md", 0.7), note("a.md", 0.4)], status: "matches" }
+        )
+      ).toBe(false);
+    });
+
+    it("separates results whose link annotations changed", () => {
+      const linked: RelevantNoteEntry = {
+        note: { path: "a.md", title: "a" },
+        metadata: { score: 0.7, hasOutgoingLinks: true, hasBacklinks: false },
+      };
+      expect(
+        isSameRelevantNotesResult(
+          { notes: [note("a.md", 0.7)], status: "matches" },
+          { notes: [linked], status: "matches" }
+        )
+      ).toBe(false);
+    });
+
+    it("separates results that settled on different statuses", () => {
+      expect(
+        isSameRelevantNotesResult(
+          { notes: [], status: "no-matches" },
+          { notes: [], status: "indexing" }
+        )
+      ).toBe(false);
+    });
+
+    it("separates results that differ only in their status details", () => {
+      expect(
+        isSameRelevantNotesResult(
+          { notes: [], status: "excluded", details: { exclusionRule: "**/journal/**" } },
+          { notes: [], status: "excluded", details: { exclusionRule: "**/archive/**" } }
+        )
+      ).toBe(false);
+    });
+
+    it("separates a result that gained a note from the one before it", () => {
+      expect(
+        isSameRelevantNotesResult(
+          { notes: [note("a.md", 0.7)], status: "matches" },
+          { notes: [note("a.md", 0.7), note("b.md", 0.4)], status: "matches" }
+        )
+      ).toBe(false);
     });
   });
 });

--- a/src/search/findRelevantNotes.ts
+++ b/src/search/findRelevantNotes.ts
@@ -278,6 +278,36 @@ export interface RelevantNotesResult {
 
 const EMPTY_RELEVANT_NOTES: readonly RelevantNoteEntry[] = Object.freeze([]);
 
+/**
+ * Report whether two settled results would render identically.
+ *
+ * Live re-queries repeat while a note is being written, and most of them
+ * reproduce the previous ranking. Callers use this to leave the rendered rows
+ * alone in that case rather than replaying their animations.
+ * https://github.com/Brevilabs/obsidian-copilot-private/issues/362
+ *
+ * @param a - Previously settled result.
+ * @param b - Newly settled result.
+ */
+export function isSameRelevantNotesResult(a: RelevantNotesResult, b: RelevantNotesResult): boolean {
+  if (a === b) return true;
+  if (a.status !== b.status) return false;
+  if (a.details?.errorMessage !== b.details?.errorMessage) return false;
+  if (a.details?.exclusionReason !== b.details?.exclusionReason) return false;
+  if (a.details?.exclusionRule !== b.details?.exclusionRule) return false;
+  if (a.notes.length !== b.notes.length) return false;
+  return a.notes.every((note, index) => {
+    const other = b.notes[index];
+    return (
+      note.note.path === other.note.path &&
+      note.note.title === other.note.title &&
+      note.metadata.score === other.metadata.score &&
+      note.metadata.hasOutgoingLinks === other.metadata.hasOutgoingLinks &&
+      note.metadata.hasBacklinks === other.metadata.hasBacklinks
+    );
+  });
+}
+
 export interface FindRelevantNotesOptions {
   app: App;
   filePath: string;

--- a/src/settings/model.test.ts
+++ b/src/settings/model.test.ts
@@ -720,6 +720,24 @@ describe("model", () => {
       expect(sanitized.selfHostSearchProvider).toBe("firecrawl");
     });
 
+    it("turns live Relevant Notes updates on for settings written before the field existed (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", () => {
+      const withoutField = { ...DEFAULT_SETTINGS } as unknown as Record<string, unknown>;
+      delete withoutField.relevantNotesLiveUpdate;
+
+      const sanitized = sanitizeSettings(withoutField as unknown as CopilotSettings);
+
+      expect(sanitized.relevantNotesLiveUpdate).toBe(true);
+    });
+
+    it("preserves a persisted choice to switch live Relevant Notes updates off (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", () => {
+      const sanitized = sanitizeSettings({
+        ...DEFAULT_SETTINGS,
+        relevantNotesLiveUpdate: false,
+      });
+
+      expect(sanitized.relevantNotesLiveUpdate).toBe(false);
+    });
+
     it("drops a persisted global output cap so it cannot truncate answers again (https://github.com/logancyang/obsidian-copilot-preview/issues/312)", () => {
       const withRetiredCap = {
         ...DEFAULT_SETTINGS,

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -150,6 +150,12 @@ export interface CopilotSettings {
   enableMiyoSearchSkill: boolean;
   /** When true, omit folder_name from Miyo search requests so all indexed content is searched */
   miyoSearchAll: boolean;
+  /**
+   * Keep Relevant Notes in step with the note being written. Miyo re-embeds a
+   * file a few seconds after it lands on disk, so the pane can re-rank itself
+   * while the user types instead of only when they switch notes.
+   */
+  relevantNotesLiveUpdate: boolean;
   /** URL endpoint for the self-host mode backend */
   /** API key for the self-host mode backend (if required) */
   /** Custom Miyo server URL, e.g. "http://192.168.1.10:8742" (empty = use local service discovery) */
@@ -977,6 +983,11 @@ export function sanitizeSettings(settings: CopilotSettings): CopilotSettings {
   // Ensure miyoSearchAll has a default value
   if (typeof sanitizedSettings.miyoSearchAll !== "boolean") {
     sanitizedSettings.miyoSearchAll = DEFAULT_SETTINGS.miyoSearchAll;
+  }
+
+  // Ensure relevantNotesLiveUpdate has a default value
+  if (typeof sanitizedSettings.relevantNotesLiveUpdate !== "boolean") {
+    sanitizedSettings.relevantNotesLiveUpdate = DEFAULT_SETTINGS.relevantNotesLiveUpdate;
   }
 
   // Ensure miyoServerUrl has a default value


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#362

## Why

Open the Relevant Notes pane on a note and it shows a ranked list of related notes with similarity percentages, headed by "Relevant to <note name>". That list is computed once, when you open the note. Write three more paragraphs and it does not move: the pane only asks Miyo again when you switch notes, when Miyo signals an index change, or when you press a recovery action's **Refresh**.

Miyo has already done the expensive half by then. Its file watcher debounces a write for three seconds, skips files whose size and modification time are unchanged, then re-embeds. Measured against a local Miyo 0.2.23 with 3,727 indexed files, a write reaches the index about four seconds later and a related-note query answers in 8 to 11 milliseconds.

The answer genuinely changes in that time. Taking one scratch note through three revisions in a real vault: a paragraph about neural networks puts `@Anthropic Devrel.md` on top at 64%; adding a paragraph about a Hong Kong food trip replaces it with `Hong Kong Weekend Food Trip.md` at 56%; deleting the machine-learning paragraph raises that note to 72% and pushes every machine-learning note out of the top five. Nobody writing the note sees any of it.

## What

A **Live** switch sits at the right of the pane's header, opposite "Relevant to <note name>". It is on by default and remembered. While it is on, the pane re-ranks itself as you write, and shows the ranking moving rather than swapping the list between frames: a note that gains relevance rises and its relevance bar grows, a newly relevant note fades in, and a note that stops relating fades out before the list closes over it. Switching Live on catches the pane up on writes made while it was off. With `prefers-reduced-motion: reduce`, the list still updates and nothing animates.

| Condition | Before | After, Live on | After, Live off |
| --- | --- | --- | --- |
| Writing the open note | Ranking stays as it was when the note opened | Re-ranks a few seconds after each change lands | Stays as it was |
| Note left untouched | No requests | No requests | No requests |
| A re-query reproduces the ranking | n/a | Nothing on screen changes | n/a |
| Miyo disabled | No Live control | Control hidden, setup guidance unchanged | Control hidden |

Requests are gated on Obsidian actually writing the note, so a note nobody is editing costs nothing. Each write opens a twenty second window covering several five-second polls, because a single poll placed right after a write regularly lands before the new vectors exist. A re-query never returns the pane to its "Finding relevant notes…" state.

## Non goal

- No change to how Miyo ranks related notes, and no change to any Miyo endpoint.
- No embedding of the unsaved editor buffer. Results follow what Miyo has indexed from disk, so they lag the last write by Miyo's own debounce.
- No live re-ranking driven by edits to *other* notes in the vault; the existing Miyo index signal and the pane's recovery **Refresh** already cover that. Suggested follow-up: re-rank Relevant Notes when a related note changes.
- No settings-tab control duplicating the header switch.
- No settings schema version bump; the new field defaults on for settings written before it existed.

## Screenshot

Both images are the same note in the same vault, after rewriting it from a Hong Kong food trip to a machine-learning topic and waiting twenty seconds.

**Before** (base branch): the pane still lists `Hong Kong Weekend Food Trip` first, and there is no Live control.

<img width="1200" alt="Relevant Notes on the base branch, still ranked for the note's previous content" src="https://github.com/user-attachments/assets/1fa4e567-25dd-4bdf-a86d-b71532bbd4ff" />

**After** (this branch): Live is on in the header, and the pane has re-ranked to `@Anthropic Devrel` and the other machine-learning notes.

<img width="1200" alt="Relevant Notes on this branch, re-ranked to the note's current content with the Live switch on" src="https://github.com/user-attachments/assets/484b1d71-4f76-403d-9f43-b2c941bda57d" />

## Risk

**Medium**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Poll gating, window extension, teardown, result equality, row retention, reorder, reduced motion, the persisted default, and the pane's no-flash contract all have deterministic tests |
| A defect would fail CI or be obvious on first use | ✅ | Those tests run in CI, and a broken pane is visible the moment the note is written |
| A revert fully restores prior state, including persisted data | ✅ | The only persisted addition is one boolean whose absence re-defaults on load |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | The credential path into Miyo is untouched |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Settings gain one optional boolean at the existing schema version; no Miyo request or response shape changes |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | A repeating query now overlaps the pane's existing supersede-and-settle logic, and rows are held mounted past their removal |
| No hot-path behavior lacks deterministic coverage | ✅ | Every added branch is covered; the rendered animation itself is not automatable and was verified by hand |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Confined to the Relevant Notes pane, where a wrong result is visible on the next write |

Review: read `useRelevantNotes` and `nextSettledRequest` in `src/components/chat-components/RelevantNotes.tsx` line by line, since a live re-query deliberately reuses the request key while the pane's supersede logic still has to reject stale and superseded results. Then read `mergeRows` and the layout effect in `src/components/chat-components/ui/useRelevantNoteRowTransitions.ts`, which decide which rows outlive their removal. Finally check the window and teardown arithmetic in `src/hooks/useLiveRelevantNotesRefresh.ts`. Run Verification steps 2 through 5, including step 5's off state.

## Verification

Requires Miyo running with this vault registered and Miyo enabled in Copilot settings.

1. Open a note that has clear semantic neighbours in your vault, then run **Copilot: Open relevant notes view**. The header should read "Relevant to <note name>" on the left and **Live** with the switch on at the right.
2. Note the top few results. Replace the note's body with a paragraph on a completely different subject and stop typing. Within about ten seconds the list should re-rank to the new subject. The rows should slide to their new positions, new notes should fade in, and departing notes should fade out. The pane should never show "Finding relevant notes…" during this.
3. Add a sentence that reinforces the new subject. The leading note's percentage and its relevance bar should grow rather than jump.
4. Leave the note alone for a minute. The list should stay completely still.
5. Switch **Live** off, rewrite the note to a third unrelated subject, and wait twenty seconds: the list should not move. Switch **Live** back on: it should re-rank at once. Reopen the pane and confirm the switch is still off or on as you left it.
6. Turn on **System Settings → Accessibility → Display → Reduce motion**, then repeat step 2. The list should still re-rank, with no sliding or fading.
7. Turn Miyo off in Copilot settings. The **Live** control should disappear and the pane should show its usual Miyo setup guidance.
