### PR TITLE
Add llmman as a Self Host BYOK provider template

### DIFF
--- a/docs/copilot-plus-and-self-host.md
+++ b/docs/copilot-plus-and-self-host.md
@@ -73,14 +73,14 @@ After the included Plus period ends, the lifetime Self-Host and Miyo benefits re
 
 The label in the model picker tells you which service handles the conversation:
 
-| Model source                | How access works                                               | Who processes the prompt                                        |
-| --------------------------- | -------------------------------------------------------------- | --------------------------------------------------------------- |
-| **Copilot-hosted**          | Lite, Plus, or included Supporter access                       | Brevilabs and the enterprise model provider used for that model |
-| **Cloud BYOK**              | Your API key under BYOK                                        | The provider and endpoint you configured                        |
-| **Local BYOK**              | Ollama, LM Studio, or another local OpenAI-compatible endpoint | Your local endpoint                                             |
-| **opencode-reported model** | Authentication managed by opencode                             | The provider behind that opencode model                         |
-| **Claude**                  | Claude Code login or environment                               | Anthropic under your Claude account                             |
-| **Codex**                   | Codex CLI login through `codex-acp`                            | OpenAI under your Codex or ChatGPT account                      |
+| Model source                | How access works                                                       | Who processes the prompt                                        |
+| --------------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------- |
+| **Copilot-hosted**          | Lite, Plus, or included Supporter access                               | Brevilabs and the enterprise model provider used for that model |
+| **Cloud BYOK**              | Your API key under BYOK                                                | The provider and endpoint you configured                        |
+| **Local BYOK**              | Ollama, LM Studio, llmman, or another local OpenAI-compatible endpoint | Your local endpoint                                             |
+| **opencode-reported model** | Authentication managed by opencode                                     | The provider behind that opencode model                         |
+| **Claude**                  | Claude Code login or environment                                       | Anthropic under your Claude account                             |
+| **Codex**                   | Codex CLI login through `codex-acp`                                    | OpenAI under your Codex or ChatGPT account                      |
 
 A Claude or ChatGPT subscription is not an API key. Use the Claude or Codex Agent Chat setup for those subscriptions. Use BYOK only when you have API access or an OpenAI-compatible endpoint.
 

--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -47,7 +47,8 @@ with that provider.
 
 1. Open **Settings → Copilot → BYOK**.
 2. Click **Add a provider**.
-3. Choose a provider, **Ollama**, **LM Studio**, or **Add a custom provider**.
+3. Choose a provider, **Ollama**, **LM Studio**, **llmman**, or **Add a custom
+   provider**.
 4. Enter the **API key** and **Base URL** when required.
 5. Select or enter at least one model, optionally click **Test**, then click
    **Save**.
@@ -70,13 +71,14 @@ is left out of the opencode list, but may still work in Quick Chat.
 
 ### Local and Custom Endpoints
 
-Inside **BYOK → Add a provider**, choose **Ollama** or **LM Studio** from the
-**Self Host** group to use their local OpenAI-compatible servers. This does not
-require a Self-Host license. Their API key is optional, and Copilot fills in the
-usual local URL:
+Inside **BYOK → Add a provider**, choose **Ollama**, **LM Studio**, or
+**llmman** from the **Self Host** group to use their local OpenAI-compatible
+servers. This does not require a Self-Host license. Their API key is optional,
+and Copilot fills in the usual local URL:
 
 - Ollama: `http://localhost:11434/v1`
 - LM Studio: `http://localhost:1234/v1`
