### PR TITLE
Honor the opencode default model when its saved effort is not offered

### DIFF
--- a/src/agentMode/backends/opencode/descriptor.test.ts
+++ b/src/agentMode/backends/opencode/descriptor.test.ts
@@ -277,6 +277,26 @@ describe("descriptor", () => {
         expect(setConfigOption).toHaveBeenCalledWith("effort", "high");
       });
 
+      it("activates the bare model when the catalog is config-option backed but publishes no effort option, dropping a saved level instead of suffixing it (https://github.com/Brevilabs/obsidian-copilot-private/issues/364)", async () => {
+        const { session, applyModelWireId, setConfigOption } = makeSession({
+          model: {
+            current: { baseModelId: "opencode/big-pickle", effort: null },
+            availableModels: [entryOffering("copilot-plus/copilot-plus-flash", [])],
+            apply: { kind: "setConfigOption", configId: "model" },
+          },
+          mode: null,
+        });
+
+        await OpencodeBackendDescriptor.applySelection(session, {
+          baseModelId: "copilot-plus/copilot-plus-flash",
+          effort: "high",
+        });
+
+        expect(applyModelWireId).toHaveBeenCalledTimes(1);
+        expect(applyModelWireId).toHaveBeenCalledWith("copilot-plus/copilot-plus-flash");
+        expect(setConfigOption).not.toHaveBeenCalled();
+      });
+
       it("leaves the model on its native effort when the saved level is no longer offered (https://github.com/logancyang/obsidian-copilot/issues/2917)", async () => {
         const { session, applyModelWireId, setConfigOption } = makeSession({
           model: {

--- a/src/agentMode/backends/opencode/descriptor.ts
+++ b/src/agentMode/backends/opencode/descriptor.ts
@@ -185,7 +185,12 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
 
   async applySelection(session: AgentSession, selection: ModelSelection, context): Promise<void> {
     const apply = session.getState()?.model?.apply;
-    if (apply?.kind === "setConfigOption" && apply.effortConfigId) {
+    // A config-option catalog takes bare model ids only. Effort travels through
+    // its own option when the model publishes one and is dropped otherwise; a
+    // saved level the model does not offer must never become a `/<effort>`
+    // suffix, which opencode rejects, and that rejection reverts the whole
+    // seed to the agent's own default model. https://github.com/Brevilabs/obsidian-copilot-private/issues/364
+    if (apply?.kind === "setConfigOption") {
       // The effort option is model-specific, so activate the bare model first
       // and use the option id from the refreshed state.
       const currentBase = context


### PR DESCRIPTION
Fixes Brevilabs/obsidian-copilot-private#364

## Why

With **Default backend: opencode** and **Default model: Copilot Plus Flash**, every new chat opened on OpenCode Zen/Big Pickle. The saved selection carried a stale `effort: "high"` from an earlier model. `applySelection` only took the config-option path when an effort option existed; without one it fell through to the wire encoder and sent `copilot-plus/copilot-plus-flash/high`, which opencode rejects, and the failed confirmation reverted the whole seed to the agent's own default.

## What

| State | Before | After |
| --- | --- | --- |
| Config-option catalog, model publishes an effort option | Base model switched, effort written through the option | Unchanged |
| Config-option catalog, no effort option, saved effort set | `/<effort>` suffix sent, rejected, seed reverted to Big Pickle | Base model switched with a bare id; the saved effort is dropped |
| Non-config-option catalog | Wire id with effort suffix | Unchanged |

## Non goal

Clearing or migrating stale `effort` values already persisted in settings.

## Screenshot

Not applicable. The change is in the model apply path; the composer picker simply shows the configured model.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | New descriptor test covers the config-option-without-effort case; the existing effort-option tests still pass |
| A defect would fail CI or be obvious on first use | ✅ | A wrong model shows in the composer picker immediately |
| A revert fully restores prior state, including persisted data | ✅ | No persisted format changes |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Model apply only |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Internal descriptor logic |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Same call sequence, one guard widened |
| No hot-path behavior lacks deterministic coverage | ✅ | Covered in `descriptor.test.ts` |
| No new dependency | ✅ | None |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Composer picker on new chat |

Review: `applySelection` in `src/agentMode/backends/opencode/descriptor.ts`, one guard. Verified live on opencode 1.16.0: before, `session/set_config_option` value `copilot-plus/copilot-plus-flash/high` → `Invalid params: model not found` → `reverting seed`; after, value `copilot-plus/copilot-plus-flash` accepted and `currentValue` reports it.

## Verification

1. In Settings → Agents, set Default backend to opencode and Default model to a Copilot Plus model whose Default effort shows "Not supported".
2. Open a new Agent Chat. The composer picker shows that model, not Big Pickle.
3. With Settings → Advanced debug logging on, the console shows no `could not apply seeded selection` warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
