### PR TITLE
Regenerate the gallery story index before the test-vault build

### DIFF
--- a/scripts/test-vault.sh
+++ b/scripts/test-vault.sh
@@ -62,6 +62,12 @@ if [[ -n "$(git -C "$WORKTREE_ROOT" status --porcelain --untracked-files=normal 
   BUILD_STATE="dirty"
 fi
 
+# The plugin type check covers dev/gallery, and the gallery's generated story
+# index is untracked build output. Regenerate it first so a story renamed or
+# deleted on this branch cannot fail the plugin build with a dangling import.
+echo "==> Regenerating gallery story index"
+npm run gallery:stories
+
 echo "==> Building plugin"
 npm run build
 

--- a/scripts/test-vault.test.sh
+++ b/scripts/test-vault.test.sh
@@ -115,6 +115,13 @@ if [[ "$(node -p "require('$FIXTURE_ROOT/manifest.json').version")" != "4.0.0-pr
   exit 1
 fi
 
+STORIES_LINE="$(grep -n -m1 '^npm run gallery:stories$' "$DEPLOY_CALL_LOG" | cut -d: -f1)"
+BUILD_LINE="$(grep -n -m1 '^npm run build$' "$DEPLOY_CALL_LOG" | cut -d: -f1)"
+if [[ -z "$STORIES_LINE" || -z "$BUILD_LINE" || "$BUILD_LINE" -le "$STORIES_LINE" ]]; then
+  echo "built the plugin before regenerating the gallery story index" >&2
+  exit 1
+fi
+
 printf 'dirty\n' >>"$FIXTURE_ROOT/source.txt"
 printf 'dirty bundle\n' >"$FIXTURE_ROOT/main.js"
 run_deploy


### PR DESCRIPTION
## Why

`npm run test:vault` type-checks the plugin with `tsc`, and that check includes `dev/gallery`. The gallery's story index, `dev/gallery/stories.generated.ts`, is untracked output that only `npm run gallery:stories` refreshes. After a story file is renamed or deleted on a branch, the stale index still imports the old path and the plugin build fails:

```
dev/gallery/stories.generated.ts:203:42 - error TS2307: Cannot find module '@/settings/v2/components/LegacyVaultIndexSetting.stories'
```

The script's own gallery redeploy step would regenerate the index, but it runs after the plugin build, so the run never reaches it. The developer has to know to run `npm run gallery:stories` by hand.

## What

> **Before:** `npm run test:vault` on a branch that removed a story fails in the plugin type check with a dangling import from the stale story index.
>
> **After:** `npm run test:vault` regenerates the story index before building the plugin, so the build sees the current story files.

The script test now asserts that the regeneration happens before the build.

## Non goal

- Excluding the generated file from the plugin type check. The gallery entry point imports it, so tsc follows the import regardless of tsconfig `exclude`.
- Changing `npm run build` or CI. Without the generated file present, an ambient declaration already satisfies the import, so CI is unaffected.

## Screenshot

Not applicable, this PR changes a developer deploy script with no rendered surface.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | `scripts/test-vault.test.sh` asserts the story index regenerates before the plugin build |
| A defect would fail CI or be obvious on first use | ✅ | A missing or misordered step fails the script test; a broken regeneration fails the very next `test:vault` run |
| A revert fully restores prior state, including persisted data | ✅ | One extra command in a deploy script, nothing persisted |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Developer tooling only |
| No public API, plugin API, message, or on-disk contract changes | ✅ | The generated file is gitignored build output |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Sequential shell step |
| No hot-path behavior lacks deterministic coverage | ✅ | The ordering is covered by the script test |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Only `test:vault` runs change, and a failure shows in that run's output |

Review: skim `Why` and `What`, run Verification step 3, and confirm CI is green.

## Verification

1. On master, run `npm run gallery:stories`, then delete any `*.stories.tsx` file under `src/` (do not regenerate).
2. Run `npm run build` and observe the TS2307 error naming the deleted story.
3. Check out this branch with the same deleted story and stale index, then run `npm run test:vault`. The build passes and the deploy completes.
4. Run `npm run test:vault:script` and observe `test-vault deployment tests passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9Vw1ZafbmK7CQbVmemwhe
