### PR TITLE
[Agent Mode] - Step 5: Synchronize managed updates across agent surfaces

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -143,3 +143,7 @@ On Windows, creating the folder links may require **Developer Mode** or administ
 - [Instructions for Agent Chat and Quick Chat](system-prompts.md)
 - [Copilot Commands and Quick Ask](custom-commands.md)
 - [Copilot Plans, Privacy, and Self-Hosting](copilot-plus-and-self-host.md)
+
+### Updating an agent
+
+When an installed agent needs a supported version, Basic → Agents and Agent Chat offer **Update** if Copilot can update that installation. Both show the same progress, including updates started in Configure. If an update fails, use **Retry**. A failed custom-path selection is reported in Configure and does not turn the update action into a path-validation retry.

--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -144,6 +144,6 @@ On Windows, creating the folder links may require **Developer Mode** or administ
 - [Copilot Commands and Quick Ask](custom-commands.md)
 - [Copilot Plans, Privacy, and Self-Hosting](copilot-plus-and-self-host.md)
 
-### Updating an agent
+### Upgrading an agent
 
-When an installed agent needs a supported version, Basic → Agents and Agent Chat offer **Update** if Copilot can update that installation. Both show the same progress, including updates started in Configure. If an update fails, use **Retry**. A failed custom-path selection is reported in Configure and does not turn the update action into a path-validation retry.
+When an installed agent needs a supported version, Basic → Agents and Agent Chat offer **Upgrade** if Copilot can upgrade that installation. Both show the same progress, including upgrades started in Configure. If an upgrade fails, use **Retry**. A failed custom-path selection is reported in Configure and does not turn the upgrade action into a path-validation retry.

--- a/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
@@ -672,6 +672,7 @@ describe("OpencodeBinaryManager.runtimeState", () => {
     // Durable rather than announced: whichever surface mounts next renders it.
     expect(mgr.getRuntimeState()).toEqual({
       kind: "error",
+      operation: "configure",
       message: expect.stringContaining("No file at"),
     });
   });