+- [llmman](https://github.com/llmmanorg/llmman): `http://localhost:17434/v1`
 
 Start the local server before testing the provider. For another compatible
 service or proxy, choose **Add a custom provider** and enter its base URL and

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -144,26 +144,26 @@ See [`AGENTS.md` examples](agents-md-examples.md) and [Projects](projects.md) fo
 
 ## BYOK
 
-Bring Your Own Key connects Copilot directly to a model provider, compatible gateway, Ollama, LM Studio, or another OpenAI-compatible endpoint. No Copilot license is required. Cloud-provider billing and data handling belong to that provider.
+Bring Your Own Key connects Copilot directly to a model provider, compatible gateway, Ollama, LM Studio, llmman, or another OpenAI-compatible endpoint. No Copilot license is required. Cloud-provider billing and data handling belong to that provider.
 
 ### Add a provider
 
 1. Select **Add a provider**.
-2. Search or choose from **Recommended** providers, **Self Host** templates for Ollama and LM Studio, the dynamic **More providers** catalog, or **Add a custom provider**.
+2. Search or choose from **Recommended** providers, **Self Host** templates for Ollama, LM Studio, and llmman, the dynamic **More providers** catalog, or **Add a custom provider**.
 3. Complete the configuration and select at least one model.
 4. Select **Save**. New chat models are enabled for Quick Chat and opencode automatically; curate each list later under **Basic → Agents**.
 
 The configuration dialog contains:
 
-| Control                     | Default                                           | What it does                                                                                                                                                                                                                                     |
-| --------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Display name**            | Provider name                                     | Changes the label shown throughout Copilot.                                                                                                                                                                                                      |
-| **API key**                 | Blank; required or optional according to provider | **Test** verifies the current key and refreshes model discovery. In edit mode, **Clear** stages key removal until you select **Save**. Required-key providers cannot be saved without a key. Keys are stored in this device's Obsidian Keychain. |
-| **Base URL**                | Provider's standard endpoint when known           | Overrides where Copilot sends requests. A custom OpenAI-compatible provider must have a Base URL. Ollama defaults to `http://localhost:11434/v1`; LM Studio defaults to `http://localhost:1234/v1`.                                              |
-| **Enable CORS**             | Off                                               | Compatibility option for Quick Chat endpoints that reject browser-style requests. When enabled, responses arrive only after completion instead of streaming token by token. It does not change opencode routing.                                 |
-| **Model ID → Add**          | Blank                                             | Adds an exact model ID manually. Use this when an endpoint cannot list models. A typed ID can be removed from the candidate list with its remove button.                                                                                         |
-| **Search available models** | Blank                                             | Filters discovered, previously configured, and manually added models. Check each model you want to save. Model rows can show context size, release date, and capabilities when known.                                                            |
-| **Save / Cancel**           | Save disabled until the setup is usable           | Save requires at least one model, a required key when applicable, and a routable custom endpoint. A conclusive invalid-key result blocks saving; a temporary network failure does not prevent an offline setup from being saved.                 |
+| Control                     | Default                                           | What it does                                                                                                                                                                                                                                        |
+| --------------------------- | ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Display name**            | Provider name                                     | Changes the label shown throughout Copilot.                                                                                                                                                                                                         |
+| **API key**                 | Blank; required or optional according to provider | **Test** verifies the current key and refreshes model discovery. In edit mode, **Clear** stages key removal until you select **Save**. Required-key providers cannot be saved without a key. Keys are stored in this device's Obsidian Keychain.    |
+| **Base URL**                | Provider's standard endpoint when known           | Overrides where Copilot sends requests. A custom OpenAI-compatible provider must have a Base URL. Ollama defaults to `http://localhost:11434/v1`; LM Studio defaults to `http://localhost:1234/v1`; llmman defaults to `http://localhost:17434/v1`. |
+| **Enable CORS**             | Off                                               | Compatibility option for Quick Chat endpoints that reject browser-style requests. When enabled, responses arrive only after completion instead of streaming token by token. It does not change opencode routing.                                    |
+| **Model ID → Add**          | Blank                                             | Adds an exact model ID manually. Use this when an endpoint cannot list models. A typed ID can be removed from the candidate list with its remove button.                                                                                            |
+| **Search available models** | Blank                                             | Filters discovered, previously configured, and manually added models. Check each model you want to save. Model rows can show context size, release date, and capabilities when known.                                                               |
+| **Save / Cancel**           | Save disabled until the setup is usable           | Save requires at least one model, a required key when applicable, and a routable custom endpoint. A conclusive invalid-key result blocks saving; a temporary network failure does not prevent an offline setup from being saved.                    |
 
 ### Manage providers and models
 

--- a/src/modelManagement/catalog/builtinDefinitions.ts
+++ b/src/modelManagement/catalog/builtinDefinitions.ts
@@ -3,7 +3,7 @@
  * wizard alongside catalog-derived definitions.
  *
  * Covers providers `models.dev` does not list — local runners
- * (Ollama, LM Studio) and the
+ * (Ollama, LM Studio, llmman) and the
  * catch-all custom OpenAI-compatible endpoint. None carry a model list;
  * available ids come from `/models` fetched at dialog open or from the
  * user typing them in manually.
@@ -32,6 +32,16 @@ export const LOCAL_PROVIDER_DEFINITIONS: readonly ProviderDefinition[] = [
     defaultBaseUrl: "http://localhost:1234/v1",
     requiresApiKey: false,
     modelInputHint: "e.g. lmstudio-community/Qwen2.5-7B-Instruct-GGUF",
+  },
+  {
+    // llmman (https://github.com/llmmanorg/llmman) serves the Ollama and OpenAI
+    // APIs on port 17434; like Ollama, Copilot talks to its `/v1` routes.
+    id: "llmman",
+    displayName: "llmman",
+    providerType: "openai-compatible",
+    defaultBaseUrl: "http://localhost:17434/v1",
+    requiresApiKey: false,
+    modelInputHint: "e.g. gemma4, hf.co/unsloth/Qwen3.5-0.8B-GGUF",
   },
 ];
 


### PR DESCRIPTION
Adds [llmman](https://github.com/llmmanorg/llmman), a local model runner that serves the Ollama and OpenAI APIs on port 17434.

- `src/modelManagement/catalog/builtinDefinitions.ts`: one new `LOCAL_PROVIDER_DEFINITIONS` entry (`id: "llmman"`, `providerType: "openai-compatible"`, `defaultBaseUrl: "http://localhost:17434/v1"`, `requiresApiKey: false`), the same shape as the Ollama and LM Studio templates, so it appears in the **Self Host** group and gets chat, embeddings, and `/v1/models` discovery with no further code.
- Appended after LM Studio; the existing list is not alphabetical and I did not reorder it.
- Legacy `ChatModelProviders` / `byokMigration` maps untouched: llmman never existed in pre-BYOK settings, so there is nothing to migrate.
- Docs: listed llmman next to Ollama and LM Studio in `docs/llm-providers.md`, `docs/settings.md`, and `docs/copilot-plus-and-self-host.md` (two tables re-aligned by Prettier).

**Testing:** `npx tsc --noEmit`, `npm run format:check`, and `npx jest src/modelManagement/catalog src/modelManagement/ui/dialogs/AddProviderDialog.test.tsx src/modelManagement/ui/dialogs/ConfigureProviderDialog.test.tsx` all pass; not run against a live llmman server or inside Obsidian.

> AI-assisted, reviewed before submitting.