@@ -718,6 +719,7 @@ describe("OpencodeBinaryManager.runtimeState", () => {
     // while an error is showing.
     expect(mgr.getRuntimeState()).toEqual({
       kind: "error",
+      operation: "configure",
       message: expect.stringContaining("Couldn't find opencode"),
     });
     expect(mgr.isBusy()).toBe(false);

--- a/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
@@ -1,3 +1,4 @@
+import { waitFor } from "@testing-library/react";
 jest.mock("obsidian", () => ({
   // pickMatchingAsset is pure; FileSystemAdapter and requestUrl are
   // referenced by the manager class but not by these tests.
@@ -475,6 +476,42 @@ describe("OpencodeBinaryManager.upgradeCustomBinary", () => {
   afterEach(async () => {
     await fs.promises.rm(tmpDir, { recursive: true, force: true });
   });
+
+  it.each(["upgrade", "--version"])(
+    "https://github.com/Brevilabs/obsidian-copilot-private/issues/368 cancels during %s without publishing settings or Retry",
+    async (phase) => {
+      if (process.platform === "win32") return;
+      const file = path.join(tmpDir, "opencode");
+      const marker = path.join(tmpDir, "started");
+      await fs.promises.writeFile(
+        file,
+        `#!${process.execPath}
+if (process.argv[2] === ${JSON.stringify(phase)}) {
+  require("fs").writeFileSync(${JSON.stringify(marker)}, String(process.pid));
+  setTimeout(() => process.stdout.write("99.0.0"), ${phase === "upgrade" ? 30000 : 250});
+}
+`
+      );
+      await fs.promises.chmod(file, 0o755);
+      const initial = { binaryPath: file, binaryVersion: "1.0.0", binarySource: "custom" as const };
+      settingsMock.__reset(initial);
+      const manager = new OpencodeBinaryManager(fakePlugin);
+      const operation = manager.upgradeCustomBinary();
+      const rejected = expect(operation).rejects.toMatchObject({ name: "AbortError" });
+      try {
+        await waitFor(() => expect(fs.existsSync(marker)).toBe(true));
+        const pid = Number(await fs.promises.readFile(marker, "utf8"));
+        manager.cancelCurrentOperation();
+        await rejected;
+        await waitFor(() => expect(() => process.kill(pid, 0)).toThrow());
+        expect(settingsMock.__get()).toEqual(initial);
+        expect(manager.getRuntimeState()).toEqual({ kind: "idle" });
+      } finally {
+        manager.cancelCurrentOperation();
+        await operation.catch(() => undefined);
+      }
+    }
+  );
 
   it("rejects when opencode upgrade exits successfully but leaves an outdated binary", async () => {
     if (process.platform === "win32") return;

--- a/src/agentMode/backends/opencode/OpencodeBinaryManager.ts
+++ b/src/agentMode/backends/opencode/OpencodeBinaryManager.ts
@@ -575,7 +575,7 @@ export class OpencodeBinaryManager extends ManagedBinaryManager<ProgressEvent, I
    * are untouched. Throws with a readable message on failure.
    */
   async upgradeCustomBinary(): Promise<{ version: string; path: string }> {
-    return this.runExclusive({ kind: "busy" }, async () => {
+    return this.runExclusive({ kind: "installing", progress: null }, async () => {
       const s = readOpencodeSettings();
       if (s.binarySource !== "custom" || !s.binaryPath) {
         throw new Error("No custom opencode binary is configured to upgrade.");

--- a/src/agentMode/backends/opencode/OpencodeBinaryManager.ts
+++ b/src/agentMode/backends/opencode/OpencodeBinaryManager.ts
@@ -35,7 +35,7 @@ function nodePath(): typeof import("node:path") {
 async function execFileAsync(
   file: string,
   args: string[],
-  options: Pick<import("node:child_process").ExecFileOptions, "timeout" | "windowsHide">
+  options: Pick<import("node:child_process").ExecFileOptions, "timeout" | "windowsHide" | "signal">
 ): Promise<{ stdout: string | Buffer }> {
   const { execFile } = requireNodeModule<typeof import("node:child_process")>("child_process");
   const { promisify } = requireNodeModule<typeof import("node:util")>("util");
@@ -575,7 +575,7 @@ export class OpencodeBinaryManager extends ManagedBinaryManager<ProgressEvent, I
    * are untouched. Throws with a readable message on failure.
    */
   async upgradeCustomBinary(): Promise<{ version: string; path: string }> {
-    return this.runExclusive({ kind: "installing", progress: null }, async () => {
+    return this.runExclusive({ kind: "installing", progress: null }, async (signal) => {
       const s = readOpencodeSettings();
       if (s.binarySource !== "custom" || !s.binaryPath) {
         throw new Error("No custom opencode binary is configured to upgrade.");
@@ -583,14 +583,21 @@ export class OpencodeBinaryManager extends ManagedBinaryManager<ProgressEvent, I
       const binaryPath = s.binaryPath;
       try {
         await execFileAsync(binaryPath, ["upgrade"], {
+          // Configure exposes Cancel for this shared operation; stop the process as well.
+          // https://github.com/Brevilabs/obsidian-copilot-private/issues/368
+          signal,
           timeout: UPGRADE_BINARY_TIMEOUT_MS,
           windowsHide: true,
         });
       } catch (e) {
+        this.throwIfAborted(signal);
         const err = e as NodeJS.ErrnoException;
         throw new Error(`\`${binaryPath} upgrade\` failed: ${err.message ?? String(err)}`);
       }
       const { stdout } = await verifyOpencodeBinary(binaryPath);
+      // Cancellation during validation must not publish an updated configuration.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/368
+      this.throwIfAborted(signal);
       const version = parseVersionFromStdout(stdout);
       if (!version) {
         throw new Error(`${binaryPath} --version didn't report a version after upgrade.`);

--- a/src/agentMode/backends/opencode/OpencodeInlineInstall.test.tsx
+++ b/src/agentMode/backends/opencode/OpencodeInlineInstall.test.tsx
@@ -108,7 +108,7 @@ describe("OpencodeInlineInstall", () => {
     it("surfaces the failure reason and offers a retry when an operation fails", () => {
       render(<OpencodeAbsentInstallActions plugin={plugin} />);
 
-      fake.publish({ kind: "error", message: "GitHub API rate-limited" });
+      fake.publish({ kind: "error", operation: "install", message: "GitHub API rate-limited" });
 
       expect(screen.getByText("GitHub API rate-limited")).not.toBeNull();
       expect(screen.getByRole("button", { name: "Try again" })).not.toBeNull();
@@ -116,7 +116,7 @@ describe("OpencodeInlineInstall", () => {
 
     it("runs a fresh install when the user retries after a failure", async () => {
       render(<OpencodeAbsentInstallActions plugin={plugin} />);
-      fake.publish({ kind: "error", message: "network down" });
+      fake.publish({ kind: "error", operation: "install", message: "network down" });
 
       fireEvent.click(screen.getByRole("button", { name: "Try again" }));
 
@@ -138,7 +138,11 @@ describe("OpencodeInlineInstall", () => {
     // while the button that message depends on had vanished from the row.
     it("reveals Configure and retires the adopt action when no opencode is found", async () => {
       fake.adoptExistingBinary.mockImplementation(() => {
-        fake.publish({ kind: "error", message: new OpencodeNotFoundError().message });
+        fake.publish({
+          kind: "error",
+          operation: "install",
+          message: new OpencodeNotFoundError().message,
+        });
         return Promise.reject(new OpencodeNotFoundError());
       });
       render(<OpencodeAbsentInstallActions plugin={plugin} />);
@@ -175,7 +179,7 @@ describe("OpencodeInlineInstall", () => {
 
     it("opens the Configure dialog from the failure state so a custom path stays reachable", () => {
       render(<OpencodeAbsentInstallActions plugin={plugin} />);
-      fake.publish({ kind: "error", message: "nothing found" });
+      fake.publish({ kind: "error", operation: "install", message: "nothing found" });
 
       fireEvent.click(screen.getByRole("button", { name: "Configure" }));
 
@@ -222,7 +226,7 @@ describe("OpencodeInlineInstall", () => {
     });
 
     it("shows a failure that settled before it mounted", () => {
-      fake.publish({ kind: "error", message: "Network unreachable" });
+      fake.publish({ kind: "error", operation: "install", message: "Network unreachable" });
 
       render(<OpencodeAbsentInstallActions plugin={plugin} />);
 

--- a/src/agentMode/backends/opencode/OpencodeInstallModal.test.tsx
+++ b/src/agentMode/backends/opencode/OpencodeInstallModal.test.tsx
@@ -249,7 +249,7 @@ describe("OpencodeInstallModal", () => {
       await act(async () => {
         installDeferred().reject(new Error("tar exited with 1"));
       });
-      publish({ kind: "error", message: "tar exited with 1" });
+      publish({ kind: "error", operation: "install", message: "tar exited with 1" });
 
       expect(screen.getByText("tar exited with 1")).toBeTruthy();
       expect(screen.getByRole("button", { name: "Download & install" })).toBeTruthy();

--- a/src/agentMode/backends/opencode/descriptor.test.ts
+++ b/src/agentMode/backends/opencode/descriptor.test.ts
@@ -13,7 +13,7 @@ import type {
   ModelEntry,
   ModelState,
 } from "@/agentMode/session/types";
-import type { CopilotSettings } from "@/settings/model";
+import { getSettings, setSettings, type CopilotSettings } from "@/settings/model";
 
 jest.mock("@/settings/model", () => ({
   ...jest.requireActual("@/settings/model"),
@@ -28,6 +28,102 @@ jest.mock("@/logger", () => ({
 
 describe("descriptor", () => {
   describe("OpencodeBackendDescriptor", () => {
+    describe("managedInstall", () => {
+      it("https://github.com/Brevilabs/obsidian-copilot-private/issues/368 maps shared progress without adding a fabricated percentage", async () => {
+        const manager = getOpencodeBinaryManager(vaultPlugin(os.tmpdir()));
+        const subscribe = jest.spyOn(manager, "subscribeRuntimeState");
+        const getState = jest
+          .spyOn(manager, "getRuntimeState")
+          .mockReturnValue({ kind: "installing", progress: null });
+        const plugin = vaultPlugin(os.tmpdir());
+
+        expect(OpencodeBackendDescriptor.managedInstall?.getState(plugin)).toEqual({
+          kind: "running",
+          label: "Starting…",
+        });
+        const listener = jest.fn();
+        OpencodeBackendDescriptor.managedInstall?.subscribe(plugin, listener);
+        expect(subscribe).toHaveBeenCalledWith(listener);
+
+        for (const kind of ["busy", "detecting"] as const) {
+          getState.mockReturnValue({ kind });
+          expect(OpencodeBackendDescriptor.managedInstall?.getState(plugin)).toEqual({
+            kind: "running",
+            label: "Configuring…",
+          });
+        }
+        getState.mockReturnValue({
+          kind: "error",
+          message: "invalid path",
+          operation: "configure",
+        });
+        expect(OpencodeBackendDescriptor.managedInstall?.getState(plugin)).toEqual({
+          kind: "idle",
+        });
+        getState.mockReturnValue({
+          kind: "error",
+          message: "download failed",
+          operation: "install",
+        });
+        expect(OpencodeBackendDescriptor.managedInstall?.getState(plugin)).toEqual({
+          kind: "error",
+          message: "download failed",
+        });
+        for (const total of [100, undefined]) {
+          getState.mockReturnValue({
+            kind: "installing",
+            progress: { phase: "download", received: 42, total, assetName: "agent.zip" },
+          });
+          const state = OpencodeBackendDescriptor.managedInstall?.getState(plugin);
+          expect(state?.kind).toBe("running");
+          if (state?.kind === "running")
+            expect(state.label.match(/%/g)?.length ?? 0).toBe(total ? 1 : 0);
+        }
+        getState.mockRestore();
+        subscribe.mockRestore();
+      });
+
+      it("keeps custom and managed upgrades on their existing manager paths", async () => {
+        const manager = getOpencodeBinaryManager(vaultPlugin(os.tmpdir()));
+        const upgradeCustom = jest.spyOn(manager, "upgradeCustomBinary").mockResolvedValue({
+          version: "1.0.0",
+          path: process.execPath,
+        });
+        const upgradeManaged = jest.spyOn(manager, "upgradeManaged").mockResolvedValue({
+          version: "1.0.0",
+          path: process.execPath,
+        });
+        const original = getSettings().agentMode;
+
+        try {
+          for (const source of ["custom", "managed"] as const) {
+            setSettings((current) => ({
+              agentMode: {
+                ...current.agentMode,
+                backends: {
+                  ...current.agentMode.backends,
+                  opencode: {
+                    ...current.agentMode.backends?.opencode,
+                    binaryPath: process.execPath,
+                    binaryVersion: "1.0.0",
+                    binarySource: source,
+                  },
+                },
+              },
+            }));
+            await OpencodeBackendDescriptor.managedInstall?.run(vaultPlugin(os.tmpdir()));
+          }
+
+          expect(upgradeCustom).toHaveBeenCalledTimes(1);
+          expect(upgradeManaged).toHaveBeenCalledTimes(1);
+        } finally {
+          setSettings({ agentMode: original });
+          upgradeCustom.mockRestore();
+          upgradeManaged.mockRestore();
+        }
+      });
+    });
+
     describe("wire.decode()", () => {
       const decode = OpencodeBackendDescriptor.wire.decode;
 

--- a/src/agentMode/backends/opencode/descriptor.test.ts
+++ b/src/agentMode/backends/opencode/descriptor.test.ts
@@ -28,10 +28,9 @@ jest.mock("@/logger", () => ({
 
 describe("descriptor", () => {
   describe("OpencodeBackendDescriptor", () => {
-    describe("managedInstall", () => {
+    describe("managedInstall.getState()", () => {
       it("https://github.com/Brevilabs/obsidian-copilot-private/issues/368 maps shared progress without adding a fabricated percentage", async () => {
         const manager = getOpencodeBinaryManager(vaultPlugin(os.tmpdir()));
-        const subscribe = jest.spyOn(manager, "subscribeRuntimeState");
         const getState = jest
           .spyOn(manager, "getRuntimeState")
           .mockReturnValue({ kind: "installing", progress: null });
@@ -41,9 +40,6 @@ describe("descriptor", () => {
           kind: "running",
           label: "Starting…",
         });
-        const listener = jest.fn();
-        OpencodeBackendDescriptor.managedInstall?.subscribe(plugin, listener);
-        expect(subscribe).toHaveBeenCalledWith(listener);
 
         for (const kind of ["busy", "detecting"] as const) {
           getState.mockReturnValue({ kind });
@@ -80,9 +76,23 @@ describe("descriptor", () => {
             expect(state.label.match(/%/g)?.length ?? 0).toBe(total ? 1 : 0);
         }
         getState.mockRestore();
+      });
+    });
+
+    describe("managedInstall.subscribe()", () => {
+      it("subscribes to shared operation changes and returns cleanup", () => {
+        const plugin = vaultPlugin(os.tmpdir());
+        const manager = getOpencodeBinaryManager(plugin);
+        const cleanup = jest.fn();
+        const subscribe = jest.spyOn(manager, "subscribeRuntimeState").mockReturnValue(cleanup);
+        const listener = jest.fn();
+        expect(OpencodeBackendDescriptor.managedInstall?.subscribe(plugin, listener)).toBe(cleanup);
+        expect(subscribe).toHaveBeenCalledWith(listener);
         subscribe.mockRestore();
       });
+    });
 
+    describe("managedInstall.run()", () => {
       it("keeps custom and managed upgrades on their existing manager paths", async () => {
         const manager = getOpencodeBinaryManager(vaultPlugin(os.tmpdir()));
         const upgradeCustom = jest.spyOn(manager, "upgradeCustomBinary").mockResolvedValue({

--- a/src/agentMode/backends/opencode/descriptor.ts
+++ b/src/agentMode/backends/opencode/descriptor.ts
@@ -38,6 +38,8 @@ import type {
 import type { BackendDescriptor, BackendProcess, InstallState } from "@/agentMode/session/types";
 import { EFFORT_LEVELS_ASCENDING } from "@/agentMode/session/types";
 import { findModelEntry } from "@/agentMode/session/translateBackendState";
+import { phaseLabel } from "./installProgress";
+import type { ManagedInstallActionState } from "@/agentMode/session/types";
 
 /** Config option id OpenCode uses to switch the active agent at runtime. */
 const OPENCODE_MODE_CONFIG_OPTION_ID = "mode";
@@ -108,6 +110,28 @@ export function getOpencodeBinaryManager(plugin: CopilotPlugin): OpencodeBinaryM
  */
 export { detectOpencodeCliPath } from "./opencodeCliDetector";
 
+const IDLE_MANAGED_INSTALL_ACTION = Object.freeze({
+  kind: "idle" as const,
+}) satisfies ManagedInstallActionState;
+
+function managedInstallActionState(manager: OpencodeBinaryManager): ManagedInstallActionState {
+  const state = manager.getRuntimeState();
+  if (state.kind === "installing") {
+    return {
+      kind: "running",
+      label: phaseLabel(state.progress),
+    };
+  }
+  // Keep competing setup actions disabled, but only retry failed installs or upgrades.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/368
+  if (state.kind === "detecting" || state.kind === "busy") {
+    return { kind: "running", label: "Configuring…" };
+  }
+  if (state.kind === "error" && state.operation === "install")
+    return { kind: "error", message: state.message };
+  return IDLE_MANAGED_INSTALL_ACTION;
+}
+
 /**
  * Descriptor for the OpenCode backend. This is the contract `session/` and
  * `ui/` consume — the rest of Agent Mode never imports `OpencodeBackend`,
@@ -173,15 +197,25 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
 
   AbsentInstallActions: OpencodeAbsentInstallActions,
 
-  async upgrade(plugin: CopilotPlugin): Promise<void> {
-    const manager = getOpencodeBinaryManager(plugin);
-    const state = computeInstallState(getSettings().agentMode?.backends?.opencode);
-    if (state.kind !== "installed") return;
-    if (state.source === "custom") {
-      await manager.upgradeCustomBinary();
-    } else {
-      await manager.upgradeManaged();
-    }
+  managedInstall: {
+    getState(plugin: CopilotPlugin): ManagedInstallActionState {
+      return managedInstallActionState(getOpencodeBinaryManager(plugin));
+    },
+
+    subscribe(plugin: CopilotPlugin, onChange: () => void): () => void {
+      return getOpencodeBinaryManager(plugin).subscribeRuntimeState(onChange);
+    },
+
+    async run(plugin: CopilotPlugin): Promise<void> {
+      const manager = getOpencodeBinaryManager(plugin);
+      const state = computeInstallState(getSettings().agentMode?.backends?.opencode);
+      if (state.kind !== "installed") return;
+      if (state.source === "custom") {
+        await manager.upgradeCustomBinary();
+      } else {
+        await manager.upgradeManaged();
+      }
+    },
   },
 
   async applySelection(

--- a/src/agentMode/backends/shared/ManagedBinaryManager.test.ts
+++ b/src/agentMode/backends/shared/ManagedBinaryManager.test.ts
@@ -154,7 +154,11 @@ describe("ManagedBinaryManager", () => {
       it("https://github.com/Brevilabs/obsidian-copilot-private/issues/368 clears a prior failure so a reopened lifecycle starts idle", async () => {
         manager.pipeline.mockRejectedValueOnce(new Error("failed"));
         await expect(manager.install()).rejects.toThrow("failed");
-        expect(manager.getRuntimeState()).toEqual({ kind: "error", message: "failed" });
+        expect(manager.getRuntimeState()).toEqual({
+          kind: "error",
+          message: "failed",
+          operation: "install",
+        });
         manager.forgetSettledError();
         expect(manager.getRuntimeState()).toEqual({ kind: "idle" });
       });
@@ -234,13 +238,18 @@ describe("ManagedBinaryManager", () => {
           expect(manager.validate).not.toHaveBeenCalled();
         }
       );
-      it("keeps the configured binary when backend version validation fails", async () => {
+      it("https://github.com/Brevilabs/obsidian-copilot-private/issues/368 keeps the configured binary and identifies a path-validation failure", async () => {
         manager.settings = { binaryPath: "/previous" };
         manager.validate.mockRejectedValueOnce(new Error("unsupported version"));
         await expect(manager.setCustomBinaryPath(customPath)).rejects.toThrow(
           "unsupported version"
         );
         expect(manager.settings.binaryPath).toBe("/previous");
+        expect(manager.getRuntimeState()).toEqual({
+          kind: "error",
+          message: "unsupported version",
+          operation: "configure",
+        });
       });
     });
   });

--- a/src/agentMode/backends/shared/ManagedBinaryManager.ts
+++ b/src/agentMode/backends/shared/ManagedBinaryManager.ts
@@ -98,6 +98,9 @@ export abstract class ManagedBinaryManager<
         this.publishState({ kind: "idle" });
       } else {
         this.publishState({
+          // A failed path selection must not offer an install Retry in other windows.
+          // https://github.com/Brevilabs/obsidian-copilot-private/issues/368
+          operation: running.kind === "installing" ? "install" : "configure",
           kind: "error",
           message: error instanceof Error ? error.message : String(error),
         });

--- a/src/agentMode/backends/shared/installStatus.test.tsx
+++ b/src/agentMode/backends/shared/installStatus.test.tsx
@@ -61,7 +61,7 @@ describe("installStatus", () => {
       ["absent", "Not set up", { kind: "absent" }],
       [
         "incompatible",
-        "Update required",
+        "Upgrade required",
         {
           kind: "incompatible",
           source: "custom",

--- a/src/agentMode/backends/shared/installStatus.tsx
+++ b/src/agentMode/backends/shared/installStatus.tsx
@@ -39,13 +39,13 @@ export function installBadge(state: InstallState): InstallBadgeSpec | null {
  * Status vocabulary for the Configure dialogs. It differs from {@link installBadge}
  * on the two states where a dialog and a settings card have different jobs: a
  * dialog is the place you go to fix things, so `absent` says so outright instead
- * of staying silent, and `incompatible` names the remedy ("Update required")
+ * of staying silent, and `incompatible` names the remedy ("Upgrade required")
  * rather than the diagnosis.
  */
 const CONFIG_STATUS_BADGES: Record<InstallState["kind"], InstallBadgeSpec> = {
   ready: { label: "Ready", variant: "success", showCheck: true },
   absent: { label: "Not set up", variant: "outline" },
-  incompatible: { label: "Update required", variant: "destructive", showAlert: true },
+  incompatible: { label: "Upgrade required", variant: "destructive", showAlert: true },
   checking: { label: "Checking…", variant: "outline" },
   error: { label: "Error", variant: "destructive" },
 };

--- a/src/agentMode/backends/shared/managedInstall.ts
+++ b/src/agentMode/backends/shared/managedInstall.ts
@@ -7,7 +7,7 @@ export type ManagedInstallRuntimeState<TProgress> =
   | { kind: "detecting" }
   | { kind: "installing"; progress: TProgress | null }
   | { kind: "busy" }
-  | { kind: "error"; message: string };
+  | { kind: "error"; message: string; operation: "install" | "configure" };
 
 /** Reports a competing process-local operation without changing the active run. */
 export class ManagedInstallOperationInFlightError extends Error {

--- a/src/agentMode/backends/shared/ui/AgentBackendHeader.stories.tsx
+++ b/src/agentMode/backends/shared/ui/AgentBackendHeader.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@/lib/story";
+import { Terminal } from "lucide-react";
+import { AgentBackendHeader, type AgentBackendHeaderProps } from "./AgentBackendHeader";
+
+const meta = {
+  title: "Settings/Agent Backend Header",
+  component: AgentBackendHeader,
+  args: {
+    displayName: "opencode",
+    Icon: Terminal,
+    installState: {
+      kind: "incompatible",
+      source: "managed",
+      currentVersion: "1.0.0",
+      minVersion: "2.0.0",
+      message: "Update opencode to the supported version.",
+    },
+    managedInstall: { kind: "idle" },
+    canUpdate: true,
+    resolvedPath: "~/.obsidian-copilot/opencode/1.0.0/opencode",
+    onUpdate: () => {},
+    onConfigure: () => {},
+  },
+  parameters: { gallery: { host: "settings-tab", layout: "padded" } },
+} satisfies Meta<AgentBackendHeaderProps>;
+export default meta;
+export const Update: StoryObj<AgentBackendHeaderProps> = {};
+export const Running: StoryObj<AgentBackendHeaderProps> = {
+  args: { managedInstall: { kind: "running", label: "Downloading opencode.zip (42%)" } },
+};
+export const Indeterminate: StoryObj<AgentBackendHeaderProps> = {
+  args: { managedInstall: { kind: "running", label: "Downloading opencode.zip" } },
+};
+export const Retry: StoryObj<AgentBackendHeaderProps> = {
+  args: {
+    managedInstall: {
+      kind: "error",
+      message: "The download failed. Check your connection and retry.",
+    },
+  },
+};

--- a/src/agentMode/backends/shared/ui/AgentBackendHeader.stories.tsx
+++ b/src/agentMode/backends/shared/ui/AgentBackendHeader.stories.tsx
@@ -13,7 +13,7 @@ const meta = {
       source: "managed",
       currentVersion: "1.0.0",
       minVersion: "2.0.0",
-      message: "Update opencode to the supported version.",
+      message: "Upgrade opencode to the supported version.",
     },
     managedInstall: { kind: "idle" },
     canUpdate: true,
@@ -24,7 +24,7 @@ const meta = {
   parameters: { gallery: { host: "settings-tab", layout: "padded" } },
 } satisfies Meta<AgentBackendHeaderProps>;
 export default meta;
-export const Update: StoryObj<AgentBackendHeaderProps> = {};
+export const Upgrade: StoryObj<AgentBackendHeaderProps> = {};
 export const Running: StoryObj<AgentBackendHeaderProps> = {
   args: { managedInstall: { kind: "running", label: "Downloading opencode.zip (42%)" } },
 };

--- a/src/agentMode/backends/shared/ui/AgentBackendHeader.test.tsx
+++ b/src/agentMode/backends/shared/ui/AgentBackendHeader.test.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { AgentBackendHeader } from "./AgentBackendHeader";
+import meta, { Running, Retry, Indeterminate } from "./AgentBackendHeader.stories";
+
+describe("AgentBackendHeader", () => {
+  describe("AgentBackendHeader()", () => {
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/368 shows update, shared progress, and retry in the settings row", () => {
+      const onUpdate = jest.fn();
+      const view = render(<AgentBackendHeader {...meta.args} onUpdate={onUpdate} />);
+      fireEvent.click(screen.getByRole("button", { name: "Update" }));
+      expect(onUpdate).toHaveBeenCalledTimes(1);
+      view.rerender(<AgentBackendHeader {...meta.args} {...Running.args} />);
+      expect(screen.getByRole("button", { name: "Updating…" }).hasAttribute("disabled")).toBe(true);
+      expect(screen.getByText("Downloading opencode.zip (42%)")).toBeTruthy();
+      view.rerender(<AgentBackendHeader {...meta.args} {...Indeterminate.args} />);
+      expect(screen.getByText("Downloading opencode.zip")).toBeTruthy();
+      expect(screen.queryByText(/0%/)).toBeNull();
+      view.rerender(<AgentBackendHeader {...meta.args} {...Retry.args} onUpdate={onUpdate} />);
+      fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+      expect(onUpdate).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/agentMode/backends/shared/ui/AgentBackendHeader.test.tsx
+++ b/src/agentMode/backends/shared/ui/AgentBackendHeader.test.tsx
@@ -8,10 +8,12 @@ describe("AgentBackendHeader", () => {
     it("https://github.com/Brevilabs/obsidian-copilot-private/issues/368 shows update, shared progress, and retry in the settings row", () => {
       const onUpdate = jest.fn();
       const view = render(<AgentBackendHeader {...meta.args} onUpdate={onUpdate} />);
-      fireEvent.click(screen.getByRole("button", { name: "Update" }));
+      fireEvent.click(screen.getByRole("button", { name: "Upgrade" }));
       expect(onUpdate).toHaveBeenCalledTimes(1);
       view.rerender(<AgentBackendHeader {...meta.args} {...Running.args} />);
-      expect(screen.getByRole("button", { name: "Updating…" }).hasAttribute("disabled")).toBe(true);
+      expect(screen.getByRole("button", { name: "Upgrading…" }).hasAttribute("disabled")).toBe(
+        true
+      );
       expect(screen.getByText("Downloading opencode.zip (42%)")).toBeTruthy();
       view.rerender(<AgentBackendHeader {...meta.args} {...Indeterminate.args} />);
       expect(screen.getByText("Downloading opencode.zip")).toBeTruthy();

--- a/src/agentMode/backends/shared/ui/AgentBackendHeader.tsx
+++ b/src/agentMode/backends/shared/ui/AgentBackendHeader.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import type {
+  BackendDescriptor,
+  InstallState,
+  ManagedInstallActionState,
+} from "@/agentMode/session/types";
+import { InstallBadge } from "@/agentMode/backends/shared/installStatus";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { TruncatedText } from "@/components/TruncatedText";
+
+export interface AgentBackendHeaderProps {
+  displayName: string;
+  Icon: BackendDescriptor["Icon"];
+  installState: InstallState;
+  managedInstall: ManagedInstallActionState;
+  canUpdate: boolean;
+  resolvedPath: string | null;
+  inlineInstall?: React.ReactNode;
+  onUpdate: () => void;
+  onConfigure: () => void;
+}
+
+export function AgentBackendHeader({
+  displayName,
+  Icon,
+  installState,
+  managedInstall,
+  canUpdate,
+  resolvedPath,
+  inlineInstall,
+  onUpdate,
+  onConfigure,
+}: AgentBackendHeaderProps) {
+  const updating = managedInstall.kind === "running";
+  const updateFailed = managedInstall.kind === "error";
+  return (
+    <div className="tw-flex tw-flex-col tw-gap-2 tw-py-4">
+      <div className="tw-flex tw-items-center tw-justify-between tw-gap-2">
+        <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-2">
+          <Icon className="tw-size-4 tw-shrink-0" />
+          <div className="tw-flex tw-min-w-0 tw-flex-col">
+            <div className="tw-flex tw-items-center tw-gap-2">
+              <span className="tw-text-base tw-font-semibold">{displayName}</span>
+              <InstallBadge state={installState} />
+              {inlineInstall && (
+                <Badge variant="accent" className="tw-font-normal">
+                  Recommended
+                </Badge>
+              )}
+            </div>
+            {resolvedPath && (
+              <TruncatedText className="tw-max-w-[90%] tw-font-mono tw-text-xs tw-text-muted">
+                {resolvedPath}
+              </TruncatedText>
+            )}
+            {inlineInstall && (
+              <span className="tw-text-xs tw-text-muted">Not installed — one download away.</span>
+            )}
+            {(installState.kind === "incompatible" || installState.kind === "error") && (
+              <span className="tw-text-xs tw-text-error">
+                {canUpdate && updating
+                  ? managedInstall.label
+                  : canUpdate && updateFailed
+                    ? managedInstall.message
+                    : installState.message}
+              </span>
+            )}
+          </div>
+        </div>
+        {inlineInstall ? (
+          inlineInstall
+        ) : canUpdate ? (
+          <Button className="tw-shrink-0" size="default" disabled={updating} onClick={onUpdate}>
+            {updating ? "Updating…" : updateFailed ? "Retry" : "Update"}
+          </Button>
+        ) : (
+          <Button
+            className="tw-shrink-0"
+            size="default"
+            variant={installState.kind === "ready" ? "secondary" : "default"}
+            onClick={onConfigure}
+          >
+            Configure
+          </Button>
+        )}
+      </div>
+      {inlineInstall && (
+        <div className="tw-text-xs tw-text-muted">
+          Works with Copilot Plus or your own API keys — add providers on the BYOK tab.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/agentMode/backends/shared/ui/AgentBackendHeader.tsx
+++ b/src/agentMode/backends/shared/ui/AgentBackendHeader.tsx
@@ -32,6 +32,8 @@ export function AgentBackendHeader({
   onUpdate,
   onConfigure,
 }: AgentBackendHeaderProps) {
+  // Shared progress prevents duplicate updates; shared errors keep Retry available across surfaces.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/368
   const updating = managedInstall.kind === "running";
   const updateFailed = managedInstall.kind === "error";
   return (

--- a/src/agentMode/backends/shared/ui/AgentBackendHeader.tsx
+++ b/src/agentMode/backends/shared/ui/AgentBackendHeader.tsx
@@ -74,7 +74,7 @@ export function AgentBackendHeader({
           inlineInstall
         ) : canUpdate ? (
           <Button className="tw-shrink-0" size="default" disabled={updating} onClick={onUpdate}>
-            {updating ? "Updating…" : updateFailed ? "Retry" : "Update"}
+            {updating ? "Upgrading…" : updateFailed ? "Retry" : "Upgrade"}
           </Button>
         ) : (
           <Button

--- a/src/agentMode/backends/shared/ui/ManagedBinaryConfigView.stories.tsx
+++ b/src/agentMode/backends/shared/ui/ManagedBinaryConfigView.stories.tsx
@@ -112,7 +112,7 @@ export const Incompatible: StoryObj<ManagedBinaryConfigViewProps> = {
       source: "managed",
       currentVersion: "1.0.0",
       minVersion: MANAGED.version,
-      message: "The installed agent is not supported. Update to the version tested with Copilot.",
+      message: "The installed agent is not supported. Upgrade to the version tested with Copilot.",
     },
   },
 };

--- a/src/agentMode/backends/shared/ui/ManagedBinaryConfigView.tsx
+++ b/src/agentMode/backends/shared/ui/ManagedBinaryConfigView.tsx
@@ -21,7 +21,7 @@ export type ManagedBinarySource = "managed" | "custom";
  */
 export type ManagedBinaryRunState =
   | { kind: "idle" }
-  | { kind: "running"; label: string; percent: number }
+  | { kind: "running"; label: string; percent?: number }
   | { kind: "error"; message: string };
 
 /** What the managed download would install here, plus any install in flight. */

--- a/src/agentMode/index.ts
+++ b/src/agentMode/index.ts
@@ -31,6 +31,7 @@ export { default as CopilotAgentView } from "./ui/CopilotAgentView";
 export {
   useActiveBackendDescriptor,
   useBackendInstallState,
+  useManagedInstallActionState,
   useSessionBackendDescriptor,
 } from "./ui/useBackendDescriptor";
 export { useAgentModelPicker } from "./ui/useAgentModelPicker";
@@ -38,7 +39,14 @@ export type { AgentModelPickerOverride } from "./ui/useAgentModelPicker";
 export { useAgentModePicker } from "./ui/useAgentModePicker";
 export type { AgentModePickerOverride } from "./ui/useAgentModePicker";
 export type { AgentSessionManager } from "./session/AgentSessionManager";
-export type { AgentBrand, BackendDescriptor, BackendId, InstallState } from "./session/types";
+export type {
+  AgentBrand,
+  BackendDescriptor,
+  BackendId,
+  InstallState,
+  ManagedInstallAction,
+  ManagedInstallActionState,
+} from "./session/types";
 export { partitionOpencodeOnlyWireIds } from "./backends/opencode/opencodeProbePartition";
 export {
   mapProviderToOpencodeId,
@@ -466,3 +474,5 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
   }
   return manager;
 }
+
+export { AgentBackendHeader } from "./backends/shared/ui/AgentBackendHeader";

--- a/src/agentMode/session/descriptor.ts
+++ b/src/agentMode/session/descriptor.ts
@@ -43,6 +43,18 @@ export type InstallState =
     }
   | { kind: "error"; message: string };
 
+export type ManagedInstallActionState =
+  | { kind: "idle" }
+  | { kind: "running"; label: string; percent?: number }
+  | { kind: "error"; message: string };
+
+/** Backend-owned install lifecycle shared by Agent Chat and Settings. */
+export interface ManagedInstallAction {
+  getState(plugin: CopilotPlugin): ManagedInstallActionState;
+  subscribe(plugin: CopilotPlugin, onChange: () => void): () => void;
+  run(plugin: CopilotPlugin): Promise<void>;
+}
+
 /** Sign-in state for backends that authenticate via a CLI / external account. */
 export interface BackendAuthStatus {
   signedIn: boolean;
@@ -237,14 +249,8 @@ export interface BackendDescriptor {
    */
   AbsentInstallActions?: React.ComponentType<{ plugin: CopilotPlugin }>;
 
-  /**
-   * Optional: upgrade the installed binary in place (managed reinstall, or the
-   * CLI's own `upgrade`). Resolves when done. Changing the persisted version
-   * restarts the backend via the `subscribeInstallState` subscription, so the
-   * next session boots on the new binary. Throws with a readable message on
-   * failure; callers surface progress/errors.
-   */
-  upgrade?(plugin: CopilotPlugin): Promise<void>;
+  /** User-triggered install/update lifecycle for Copilot-managed binaries. */
+  managedInstall?: ManagedInstallAction;
 
   /**
    * Optional: sign-in capability for backends gated on an external account

--- a/src/agentMode/session/types.ts
+++ b/src/agentMode/session/types.ts
@@ -15,6 +15,8 @@ export type {
   BackendDescriptor,
   BackendSignInHandlers,
   InstallState,
+  ManagedInstallAction,
+  ManagedInstallActionState,
   ModelSelectionSession,
 } from "./descriptor";
 export type { CurrentPlan, PlanDecisionAction, PlanProposalDecision } from "./plan";

--- a/src/agentMode/ui/AgentModeChat.test.tsx
+++ b/src/agentMode/ui/AgentModeChat.test.tsx
@@ -9,6 +9,7 @@ import React from "react";
 
 // Readiness of the backend the pane would run, swapped per test. Declared with
 // the `mock` prefix so Jest allows the mock factory below to close over it.
+let mockManagedInstall: object | undefined;
 let mockInstallState: InstallState = { kind: "ready", source: "custom" };
 
 // Stub the descriptor hooks so the effect's `preloadReady`/install gates are
@@ -17,7 +18,11 @@ let mockInstallState: InstallState = { kind: "ready", source: "custom" };
 // expected here.
 /* eslint-disable @eslint-react/hooks-extra/no-unnecessary-use-prefix */
 jest.mock("@/agentMode/ui/useBackendDescriptor", () => ({
-  useSessionBackendDescriptor: () => ({ id: "claude", openInstallUI: jest.fn() }),
+  useSessionBackendDescriptor: () => ({
+    id: "claude",
+    managedInstall: mockManagedInstall,
+    openInstallUI: jest.fn(),
+  }),
   useBackendInstallState: () => mockInstallState,
 }));
 /* eslint-enable @eslint-react/hooks-extra/no-unnecessary-use-prefix */
@@ -90,7 +95,24 @@ function renderFallback(installState: InstallState, lastError: string | null, st
 
 describe("AgentModeChat", () => {
   afterEach(() => {
+    mockManagedInstall = undefined;
     mockInstallState = { kind: "ready", source: "custom" };
+  });
+
+  it("https://github.com/Brevilabs/obsidian-copilot-private/issues/368 keeps a cold-start managed upgrade on the shared status card", () => {
+    mockManagedInstall = {};
+    renderFallback(
+      {
+        kind: "incompatible",
+        source: "managed",
+        currentVersion: "1",
+        minVersion: "2",
+        message: "Update required",
+      },
+      null
+    );
+    expect(screen.getByTestId("status-card")).toBeTruthy();
+    expect(screen.queryByTestId("select-panel")).toBeNull();
   });
 
   describe("auto-spawn guard (scope-aware)", () => {

--- a/src/agentMode/ui/AgentModeChat.tsx
+++ b/src/agentMode/ui/AgentModeChat.tsx
@@ -125,7 +125,9 @@ export const AgentModeChat: React.FC<Props> = ({
     !manager.getIsStarting() &&
     manager.getLastError() === null &&
     (installState.kind === "absent" ||
-      installState.kind === "incompatible" ||
+      // Cold-start upgrades need the same progress and Retry card as active sessions.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/368
+      (installState.kind === "incompatible" && !descriptor.managedInstall) ||
       installState.kind === "error");
 
   if (isColdStart) {

--- a/src/agentMode/ui/AgentModeStatus.test.tsx
+++ b/src/agentMode/ui/AgentModeStatus.test.tsx
@@ -13,12 +13,15 @@ let installState: ReturnType<BackendDescriptor["getInstallState"]> = {
   source: "custom",
 };
 let authState: BackendAuthUiState;
+let managedInstallState: ReturnType<NonNullable<BackendDescriptor["managedInstall"]>["getState"]>;
 
 jest.mock("@/agentMode/ui/useBackendDescriptor", () => ({
   // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks real hook exports
   useSessionBackendDescriptor: () => descriptor,
   // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks real hook exports
   useBackendInstallState: () => installState,
+  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks real hook exports
+  useManagedInstallActionState: () => managedInstallState,
 }));
 
 jest.mock("@/agentMode/session/useBackendAuthState", () => ({
@@ -46,6 +49,7 @@ describe("AgentModeStatus", () => {
         url: null,
         signIn: jest.fn(),
       };
+      managedInstallState = { kind: "idle" };
       jest.clearAllMocks();
     });
 
@@ -123,17 +127,33 @@ describe("AgentModeStatus", () => {
         minVersion: "2.1.206",
         message: "Claude must be upgraded.",
       };
-      const upgrade = jest.fn(() => new Promise<void>(() => undefined));
-      descriptor = { ...descriptor, upgrade };
+      const run = jest.fn(() => new Promise<void>(() => undefined));
+      descriptor = {
+        ...descriptor,
+        managedInstall: {
+          getState: jest.fn(() => managedInstallState),
+          subscribe: jest.fn(() => () => {}),
+          run,
+        },
+      };
       const plugin = { app: {} } as unknown as CopilotPlugin;
 
-      render(<AgentModeStatus plugin={plugin} onInstallClick={jest.fn()} />);
+      const { rerender } = render(<AgentModeStatus plugin={plugin} onInstallClick={jest.fn()} />);
 
-      fireEvent.click(screen.getByRole("button", { name: "Upgrade" }));
-      expect(upgrade).toHaveBeenCalledWith(plugin);
+      fireEvent.click(screen.getByRole("button", { name: "Update" }));
+      expect(run).toHaveBeenCalledWith(plugin);
+      managedInstallState = { kind: "running", label: "Downloading… 50%" };
+      rerender(<AgentModeStatus plugin={plugin} onInstallClick={jest.fn()} />);
       expect(screen.getByRole("button", { name: "Upgrading…" }).hasAttribute("disabled")).toBe(
         true
       );
+      expect(screen.getByText("Downloading… 50%")).toBeTruthy();
+
+      managedInstallState = { kind: "error", message: "npm unavailable" };
+      rerender(<AgentModeStatus plugin={plugin} onInstallClick={jest.fn()} />);
+      expect(screen.getByText("npm unavailable")).toBeTruthy();
+      fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+      expect(run).toHaveBeenCalledTimes(2);
     });
 
     it("preserves the sign-in action and linked browser fallback", () => {

--- a/src/agentMode/ui/AgentModeStatus.test.tsx
+++ b/src/agentMode/ui/AgentModeStatus.test.tsx
@@ -140,7 +140,7 @@ describe("AgentModeStatus", () => {
 
       const { rerender } = render(<AgentModeStatus plugin={plugin} onInstallClick={jest.fn()} />);
 
-      fireEvent.click(screen.getByRole("button", { name: "Update" }));
+      fireEvent.click(screen.getByRole("button", { name: "Upgrade" }));
       expect(run).toHaveBeenCalledWith(plugin);
       managedInstallState = { kind: "running", label: "Downloading… 50%" };
       rerender(<AgentModeStatus plugin={plugin} onInstallClick={jest.fn()} />);

--- a/src/agentMode/ui/AgentModeStatus.tsx
+++ b/src/agentMode/ui/AgentModeStatus.tsx
@@ -2,6 +2,7 @@ import { AgentStatusCard } from "@/agentMode/ui/AgentStatusCard";
 import { useBackendAuthState } from "@/agentMode/session/useBackendAuthState";
 import {
   useBackendInstallState,
+  useManagedInstallActionState,
   useSessionBackendDescriptor,
 } from "@/agentMode/ui/useBackendDescriptor";
 import { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
@@ -28,8 +29,8 @@ interface Props {
 export const AgentModeStatus: React.FC<Props> = ({ manager, plugin, onInstallClick }) => {
   const descriptor = useSessionBackendDescriptor(manager);
   const installState = useBackendInstallState(descriptor, plugin);
+  const managedInstall = useManagedInstallActionState(descriptor, plugin);
   const auth = useBackendAuthState(descriptor);
-  const [upgrading, setUpgrading] = React.useState(false);
 
   // Re-render on manager notify so `lastError` flips are picked up.
   const [, setTick] = React.useState(0);
@@ -39,18 +40,17 @@ export const AgentModeStatus: React.FC<Props> = ({ manager, plugin, onInstallCli
   }, [manager]);
 
   const handleUpgrade = React.useCallback(() => {
-    if (!descriptor.upgrade || upgrading) return;
-    setUpgrading(true);
+    const action = descriptor.managedInstall;
+    if (!action || managedInstall.kind === "running") return;
     new Notice(`Upgrading ${descriptor.displayName}…`);
-    descriptor
-      .upgrade(plugin)
+    action
+      .run(plugin)
       .then(() => new Notice(`${descriptor.displayName} upgraded.`))
       .catch((e) => {
         logError("[AgentMode] upgrade failed", e);
         new Notice(`Failed to upgrade ${descriptor.displayName}. See console for details.`);
-      })
-      .finally(() => setUpgrading(false));
-  }, [descriptor, plugin, upgrading]);
+      });
+  }, [descriptor, plugin, managedInstall.kind]);
 
   if (installState.kind === "absent") {
     return (
@@ -66,16 +66,22 @@ export const AgentModeStatus: React.FC<Props> = ({ manager, plugin, onInstallCli
   }
 
   if (installState.kind === "incompatible") {
-    const canUpgrade = descriptor.upgrade !== undefined;
+    const canUpgrade = descriptor.managedInstall !== undefined;
+    const upgrading = managedInstall.kind === "running";
+    const failed = managedInstall.kind === "error";
     return (
       <AgentStatusCard
-        tone="warning"
-        message={installState.message}
+        tone={failed ? "error" : "warning"}
+        message={
+          upgrading ? managedInstall.label : failed ? managedInstall.message : installState.message
+        }
         action={{
           label: canUpgrade
             ? upgrading
               ? "Upgrading…"
-              : "Upgrade"
+              : failed
+                ? "Retry"
+                : "Update"
             : `Configure ${descriptor.displayName}`,
           disabled: canUpgrade && upgrading,
           onClick: canUpgrade ? handleUpgrade : () => descriptor.openInstallUI(plugin),

--- a/src/agentMode/ui/AgentModeStatus.tsx
+++ b/src/agentMode/ui/AgentModeStatus.tsx
@@ -67,6 +67,8 @@ export const AgentModeStatus: React.FC<Props> = ({ manager, plugin, onInstallCli
 
   if (installState.kind === "incompatible") {
     const canUpgrade = descriptor.managedInstall !== undefined;
+    // Shared progress prevents duplicate updates; shared errors keep Retry available across surfaces.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/368
     const upgrading = managedInstall.kind === "running";
     const failed = managedInstall.kind === "error";
     return (

--- a/src/agentMode/ui/AgentModeStatus.tsx
+++ b/src/agentMode/ui/AgentModeStatus.tsx
@@ -83,7 +83,7 @@ export const AgentModeStatus: React.FC<Props> = ({ manager, plugin, onInstallCli
               ? "Upgrading…"
               : failed
                 ? "Retry"
-                : "Update"
+                : "Upgrade"
             : `Configure ${descriptor.displayName}`,
           disabled: canUpgrade && upgrading,
           onClick: canUpgrade ? handleUpgrade : () => descriptor.openInstallUI(plugin),

--- a/src/agentMode/ui/AgentStatusCard.stories.tsx
+++ b/src/agentMode/ui/AgentStatusCard.stories.tsx
@@ -48,15 +48,27 @@ export const LongErrorRetry: StoryObj<AgentStatusCardProps> = {
   },
 };
 
-export const BusyUpgrade: StoryObj<AgentStatusCardProps> = {
+export const ManagedUpdateRequired: StoryObj<AgentStatusCardProps> = {
   args: {
     tone: "warning",
-    message: "Very Long Local Agent Backend Name must be upgraded before Agent Mode can start.",
-    action: {
-      label: "Upgrading…",
-      onClick: () => undefined,
-      disabled: true,
-    },
+    message: "opencode v1.15.0 is not supported. Copilot requires opencode v1.16.0 or newer.",
+    action: { label: "Update", onClick: () => undefined },
+  },
+};
+
+export const ManagedUpdateRunning: StoryObj<AgentStatusCardProps> = {
+  args: {
+    tone: "warning",
+    message: "Downloading opencode-darwin-arm64.zip 42%",
+    action: { label: "Upgrading…", onClick: () => undefined, disabled: true },
+  },
+};
+
+export const ManagedUpdateFailed: StoryObj<AgentStatusCardProps> = {
+  args: {
+    tone: "error",
+    message: "GitHub API rate-limited. Retry after the limit resets.",
+    action: { label: "Retry", onClick: () => undefined },
   },
 };
 

--- a/src/agentMode/ui/AgentStatusCard.stories.tsx
+++ b/src/agentMode/ui/AgentStatusCard.stories.tsx
@@ -48,15 +48,15 @@ export const LongErrorRetry: StoryObj<AgentStatusCardProps> = {
   },
 };
 
-export const ManagedUpdateRequired: StoryObj<AgentStatusCardProps> = {
+export const ManagedUpgradeRequired: StoryObj<AgentStatusCardProps> = {
   args: {
     tone: "warning",
     message: "opencode v1.15.0 is not supported. Copilot requires opencode v1.16.0 or newer.",
-    action: { label: "Update", onClick: () => undefined },
+    action: { label: "Upgrade", onClick: () => undefined },
   },
 };
 
-export const ManagedUpdateRunning: StoryObj<AgentStatusCardProps> = {
+export const ManagedUpgradeRunning: StoryObj<AgentStatusCardProps> = {
   args: {
     tone: "warning",
     message: "Downloading opencode-darwin-arm64.zip 42%",
@@ -64,7 +64,7 @@ export const ManagedUpdateRunning: StoryObj<AgentStatusCardProps> = {
   },
 };
 
-export const ManagedUpdateFailed: StoryObj<AgentStatusCardProps> = {
+export const ManagedUpgradeFailed: StoryObj<AgentStatusCardProps> = {
   args: {
     tone: "error",
     message: "GitHub API rate-limited. Retry after the limit resets.",

--- a/src/agentMode/ui/useBackendDescriptor.test.tsx
+++ b/src/agentMode/ui/useBackendDescriptor.test.tsx
@@ -2,12 +2,17 @@ import { act, renderHook } from "@testing-library/react";
 import { backendRegistry, getActiveBackendDescriptor } from "@/agentMode/backends/registry";
 import type { BackendId } from "@/agentMode/session/types";
 import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
-import type { BackendDescriptor, InstallState } from "@/agentMode/session/types";
+import type {
+  BackendDescriptor,
+  InstallState,
+  ManagedInstallActionState,
+} from "@/agentMode/session/types";
 import type CopilotPlugin from "@/main";
 import type { CopilotSettings } from "@/settings/model";
 import {
   useBackendInstallState,
   useBackendInstallStates,
+  useManagedInstallActionState,
   useSessionBackendDescriptor,
 } from "./useBackendDescriptor";
 
@@ -76,6 +81,30 @@ function makeInstallDescriptor(initial: InstallState, id: BackendId = "claude") 
   return {
     backend,
     emit: (next: InstallState) => {
+      state = next;
+      for (const listener of listeners) listener();
+    },
+    unsubscribed: () => listeners.size === 0,
+  };
+}
+
+function makeManagedInstallDescriptor() {
+  let state: ManagedInstallActionState = { kind: "idle" };
+  const listeners = new Set<() => void>();
+  const backend = {
+    id: "opencode",
+    managedInstall: {
+      getState: () => ({ ...state }),
+      subscribe: (_plugin: CopilotPlugin, listener: () => void) => {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+      run: jest.fn(),
+    },
+  } as unknown as BackendDescriptor;
+  return {
+    backend,
+    emit: (next: ManagedInstallActionState) => {
       state = next;
       for (const listener of listeners) listener();
     },
@@ -172,6 +201,34 @@ describe("useBackendDescriptor", () => {
 
       unmount();
 
+      expect(fake.unsubscribed()).toBe(true);
+    });
+  });
+
+  describe("useManagedInstallActionState()", () => {
+    it("returns one stable idle state when the backend has no managed action", () => {
+      const plugin = {} as CopilotPlugin;
+      const backend = descriptor("claude");
+      const { result, rerender } = renderHook(() => useManagedInstallActionState(backend, plugin));
+      const first = result.current;
+
+      rerender();
+
+      expect(result.current).toBe(first);
+      expect(result.current).toEqual({ kind: "idle" });
+    });
+
+    it("tracks the shared action progress and unsubscribes on unmount", () => {
+      const fake = makeManagedInstallDescriptor();
+      const plugin = {} as CopilotPlugin;
+      const { result, unmount } = renderHook(() =>
+        useManagedInstallActionState(fake.backend, plugin)
+      );
+
+      act(() => fake.emit({ kind: "running", label: "Downloading… 42%" }));
+      expect(result.current).toEqual({ kind: "running", label: "Downloading… 42%" });
+
+      unmount();
       expect(fake.unsubscribed()).toBe(true);
     });
   });

--- a/src/agentMode/ui/useBackendDescriptor.ts
+++ b/src/agentMode/ui/useBackendDescriptor.ts
@@ -4,12 +4,20 @@ import {
   listBackendDescriptors,
 } from "@/agentMode/backends/registry";
 import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
-import type { BackendDescriptor, BackendId, InstallState } from "@/agentMode/session/types";
+import type {
+  BackendDescriptor,
+  BackendId,
+  InstallState,
+  ManagedInstallActionState,
+} from "@/agentMode/session/types";
 import { useSettingsValue } from "@/settings/model";
 import React from "react";
 import type CopilotPlugin from "@/main";
 
 const EMPTY_BACKEND_INSTALL_STATES = Object.freeze({}) as Record<BackendId, InstallState>;
+const IDLE_MANAGED_INSTALL_ACTION_STATE = Object.freeze({
+  kind: "idle" as const,
+}) satisfies ManagedInstallActionState;
 
 function installStateSignature(state: InstallState): string {
   switch (state.kind) {
@@ -26,6 +34,17 @@ function installStateSignature(state: InstallState): string {
         state.minVersion,
         state.message,
       ]);
+    case "error":
+      return JSON.stringify([state.kind, state.message]);
+  }
+}
+
+function managedInstallActionStateSignature(state: ManagedInstallActionState): string {
+  switch (state.kind) {
+    case "idle":
+      return "idle";
+    case "running":
+      return JSON.stringify([state.kind, state.label, state.percent]);
     case "error":
       return JSON.stringify([state.kind, state.message]);
   }
@@ -91,6 +110,30 @@ export function useBackendInstallState(
     void signature;
     return descriptor.getInstallState(settings);
   }, [descriptor, settings, signature]);
+}
+
+/** Observe the descriptor's shared managed-install operation, or a stable idle state. */
+export function useManagedInstallActionState(
+  descriptor: BackendDescriptor,
+  plugin: CopilotPlugin
+): ManagedInstallActionState {
+  const action = descriptor.managedInstall;
+  const subscribe = React.useCallback(
+    (listener: () => void) => action?.subscribe(plugin, listener) ?? (() => {}),
+    [action, plugin]
+  );
+  const getSnapshot = React.useCallback(
+    () =>
+      managedInstallActionStateSignature(
+        action?.getState(plugin) ?? IDLE_MANAGED_INSTALL_ACTION_STATE
+      ),
+    [action, plugin]
+  );
+  const signature = React.useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  return React.useMemo(() => {
+    void signature;
+    return action?.getState(plugin) ?? IDLE_MANAGED_INSTALL_ACTION_STATE;
+  }, [action, plugin, signature]);
 }
 
 /**

--- a/src/settings/v2/components/AgentSettings.test.tsx
+++ b/src/settings/v2/components/AgentSettings.test.tsx
@@ -69,6 +69,8 @@ const installStates: Record<string, { kind: string; [key: string]: unknown }> = 
   claude: { kind: "ready", source: "custom" },
   codex: { kind: "ready", source: "custom" },
 };
+const managedInstallStates: Record<string, { kind: string; [key: string]: unknown }> = {};
+const runManagedInstall = jest.fn().mockResolvedValue(undefined);
 
 /** Binary path each backend reports as resolved; absent means "not installed". */
 let resolvedPaths: Record<string, string | null> = {};
@@ -99,6 +101,15 @@ function makeDescriptor(id: string, displayName: string, selfHostable = false) {
     // Only a backend the plugin can install itself ships inline actions; the
     // panel's absent-state branch keys off that.
     ...(id === "opencode" ? { AbsentInstallActions: OpencodeAbsentInstallActions } : {}),
+    ...(id === "codex"
+      ? {
+          managedInstall: {
+            getState: () => managedInstallStates.codex ?? { kind: "idle" },
+            subscribe: () => () => {},
+            run: runManagedInstall,
+          },
+        }
+      : {}),
   };
 }
 
@@ -112,6 +123,9 @@ const mockGetCachedModelCatalog = jest.fn();
 const mockPreloadModels = jest.fn();
 
 jest.mock("@/agentMode", () => ({
+  AgentBackendHeader: jest.requireActual<
+    typeof import("@/agentMode/backends/shared/ui/AgentBackendHeader")
+  >("@/agentMode/backends/shared/ui/AgentBackendHeader").AgentBackendHeader,
   backendDisplayOrder: () => DESCRIPTORS,
   backendNeedsSelfHostWarning: (
     descriptor: { selfHostable?: boolean },
@@ -129,6 +143,9 @@ jest.mock("@/agentMode", () => ({
     const read = () => descriptor.getInstallState();
     return React.useSyncExternalStore(subscribe, read, read);
   },
+  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook export
+  useManagedInstallActionState: (descriptor: { id: string }) =>
+    managedInstallStates[descriptor.id] ?? { kind: "idle" },
   AgentDefaultModelSetting: ({ descriptor }: { descriptor: { id: string } }) => (
     <div data-testid={`default-model-${descriptor.id}`}>default model</div>
   ),
@@ -173,6 +190,8 @@ describe("AgentSettings", () => {
     installStates.opencode = { kind: "ready", source: "managed" };
     installStates.claude = { kind: "ready", source: "custom" };
     installStates.codex = { kind: "ready", source: "custom" };
+    delete managedInstallStates.codex;
+    runManagedInstall.mockReset().mockResolvedValue(undefined);
     mockGetCachedModelCatalog.mockReset().mockReturnValue({ availableModels: [] });
     mockPreloadModels.mockReset().mockResolvedValue(undefined);
     resolvedPaths = {};
@@ -350,5 +369,30 @@ describe("AgentSettings", () => {
     expect(screen.getByText(MANAGED_BINARY_PATH)).not.toBeNull();
     expect(screen.getByRole("button", { name: "Configure" })).not.toBeNull();
     expect(screen.queryByRole("button", { name: "Download opencode" })).toBeNull();
+  });
+
+  it("https://github.com/Brevilabs/obsidian-copilot-private/issues/368 shares managed update progress and Retry in settings", () => {
+    installStates.codex = {
+      kind: "incompatible",
+      source: "managed",
+      currentVersion: "1.9.0",
+      minVersion: "1.10.0",
+      message: "Codex adapter 1.9.0 does not match this Copilot release (1.10.0).",
+    };
+    const view = render(<AgentSettings />);
+    fireEvent.click(screen.getByRole("tab", { name: "Codex" }));
+    fireEvent.click(screen.getByRole("button", { name: "Update" }));
+    expect(runManagedInstall).toHaveBeenCalledTimes(1);
+
+    managedInstallStates.codex = { kind: "running", label: "Installing… 30%" };
+    view.rerender(<AgentSettings />);
+    expect(screen.getByText("Installing… 30%")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Updating…" }).hasAttribute("disabled")).toBe(true);
+
+    managedInstallStates.codex = { kind: "error", message: "npm unavailable" };
+    view.rerender(<AgentSettings />);
+    expect(screen.getByText("npm unavailable")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(runManagedInstall).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/settings/v2/components/AgentSettings.test.tsx
+++ b/src/settings/v2/components/AgentSettings.test.tsx
@@ -381,13 +381,13 @@ describe("AgentSettings", () => {
     };
     const view = render(<AgentSettings />);
     fireEvent.click(screen.getByRole("tab", { name: "Codex" }));
-    fireEvent.click(screen.getByRole("button", { name: "Update" }));
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade" }));
     expect(runManagedInstall).toHaveBeenCalledTimes(1);
 
     managedInstallStates.codex = { kind: "running", label: "Installing… 30%" };
     view.rerender(<AgentSettings />);
     expect(screen.getByText("Installing… 30%")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Updating…" }).hasAttribute("disabled")).toBe(true);
+    expect(screen.getByRole("button", { name: "Upgrading…" }).hasAttribute("disabled")).toBe(true);
 
     managedInstallStates.codex = { kind: "error", message: "npm unavailable" };
     view.rerender(<AgentSettings />);

--- a/src/settings/v2/components/AgentSettings.tsx
+++ b/src/settings/v2/components/AgentSettings.tsx
@@ -1,13 +1,12 @@
 import {
+  AgentBackendHeader,
   AgentDefaultModelSetting,
   backendDisplayOrder,
   backendNeedsSelfHostWarning,
-  InstallBadge,
   useBackendInstallState,
+  useManagedInstallActionState,
   type BackendDescriptor,
 } from "@/agentMode";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import { SettingItem } from "@/components/ui/setting-item";
 import { playNotificationSound } from "@/utils/notificationSound";
 import {
@@ -16,7 +15,6 @@ import {
 } from "@/utils/notificationSoundCatalog";
 import { SettingSection } from "@/components/ui/setting-section";
 import { TabContent, TabItem, type TabItem as TabItemType } from "@/components/ui/setting-tabs";
-import { TruncatedText } from "@/components/TruncatedText";
 import { usePlugin } from "@/contexts/PluginContext";
 import { useChatBackendModelOptions } from "@/hooks/useChatBackendModelOptions";
 import { logError } from "@/logger";
@@ -229,7 +227,17 @@ const BackendPanel: React.FC<{
   const manager = plugin.agentSessionManager;
 
   const installState = useBackendInstallState(descriptor, plugin);
+  const managedInstall = useManagedInstallActionState(descriptor, plugin);
   const resolvedPath = descriptor.getResolvedBinaryPath?.(settings) ?? null;
+  const canUpdate = installState.kind === "incompatible" && descriptor.managedInstall !== undefined;
+  const updating = managedInstall.kind === "running";
+
+  const runManagedInstall = React.useCallback(() => {
+    if (!descriptor.managedInstall || updating) return;
+    descriptor.managedInstall
+      .run(plugin)
+      .catch((error) => logError(`[AgentMode] ${descriptor.id} update failed`, error));
+  }, [descriptor, plugin, updating]);
 
   // Probe when ready but uncached — the load-time preload may have skipped this
   // backend (binary installed after plugin start).
@@ -242,7 +250,6 @@ const BackendPanel: React.FC<{
       .catch((e) => logError(`[AgentMode] preload ${descriptor.id} failed`, e));
   }, [manager, descriptor.id, installState.kind]);
 
-  const Icon = descriptor.Icon;
   const showCloudWarning = backendNeedsSelfHostWarning(descriptor, settings);
   // Only a backend the plugin can install itself offers inline actions, and
   // that is also the only kind whose models run on the user's own keys — so the
@@ -270,54 +277,17 @@ const BackendPanel: React.FC<{
           come from `SettingItem` / `EnvOverridesSetting` already do. The cloud
           warning stays outside: it qualifies the whole backend, not one row. */}
       <SettingSection>
-        <div className="tw-flex tw-flex-col tw-gap-2 tw-py-4">
-          <div className="tw-flex tw-items-center tw-justify-between tw-gap-2">
-            <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-2">
-              <Icon className="tw-size-4 tw-shrink-0" />
-              <div className="tw-flex tw-min-w-0 tw-flex-col">
-                <div className="tw-flex tw-items-center tw-gap-2">
-                  <span className="tw-text-base tw-font-semibold">{descriptor.displayName}</span>
-                  <InstallBadge state={installState} />
-                  {InlineInstall && (
-                    <Badge variant="accent" className="tw-font-normal">
-                      Recommended
-                    </Badge>
-                  )}
-                </div>
-                {resolvedPath && (
-                  <TruncatedText className="tw-max-w-[90%] tw-font-mono tw-text-xs tw-text-muted">
-                    {formatBinaryPathForDisplay(resolvedPath)}
-                  </TruncatedText>
-                )}
-                {InlineInstall && (
-                  <span className="tw-text-xs tw-text-muted">
-                    Not installed — one download away.
-                  </span>
-                )}
-                {(installState.kind === "incompatible" || installState.kind === "error") && (
-                  <span className="tw-text-xs tw-text-error">{installState.message}</span>
-                )}
-              </div>
-            </div>
-            {InlineInstall ? (
-              <InlineInstall plugin={plugin} />
-            ) : (
-              <Button
-                className="tw-shrink-0"
-                size="default"
-                variant={installState.kind === "ready" ? "secondary" : "default"}
-                onClick={() => descriptor.openInstallUI(plugin)}
-              >
-                Configure
-              </Button>
-            )}
-          </div>
-          {InlineInstall && (
-            <div className="tw-text-xs tw-text-muted">
-              Works with Copilot Plus or your own API keys — add providers on the BYOK tab.
-            </div>
-          )}
-        </div>
+        <AgentBackendHeader
+          displayName={descriptor.displayName}
+          Icon={descriptor.Icon}
+          installState={installState}
+          managedInstall={managedInstall}
+          canUpdate={canUpdate}
+          resolvedPath={resolvedPath ? formatBinaryPathForDisplay(resolvedPath) : null}
+          inlineInstall={InlineInstall ? <InlineInstall plugin={plugin} /> : undefined}
+          onUpdate={runManagedInstall}
+          onConfigure={() => descriptor.openInstallUI(plugin)}
+        />
 
         {installState.kind === "ready" && manager && (
           <AgentDefaultModelSetting descriptor={descriptor} manager={manager} />


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#368

## Why

An outdated OpenCode has an “Upgrade” action in Agent Chat, while Settings offers only “Configure.” Agent Chat tracks its own busy state, so it cannot show an update started elsewhere or retain that operation's retry state.

## What

Agent Chat and Settings now observe and invoke the same managed update operation. An update started in either surface appears in both; failure exposes the shared error and Retry, and success clears both alerts.

## Non goal

Does not add Codex package installation, change OpenCode's update policy, introduce a separate banner or progress store, replace authentication, or add polling, analytics, or a cross-process lock.

## Screenshot

The component gallery supplies the running state without replacing the configured managed adapter. The table records the exact before/after behavior of the surface fixtures:

![Shared managed-update progress with disabled Upgrading action](https://github.com/user-attachments/assets/61bbf616-5644-4726-b44e-432daf3d85b6)

| State | Before | After |
| --- | --- | --- |
| Update required | Chat: “Upgrade”; Settings: “Configure” | Both: “Update” |
| Update running | Chat knows only its own click; Settings still says “Configure” | Shared progress text; disabled “Upgrading…” in Chat and “Updating…” in Settings |
| Update failed | Notice; no shared retry state | Both show the same error and “Retry” |
| Update succeeded | Each surface follows its existing install-state subscription | Both clear the update alert |

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Descriptor-hook, AgentModeStatus, and AgentSettings tests cover shared progress, failure, Retry, and absent actions. |
| A defect would fail CI or be obvious on first use | ✅ | Surface tests assert the visible state and that actions reach the shared operation. |
| A revert fully restores prior state, including persisted data | ✅ | This wiring adds no settings migration or downloaded-file format. |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Existing authentication and executable validation remain unchanged. |
| No public API, plugin API, message, or on-disk contract changes | ❌ | The backend descriptor replaces its upgrade callback with an observable managed-install action; consumers must migrate together. |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Agent Chat and Settings now subscribe to one asynchronous operation instead of keeping local busy state. |
| No hot-path behavior lacks deterministic coverage | ✅ | Subscription tests cover stable idle state, progress changes, and cleanup; surface tests cover recovery actions. |
| No new dependency | ✅ | No dependency is added. |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Remaining manual checks concern update status in Agent Chat and Settings. |

Review: Inspect the managed-install contract in `src/agentMode/session/descriptor.ts`, `useManagedInstallActionState()` in `src/agentMode/ui/useBackendDescriptor.ts`, OpenCode's `managedInstall` descriptor in `src/agentMode/backends/opencode/descriptor.ts`, `AgentModeStatus` in `src/agentMode/ui/AgentModeStatus.tsx`, and `BackendPanel` in `src/settings/v2/components/AgentSettings.tsx` line by line. Run Verification 1–3.

## Verification

1. Run the descriptor-hook, AgentModeStatus, and AgentSettings tests. For the supplied incompatible fixture, confirm Update invokes the same action and running/failure states replace the copy in the table above.
2. In a disposable vault with an outdated managed OpenCode, start Update from Settings and inspect Agent Chat. Both must show the operation; a second click must not start another install.
3. Repeat with a forced download failure, then restore connectivity and Retry from the other surface. Confirm the same error remains visible until Retry, and both alerts disappear after success. A backend without a managed action must retain Configure.
