### PR TITLE
[Agent Mode] - Step 7: Manage Codex installation and binary selection

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -43,6 +43,8 @@ Claude models and billing come from your Claude Code account. Models added under
 
 ### Codex
 
+A Copilot-managed Codex installation uses a native bundle containing the adapter and Codex runtime. It does not need Node.js or npm. Copilot checks the bundle version to offer updates. A failed download or verification keeps the previous installation selected.
+
 Managed Codex downloads are pinned to `codex-acp` **1.10.0** in this Copilot release. Copilot uses the system `tar -xf` command to unpack the runtime on all supported desktop platforms:
 
 | Platform | Download format | Extraction                                                         |
@@ -52,6 +54,8 @@ Managed Codex downloads are pinned to `codex-acp` **1.10.0** in this Copilot rel
 | Windows  | `.zip`          | Built-in `tar.exe`, which uses bsdtar and supports ZIP extraction. |
 
 The archive format and extraction command are separate: bsdtar can unpack ZIP files, while GNU tar does not support ZIP. See [bsdtar's supported formats](https://github.com/libarchive/libarchive/blob/master/tar/bsdtar.1) and [Windows tar documentation](https://learn.microsoft.com/en-us/windows/tar/). Windows includes `tar.exe` starting with Windows 10 version 1803. If installation reports that `tar` is missing, install it and retry; on macOS or Windows, use bsdtar so ZIP extraction works.
+
+You can also keep your own adapter installation. Copilot does not update or remove these custom installations.
 
 For an existing or manually installed `@agentclientprotocol/codex-acp` adapter, **0.0.45 is the minimum supported version**, not the managed download version. Both numbers refer to the ACP adapter version; the bundled Codex CLI has its own version. The manual setup steps are:
 

--- a/src/agentMode/backends/codex/CodexBinaryManager.test.ts
+++ b/src/agentMode/backends/codex/CodexBinaryManager.test.ts
@@ -1,0 +1,269 @@
+import { installCodexArchive, CODEX_BUNDLE_VERSION } from "./codexArchive";
+jest.mock("./codexArchive", () => ({
+  installCodexArchive: jest.fn(),
+  CODEX_BUNDLE_VERSION: "1.10.0-r1",
+}));
+import { getSettings, setSettings } from "@/settings/model";
+import { requireNodeModule } from "@/utils/desktopRuntime";
+import { detectBinary } from "@/utils/detectBinary";
+import type * as childProcess from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { CodexBinaryManager } from "./CodexBinaryManager";
+import { CODEX_ACP_PINNED_VERSION } from "./cliSetup";
+
+jest.mock("@/utils/detectBinary", () => ({
+  ...jest.requireActual("@/utils/detectBinary"),
+  detectBinary: jest.fn(),
+}));
+jest.mock("@/logger", () => ({ logInfo: jest.fn(), logWarn: jest.fn(), logError: jest.fn() }));
+jest.mock("@/utils/desktopRuntime", () => {
+  const actual = jest.requireActual<object>("@/utils/desktopRuntime");
+  const child = { execFile: jest.fn() };
+  const mockedOs = { ...jest.requireActual<object>("node:os"), homedir: jest.fn() };
+  return {
+    ...actual,
+    requireNodeModule: (id: string) => {
+      if (id === "child_process") return child;
+      if (id === "os") return mockedOs;
+      return jest.requireActual(`node:${id}`);
+    },
+  };
+});
+
+const mockedDetectBinary = jest.mocked(detectBinary);
+const mockedHomedir = jest.mocked(requireNodeModule<typeof import("node:os")>("os").homedir);
+const mockedExecFile = jest.mocked(
+  requireNodeModule<typeof import("node:child_process")>("child_process").execFile
+);
+const originalPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { configurable: true, value: platform });
+}
+
+function writeAdapter(prefix: string, version = CODEX_ACP_PINNED_VERSION): string {
+  const root = path.join(prefix, "node_modules", "@agentclientprotocol", "codex-acp");
+  const entry = path.join(root, "dist", "index.js");
+  fs.mkdirSync(path.dirname(entry), { recursive: true });
+  fs.writeFileSync(entry, "#!/usr/bin/env node\n");
+  fs.chmodSync(entry, 0o755);
+  fs.writeFileSync(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      name: "@agentclientprotocol/codex-acp",
+      version,
+      bin: { "codex-acp": "dist/index.js" },
+    })
+  );
+  return entry;
+}
+
+describe("CodexBinaryManager", () => {
+  describe("CodexBinaryManager", () => {
+    let tempDir: string;
+    let originalAgentMode: ReturnType<typeof getSettings>["agentMode"];
+
+    beforeEach(() => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-managed-test-"));
+      mockedHomedir.mockReturnValue(tempDir);
+      mockedExecFile.mockReset().mockImplementation((_command, _args, _options, callback) => {
+        (callback as (error: Error | null, stdout: string, stderr: string) => void)(
+          null,
+          `${CODEX_ACP_PINNED_VERSION} Codex CLI`,
+          ""
+        );
+        return {} as childProcess.ChildProcess;
+      });
+      jest
+        .mocked(installCodexArchive)
+        .mockReset()
+        .mockImplementation(async (stage) => {
+          fs.writeFileSync(path.join(stage, "codex-acp"), "native");
+          fs.writeFileSync(
+            path.join(stage, "provenance.json"),
+            JSON.stringify({
+              acpVersion: CODEX_ACP_PINNED_VERSION,
+              packagingRevision: 1,
+              target: `darwin-${process.arch}`,
+            })
+          );
+        });
+      mockedDetectBinary.mockReset().mockResolvedValue("/usr/bin/npm");
+      originalAgentMode = getSettings().agentMode;
+      setPlatform("darwin");
+    });
+
+    afterEach(() => {
+      setSettings({ agentMode: originalAgentMode });
+      setPlatform(originalPlatform);
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    describe("install()", () => {
+      it("https://github.com/Brevilabs/obsidian-copilot-private/issues/379 selects the verified native bundle without invoking npm", async () => {
+        const manager = new CodexBinaryManager();
+        const listener = jest.fn();
+        const unsubscribe = manager.subscribeRuntimeState(listener);
+        await manager.install();
+        expect(getSettings().agentMode.backends?.codex).toMatchObject({
+          binarySource: "managed",
+          binaryVersion: CODEX_BUNDLE_VERSION,
+          binaryPath: path.join(manager.getDataDir(), CODEX_BUNDLE_VERSION, "codex-acp"),
+        });
+        expect(mockedDetectBinary).not.toHaveBeenCalled();
+        expect(listener).toHaveBeenCalled();
+        expect(manager.getActionState()).toEqual({ kind: "idle" });
+        unsubscribe();
+      });
+      it("https://github.com/Brevilabs/obsidian-copilot-private/issues/379 rejects a wrong adapter version or missing bundled runtime before selecting files", async () => {
+        const manager = new CodexBinaryManager();
+        const before = getSettings().agentMode.backends?.codex;
+        for (const output of ["0.0.1", CODEX_ACP_PINNED_VERSION]) {
+          mockedExecFile.mockImplementation((_command, _args, _options, callback) => {
+            (callback as (error: Error | null, stdout: string, stderr: string) => void)(
+              null,
+              output,
+              ""
+            );
+            return {} as childProcess.ChildProcess;
+          });
+          await expect(manager.install()).rejects.toThrow(
+            output === "0.0.1" ? "did not report version" : "runtime could not start"
+          );
+          expect(getSettings().agentMode.backends?.codex).toEqual(before);
+          expect(fs.readdirSync(manager.getDataDir())).toEqual([]);
+        }
+      });
+      it.each(["download", "launcher"])(
+        "https://github.com/Brevilabs/obsidian-copilot-private/issues/379 preserves the selected native installation after a %s failure",
+        async (failure) => {
+          const manager = new CodexBinaryManager();
+          const previousDir = path.join(manager.getDataDir(), "1.9.0-r1");
+          fs.mkdirSync(previousDir, { recursive: true });
+          const entry = path.join(previousDir, "codex-acp");
+          fs.writeFileSync(entry, "native");
+          setSettings((cur) => ({
+            agentMode: {
+              ...cur.agentMode,
+              backends: {
+                ...cur.agentMode.backends,
+                codex: { binarySource: "managed", binaryPath: entry, binaryVersion: "1.9.0-r1" },
+              },
+            },
+          }));
+          if (failure === "download")
+            jest.mocked(installCodexArchive).mockRejectedValue(new Error("download failed"));
+          else
+            mockedExecFile.mockImplementation((_c, _a, _o, cb) => {
+              (cb as (error: Error | null, stdout: string, stderr: string) => void)(
+                new Error("launcher failed"),
+                "",
+                ""
+              );
+              return {} as childProcess.ChildProcess;
+            });
+          await expect(manager.install()).rejects.toThrow(`${failure} failed`);
+          expect(getSettings().agentMode.backends?.codex?.binaryPath).toBe(entry);
+          expect(fs.existsSync(entry)).toBe(true);
+          expect(fs.readdirSync(manager.getDataDir())).toEqual(["1.9.0-r1"]);
+        }
+      );
+    });
+
+    describe("getDataDir()", () => {
+      it("https://github.com/Brevilabs/obsidian-copilot-private/issues/379 rejects a missing home before choosing an installation directory", () => {
+        mockedHomedir.mockReturnValue("");
+        expect(() => new CodexBinaryManager().getDataDir()).toThrow("home directory");
+      });
+    });
+    describe("getActionState()", () => {
+      it("https://github.com/Brevilabs/obsidian-copilot-private/issues/368 exposes installation progress and retryable failures", () => {
+        const manager = new CodexBinaryManager();
+        const state = jest.spyOn(manager, "getRuntimeState");
+        state.mockReturnValue({
+          kind: "installing",
+          progress: { label: "Downloading", percent: 30 },
+        });
+        expect(manager.getActionState()).toEqual({
+          kind: "running",
+          label: "Downloading",
+          percent: 30,
+        });
+        state.mockReturnValue({ kind: "error", message: "download failed", operation: "install" });
+        expect(manager.getActionState()).toEqual({ kind: "error", message: "download failed" });
+        state.mockRestore();
+      });
+      it("https://github.com/Brevilabs/obsidian-copilot-private/issues/368 disables competing actions during path validation and hides unrelated failures", () => {
+        const manager = new CodexBinaryManager();
+        const state = jest.spyOn(manager, "getRuntimeState");
+        for (const kind of ["busy", "detecting"] as const) {
+          state.mockReturnValue({ kind });
+          expect(manager.getActionState()).toEqual({ kind: "running", label: "Configuring…" });
+        }
+        state.mockReturnValue({ kind: "error", message: "bad path", operation: "configure" });
+        expect(manager.getActionState()).toEqual({ kind: "idle" });
+        expect(manager.getActionState()).toBe(manager.getActionState());
+        state.mockRestore();
+      });
+    });
+
+    describe("setCustomBinaryPath()", () => {
+      it("https://github.com/Brevilabs/obsidian-copilot-private/issues/368 normalizes a supported package symlink before selecting the custom adapter", async () => {
+        const entry = writeAdapter(path.join(tempDir, "custom"));
+        const linked = path.join(tempDir, "codex-acp");
+        fs.symlinkSync(entry, linked);
+        const manager = new CodexBinaryManager();
+        await manager.setCustomBinaryPath(linked);
+        expect(getSettings().agentMode.backends?.codex).toMatchObject({
+          binaryPath: fs.realpathSync(entry),
+          binaryVersion: CODEX_ACP_PINNED_VERSION,
+          binarySource: "custom",
+        });
+      });
+      it("rejects an unsupported custom package before changing settings", async () => {
+        const entry = writeAdapter(path.join(tempDir, "custom"), "0.0.1");
+        const before = getSettings().agentMode.backends?.codex;
+        await expect(new CodexBinaryManager().setCustomBinaryPath(entry)).rejects.toThrow();
+        expect(getSettings().agentMode.backends?.codex).toEqual(before);
+      });
+    });
+    describe("uninstall()", () => {
+      it("https://github.com/Brevilabs/obsidian-copilot-private/issues/368 preserves legacy custom selections without source metadata", async () => {
+        const entry = writeAdapter(path.join(tempDir, "custom"));
+        setSettings((current) => ({
+          agentMode: {
+            ...current.agentMode,
+            backends: {
+              ...current.agentMode.backends,
+              codex: { binaryPath: entry, binaryVersion: CODEX_ACP_PINNED_VERSION },
+            },
+          },
+        }));
+        const manager = new CodexBinaryManager();
+        fs.mkdirSync(manager.getDataDir(), { recursive: true });
+        await manager.uninstall();
+        expect(getSettings().agentMode.backends?.codex?.binaryPath).toBe(entry);
+        expect(fs.existsSync(entry)).toBe(true);
+        expect(fs.existsSync(manager.getDataDir())).toBe(false);
+      });
+    });
+    describe("cancelCurrentOperation()", () => {
+      it("https://github.com/Brevilabs/obsidian-copilot-private/issues/368 cancels after launcher verification without replacing the selected adapter", async () => {
+        const manager = new CodexBinaryManager();
+        const before = getSettings().agentMode.backends?.codex;
+        mockedExecFile.mockImplementation((command, args, _options, callback) => {
+          const cb = callback as (error: Error | null, stdout: string, stderr: string) => void;
+          manager.cancelCurrentOperation();
+          cb(null, `${CODEX_ACP_PINNED_VERSION} Codex CLI`, "");
+          return {} as childProcess.ChildProcess;
+        });
+        await expect(manager.install()).rejects.toThrow("Aborted");
+        expect(getSettings().agentMode.backends?.codex).toEqual(before);
+        expect(fs.existsSync(path.join(manager.getDataDir(), CODEX_BUNDLE_VERSION))).toBe(false);
+        expect(manager.getRuntimeState()).toEqual({ kind: "idle" });
+      });
+    });
+  });
+});

--- a/src/agentMode/backends/codex/CodexBinaryManager.test.ts
+++ b/src/agentMode/backends/codex/CodexBinaryManager.test.ts
@@ -1,7 +1,7 @@
 import { installCodexArchive, CODEX_BUNDLE_VERSION } from "./codexArchive";
 jest.mock("./codexArchive", () => ({
   installCodexArchive: jest.fn(),
-  CODEX_BUNDLE_VERSION: "1.10.0-r1",
+  CODEX_BUNDLE_VERSION: "1.10.0",
 }));
 import { getSettings, setSettings } from "@/settings/model";
 import { requireNodeModule } from "@/utils/desktopRuntime";
@@ -85,7 +85,6 @@ describe("CodexBinaryManager", () => {
             path.join(stage, "provenance.json"),
             JSON.stringify({
               acpVersion: CODEX_ACP_PINNED_VERSION,
-              packagingRevision: 1,
               target: `darwin-${process.arch}`,
             })
           );

--- a/src/agentMode/backends/codex/CodexBinaryManager.ts
+++ b/src/agentMode/backends/codex/CodexBinaryManager.ts
@@ -1,0 +1,155 @@
+import {
+  ManagedBinaryManager,
+  type BinarySettings,
+  type InstalledBinary,
+  type ManagedBinaryInstallOptions,
+} from "@/agentMode/backends/shared/ManagedBinaryManager";
+import {
+  ManagedInstallAbortError,
+  promoteManagedVersion,
+} from "@/agentMode/backends/shared/managedInstall";
+import type { ManagedInstallActionState } from "@/agentMode/session/types";
+import { copilotAppDataDir } from "@/utils/appPaths";
+import { requireNodeModule } from "@/utils/desktopRuntime";
+import { getSettings, updateAgentModeBackendFields } from "@/settings/model";
+import { resolveSupportedCodexAcpPackage } from "./codexVersion";
+import { CODEX_ACP_PINNED_VERSION } from "./cliSetup";
+
+import { installCodexArchive, CODEX_BUNDLE_VERSION } from "./codexArchive";
+
+const IDLE_ACTION_STATE = Object.freeze({ kind: "idle" as const });
+const TIMEOUT_MS = 5 * 60_000;
+const EMPTY_BINARY_SETTINGS: BinarySettings = Object.freeze({});
+
+interface CodexInstallProgress {
+  label: string;
+  percent: number;
+}
+
+/** Owns the native Codex bundle installation; shared lifecycle operations never modify user-owned packages. */
+export class CodexBinaryManager extends ManagedBinaryManager<CodexInstallProgress> {
+  constructor() {
+    super("Codex adapter");
+  }
+
+  protected readBinarySettings(): BinarySettings {
+    const settings = getSettings().agentMode.backends?.codex;
+    // Existing custom selections predate source metadata and still belong to the user.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/368
+    if (settings?.binaryPath && !settings.binarySource)
+      return { ...settings, binarySource: "custom" };
+    return settings ?? EMPTY_BINARY_SETTINGS;
+  }
+
+  protected updateBinarySettings(settings: BinarySettings): void {
+    updateAgentModeBackendFields("codex", settings);
+  }
+
+  protected async validateCustomBinary(binaryPath: string): Promise<InstalledBinary> {
+    const supported = resolveSupportedCodexAcpPackage(binaryPath);
+    return { version: supported.version, path: supported.entryPath };
+  }
+
+  readonly getActionState = (): ManagedInstallActionState => {
+    const state = this.getRuntimeState();
+    if (state.kind === "installing") {
+      return {
+        kind: "running",
+        label: state.progress?.label ?? "Starting…",
+        percent: state.progress?.percent ?? 0,
+      };
+    }
+    // Path validation holds the same lock; other windows must not start a competing update.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/368
+    if (state.kind === "busy" || state.kind === "detecting")
+      return { kind: "running", label: "Configuring…" };
+    // Retry installs only, never a failed custom-path selection.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/368
+    if (state.kind === "error" && state.operation === "install")
+      return { kind: "error", message: state.message };
+    return IDLE_ACTION_STATE;
+  };
+  getDataDir(): string {
+    const home = requireNodeModule<typeof import("node:os")>("os").homedir();
+    if (!home || !path().isAbsolute(home) || path().parse(home).root === home) {
+      throw new Error("Could not resolve your home directory for the managed Codex adapter.");
+    }
+    return path().join(copilotAppDataDir(home), "codex");
+  }
+  protected async installPipeline({
+    signal,
+    onProgress,
+  }: ManagedBinaryInstallOptions<CodexInstallProgress> & {
+    signal: AbortSignal;
+  }): Promise<InstalledBinary> {
+    const dataDir = this.getDataDir();
+    const versionDir = path().join(dataDir, CODEX_BUNDLE_VERSION);
+    const stageDir = path().join(dataDir, `.tmp-${CODEX_ACP_PINNED_VERSION}-${Date.now()}`);
+    await fs().promises.mkdir(stageDir, { recursive: true });
+    try {
+      onProgress?.({ label: "Installing the Codex adapter…", percent: 30 });
+      await installCodexArchive(stageDir, signal);
+      onProgress?.({ label: "Verifying the Codex adapter…", percent: 85 });
+      const stagedEntry = entryPath(stageDir);
+      await verifyLauncher(stagedEntry, signal);
+      // A runnable adapter alone does not prove its bundled native runtime survived extraction.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/379
+      const runtime = await run(stagedEntry, ["cli", "--help"], signal);
+      if (!runtime.includes("Codex CLI"))
+        throw new Error("The bundled Codex runtime could not start.");
+      // Cancellation during verification must not replace the working installation.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/368
+      if (signal.aborted) throw new ManagedInstallAbortError();
+      await promoteManagedVersion(stageDir, versionDir, "Codex adapter");
+      const finalEntry = entryPath(versionDir);
+      updateAgentModeBackendFields("codex", {
+        binaryPath: finalEntry,
+        binaryVersion: CODEX_BUNDLE_VERSION,
+        binarySource: "managed",
+      });
+      onProgress?.({ label: "Codex adapter ready.", percent: 100 });
+      return { version: CODEX_BUNDLE_VERSION, path: finalEntry };
+    } finally {
+      await fs()
+        .promises.rm(stageDir, { recursive: true, force: true })
+        .catch(() => {});
+    }
+  }
+}
+
+function entryPath(versionDir: string): string {
+  return path().join(versionDir, process.platform === "win32" ? "codex-acp.exe" : "codex-acp");
+}
+
+async function verifyLauncher(entry: string, signal: AbortSignal): Promise<void> {
+  const stdout = await run(entry, ["--version"], signal);
+  if (!stdout.includes(CODEX_ACP_PINNED_VERSION)) {
+    throw new Error(`The Codex adapter did not report version ${CODEX_ACP_PINNED_VERSION}.`);
+  }
+}
+
+function run(command: string, args: string[], signal: AbortSignal): Promise<string> {
+  const childProcess = requireNodeModule<typeof import("node:child_process")>("child_process");
+  return new Promise((resolve, reject) => {
+    childProcess.execFile(
+      command,
+      args,
+      {
+        env: process.env,
+        signal,
+        timeout: TIMEOUT_MS,
+        windowsHide: true,
+        maxBuffer: 1024 * 1024,
+      },
+      (error, stdout) => (error ? reject(error) : resolve(stdout))
+    );
+  });
+}
+
+function fs(): typeof import("node:fs") {
+  return requireNodeModule<typeof import("node:fs")>("fs");
+}
+
+function path(): typeof import("node:path") {
+  return requireNodeModule<typeof import("node:path")>("path");
+}

--- a/src/agentMode/backends/codex/CodexInstallModal.test.tsx
+++ b/src/agentMode/backends/codex/CodexInstallModal.test.tsx
@@ -1,0 +1,160 @@
+import { CodexConfigView } from "@/agentMode/backends/codex/ui/CodexConfigView";
+import { CodexBinaryManager } from "@/agentMode/backends/codex/CodexBinaryManager";
+import { CodexInstallModal } from "@/agentMode/backends/codex/CodexInstallModal";
+import { getCodexBinaryManager } from "@/agentMode/backends/codex/descriptor";
+import type { InstalledBinary } from "@/agentMode/backends/shared/ManagedBinaryManager";
+import { DEFAULT_SETTINGS } from "@/constants";
+import { getSettings, settingsAtom, settingsStore } from "@/settings/model";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { App, Notice } from "obsidian";
+import React from "react";
+
+jest.mock("@/agentMode/backends/codex/ui/CodexConfigView", () => {
+  const actual = jest.requireActual("@/agentMode/backends/codex/ui/CodexConfigView");
+  return { ...actual, CodexConfigView: jest.fn(actual.CodexConfigView) };
+});
+jest.mock("@/logger", () => ({ logError: jest.fn(), logInfo: jest.fn(), logWarn: jest.fn() }));
+jest.mock("@/agentMode/backends/codex/descriptor", () => ({
+  detectCodexAcpPath: jest.fn().mockResolvedValue(null),
+  codexAcpDetectionSearchDirs: () => [],
+  getCodexBinaryManager: jest.fn(),
+}));
+const ISSUE = "https://github.com/Brevilabs/obsidian-copilot-private/issues/368";
+
+class PendingInstallManager extends CodexBinaryManager {
+  finish!: (installed: InstalledBinary) => void;
+  protected installPipeline(): Promise<InstalledBinary> {
+    return new Promise((resolve) => {
+      this.finish = resolve;
+    });
+  }
+}
+class TestModal extends CodexInstallModal {
+  content(): React.ReactElement {
+    return this.renderContent(jest.fn());
+  }
+}
+
+describe("CodexInstallModal", () => {
+  describe("CodexInstallModal", () => {
+    describe("renderContent()", () => {
+      let tempDir: string;
+      let customEntry: string;
+      let manager: PendingInstallManager;
+      let previousSettings: ReturnType<typeof getSettings>;
+      beforeEach(() => {
+        jest.clearAllMocks();
+        previousSettings = getSettings();
+        settingsStore.set(settingsAtom, {
+          ...DEFAULT_SETTINGS,
+          agentMode: {
+            ...DEFAULT_SETTINGS.agentMode,
+            backends: {
+              codex: {
+                binaryPath: "/managed/codex-acp",
+                binaryVersion: "1.10.0",
+                binarySource: "managed",
+              },
+            },
+          },
+        });
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-dialog-test-"));
+        const packageRoot = path.join(tempDir, "node_modules", "@agentclientprotocol", "codex-acp");
+        customEntry = path.join(packageRoot, "dist", "index.js");
+        fs.mkdirSync(path.dirname(customEntry), { recursive: true });
+        fs.writeFileSync(customEntry, "#!/usr/bin/env node\n", { mode: 0o755 });
+        fs.writeFileSync(
+          path.join(packageRoot, "package.json"),
+          JSON.stringify({
+            name: "@agentclientprotocol/codex-acp",
+            version: "1.9.0",
+            bin: { "codex-acp": "dist/index.js" },
+          })
+        );
+        manager = new PendingInstallManager();
+        jest.mocked(getCodexBinaryManager).mockReturnValue(manager);
+      });
+      afterEach(() => {
+        cleanup();
+        settingsStore.set(settingsAtom, previousSettings);
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      });
+      it("https://github.com/Brevilabs/obsidian-copilot-private/issues/379 passes the managed ownership to the existing dialog of a native bundle", () => {
+        const nativeEntry = path.join(
+          tempDir,
+          process.platform === "win32" ? "codex-acp.exe" : "codex-acp"
+        );
+        fs.writeFileSync(nativeEntry, "native");
+        fs.writeFileSync(
+          path.join(tempDir, "provenance.json"),
+          JSON.stringify({
+            acpVersion: "1.10.0",
+            packagingRevision: 1,
+            target: `${process.platform}-${process.arch}`,
+          })
+        );
+        settingsStore.set(settingsAtom, {
+          ...getSettings(),
+          agentMode: {
+            ...getSettings().agentMode,
+            backends: {
+              codex: {
+                binarySource: "managed",
+                binaryVersion: "1.10.0-r1",
+                binaryPath: nativeEntry,
+              },
+            },
+          },
+        });
+        render(new TestModal(new App()).content());
+        expect(screen.getByText("Ready")).toBeTruthy();
+        expect(jest.mocked(CodexConfigView).mock.calls.at(-1)?.[0].state).toEqual({
+          kind: "ready",
+          source: "managed",
+        });
+      });
+      it(`selects a custom adapter with its own version and clears all selection metadata without deleting its file for ${ISSUE}`, async () => {
+        render(new TestModal(new App()).content());
+        fireEvent.change(screen.getByRole("textbox"), { target: { value: customEntry } });
+        await act(async () => fireEvent.click(screen.getByRole("button", { name: "Apply" })));
+        await waitFor(() =>
+          expect(getSettings().agentMode.backends?.codex).toMatchObject({
+            binaryPath: fs.realpathSync(customEntry),
+            binaryVersion: "1.9.0",
+            binarySource: "custom",
+          })
+        );
+        await act(async () => fireEvent.click(screen.getByRole("button", { name: "Clear" })));
+        expect(getSettings().agentMode.backends?.codex).toMatchObject({
+          binaryPath: undefined,
+          binaryVersion: undefined,
+          binarySource: undefined,
+        });
+        expect(fs.existsSync(customEntry)).toBe(true);
+      });
+      it(`rejects applying and clearing a path while a managed install holds the write lock for ${ISSUE}`, async () => {
+        render(new TestModal(new App()).content());
+        const before = getSettings().agentMode.backends?.codex;
+        const installing = manager.install();
+        try {
+          fireEvent.change(screen.getByRole("textbox"), { target: { value: customEntry } });
+          await act(async () => fireEvent.click(screen.getByRole("button", { name: "Apply" })));
+          expect(screen.getByText(/setup operation is already running/)).toBeTruthy();
+          expect(getSettings().agentMode.backends?.codex).toEqual(before);
+          fireEvent.change(screen.getByRole("textbox"), { target: { value: before?.binaryPath } });
+          await act(async () => fireEvent.click(screen.getByRole("button", { name: "Clear" })));
+          expect(Notice).toHaveBeenCalledWith(
+            expect.stringContaining("Couldn't clear the custom path")
+          );
+          expect(getSettings().agentMode.backends?.codex).toEqual(before);
+        } finally {
+          manager.finish({ version: "1.10.0", path: "/managed/codex-acp" });
+          await installing;
+        }
+      });
+    });
+  });
+});

--- a/src/agentMode/backends/codex/CodexInstallModal.tsx
+++ b/src/agentMode/backends/codex/CodexInstallModal.tsx
@@ -1,11 +1,14 @@
 import { CodexConfigView } from "@/agentMode/backends/codex/ui/CodexConfigView";
 import { FullBleedReactModal } from "@/components/modals/ReactModal";
 import { useSettingsValue } from "@/settings/model";
-import { validateExecutableFile } from "@/utils/detectBinary";
 import { App, Notice } from "obsidian";
 import React from "react";
-import { codexAcpDetectionSearchDirs, detectCodexAcpPath, updateCodexFields } from "./descriptor";
-import { isSupportedCodexAcpPath, resolveSupportedCodexAcpEntry } from "./codexVersion";
+import {
+  codexAcpDetectionSearchDirs,
+  detectCodexAcpPath,
+  getCodexBinaryManager,
+} from "./descriptor";
+import { isSupportedCodexAcpPath } from "./codexVersion";
 
 /**
  * Stateful half of the Codex Configure dialog: the only place that reads
@@ -14,35 +17,47 @@ import { isSupportedCodexAcpPath, resolveSupportedCodexAcpEntry } from "./codexV
  */
 const CodexConfigContainer: React.FC<{ onClose: () => void }> = ({ onClose }) => {
   const settings = useSettingsValue();
+  const manager = getCodexBinaryManager();
   const binaryPath = settings.agentMode?.backends?.codex?.binaryPath ?? "";
   const state = isSupportedCodexAcpPath(binaryPath)
-    ? ({ kind: "ready", source: "custom" } as const)
+    ? ({
+        kind: "ready",
+        source: settings.agentMode?.backends?.codex?.binarySource ?? "custom",
+      } as const)
     : ({ kind: "absent" } as const);
 
-  const onSavePath = React.useCallback(async (path: string): Promise<string | null> => {
-    const err = await validateExecutableFile(path);
-    if (err) return err;
-    try {
-      resolveSupportedCodexAcpEntry(path);
-    } catch (error) {
-      return error instanceof Error ? error.message : String(error);
-    }
-    updateCodexFields({ binaryPath: path });
-    new Notice("Codex adapter path saved.");
-    return null;
-  }, []);
+  // Path changes must share the installer lock and update ownership together.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/368
+  const onSavePath = React.useCallback(
+    async (path: string): Promise<string | null> => {
+      try {
+        await manager.setCustomBinaryPath(path);
+        new Notice("Codex adapter path saved.");
+        return null;
+      } catch (error) {
+        return error instanceof Error ? error.message : String(error);
+      }
+    },
+    [manager]
+  );
 
-  const onClearPath = React.useCallback((): void => {
-    updateCodexFields({ binaryPath: undefined });
-    new Notice("Codex adapter path cleared.");
-  }, []);
+  const onClearPath = React.useCallback(async (): Promise<void> => {
+    try {
+      await manager.setCustomBinaryPath(null);
+      new Notice("Codex adapter path cleared.");
+    } catch (error) {
+      new Notice(
+        `Couldn't clear the custom path: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }, [manager]);
 
   return (
     <CodexConfigView
       state={state}
       binaryPath={binaryPath}
       onSavePath={onSavePath}
-      onClearPath={onClearPath}
+      onClearPath={() => void onClearPath()}
       detect={detectCodexAcpPath}
       searchedDirs={codexAcpDetectionSearchDirs}
       onClose={onClose}

--- a/src/agentMode/backends/codex/descriptor.test.ts
+++ b/src/agentMode/backends/codex/descriptor.test.ts
@@ -1,7 +1,10 @@
+import type CopilotPlugin from "@/main";
+import { getSettings, setSettings, type CopilotSettings } from "@/settings/model";
 import { detectBinary } from "@/utils/detectBinary";
 import { resolveCodexAcpBinary } from "./codexBinaryResolver";
-import { CodexBackendDescriptor, detectCodexAcpPath } from "./descriptor";
-import { isSupportedCodexAcpPath } from "./codexVersion";
+import { CODEX_BUNDLE_VERSION } from "./codexArchive";
+import { CodexBackendDescriptor, detectCodexAcpPath, getCodexBinaryManager } from "./descriptor";
+import { isSupportedCodexAcpPath, resolveSupportedCodexAcpPackage } from "./codexVersion";
 
 jest.mock("@/utils/detectBinary", () => ({ detectBinary: jest.fn() }));
 jest.mock("./codexBinaryResolver", () => ({
@@ -11,6 +14,7 @@ jest.mock("./codexBinaryResolver", () => ({
 jest.mock("./codexVersion", () => ({
   ...jest.requireActual("./codexVersion"),
   isSupportedCodexAcpPath: jest.fn(),
+  resolveSupportedCodexAcpPackage: jest.fn(),
 }));
 
 const mockedDetectBinary = jest.mocked(detectBinary);
@@ -63,6 +67,13 @@ const ADVERTISED_CONFIG_OPTIONS: BackendConfigOption[] = [
     ],
   },
 ];
+const mockedResolveSupportedPackage = jest.mocked(resolveSupportedCodexAcpPackage);
+
+function settingsWithCodex(codex: Record<string, unknown>): CopilotSettings {
+  return {
+    agentMode: { backends: { codex } },
+  } as unknown as CopilotSettings;
+}
 
 describe("descriptor", () => {
   describe("detectCodexAcpPath()", () => {
@@ -253,6 +264,115 @@ describe("descriptor", () => {
           state.model!.current
         );
         expect(applyModelWireId).toHaveBeenCalledWith("example[high]");
+      });
+    });
+
+    describe("getInstallState()", () => {
+      it.each([
+        ["legacy path", {}, "1.9.0", { kind: "ready", source: "custom" }],
+        [
+          "managed older bundle",
+          { binarySource: "managed", binaryVersion: "1.9.0-r1" },
+          "1.9.0-r1",
+          { kind: "incompatible", source: "managed" },
+        ],
+        [
+          "custom mismatch",
+          { binarySource: "custom", binaryVersion: "1.9.0" },
+          "1.9.0",
+          { kind: "ready", source: "custom" },
+        ],
+        [
+          "managed packaging mismatch",
+          { binarySource: "managed", binaryVersion: "1.10.0-r2" },
+          "1.10.0-r2",
+          { kind: "incompatible", source: "managed" },
+        ],
+        [
+          "managed pin",
+          { binarySource: "managed", binaryVersion: CODEX_BUNDLE_VERSION },
+          CODEX_BUNDLE_VERSION,
+          { kind: "ready", source: "managed" },
+        ],
+      ])(
+        "https://github.com/Brevilabs/obsidian-copilot-private/issues/379 classifies a supported %s by ownership",
+        (_label, fields, actualVersion, expected) => {
+          mockedResolveSupportedPackage.mockReturnValue({
+            entryPath: "/codex/index.js",
+            version: actualVersion,
+          });
+
+          expect(
+            CodexBackendDescriptor.getInstallState(
+              settingsWithCodex({ binaryPath: "/codex/index.js", ...fields })
+            )
+          ).toMatchObject(expected);
+        }
+      );
+    });
+
+    describe("subscribeInstallState()", () => {
+      it.each(["binaryPath", "binaryVersion", "binarySource"] as const)(
+        "publishes install-state changes when %s changes",
+        (field) => {
+          const original = getSettings().agentMode;
+          const listener = jest.fn();
+          const unsubscribe = CodexBackendDescriptor.subscribeInstallState(
+            {} as CopilotPlugin,
+            listener
+          );
+          try {
+            setSettings((current) => ({
+              agentMode: {
+                ...current.agentMode,
+                backends: {
+                  ...current.agentMode.backends,
+                  codex: { ...current.agentMode.backends?.codex, [field]: "changed" },
+                },
+              },
+            }));
+            expect(listener).toHaveBeenCalledTimes(1);
+          } finally {
+            unsubscribe();
+            setSettings({ agentMode: original });
+          }
+        }
+      );
+    });
+
+    describe("managedInstall.run()", () => {
+      it("routes the backend-neutral managed action to the Codex manager", async () => {
+        const manager = getCodexBinaryManager();
+        const install = jest
+          .spyOn(manager, "install")
+          .mockResolvedValue({ version: "1.10.0", path: "/managed/codex-acp" });
+        const listener = jest.fn();
+        const subscribe = jest.spyOn(manager, "subscribeRuntimeState");
+        try {
+          expect(CodexBackendDescriptor.managedInstall?.getState({} as CopilotPlugin)).toEqual({
+            kind: "idle",
+          });
+          const unsubscribe = CodexBackendDescriptor.managedInstall?.subscribe(
+            {} as CopilotPlugin,
+            listener
+          );
+          await CodexBackendDescriptor.managedInstall?.run({} as CopilotPlugin);
+          expect(subscribe).toHaveBeenCalledWith(listener);
+          expect(install).toHaveBeenCalledTimes(1);
+          unsubscribe?.();
+        } finally {
+          install.mockRestore();
+          subscribe.mockRestore();
+        }
+      });
+    });
+
+    describe("onPluginLoad()", () => {
+      it("https://github.com/Brevilabs/obsidian-copilot-private/issues/368 clears the singleton failure for each plugin lifecycle", async () => {
+        const reset = jest.spyOn(getCodexBinaryManager(), "forgetSettledError");
+        await CodexBackendDescriptor.onPluginLoad?.({} as CopilotPlugin);
+        expect(reset).toHaveBeenCalledTimes(1);
+        reset.mockRestore();
       });
     });
 

--- a/src/agentMode/backends/codex/descriptor.ts
+++ b/src/agentMode/backends/codex/descriptor.ts
@@ -28,9 +28,17 @@ import type {
 } from "@/agentMode/session/types";
 import { formatCodexModelId, parseCodexModelId } from "@/utils/codexModelId";
 import { codexAcpSearchDirs, resolveCodexAcpBinary } from "./codexBinaryResolver";
+import { CodexBinaryManager } from "./CodexBinaryManager";
+import { CODEX_BUNDLE_VERSION } from "./codexArchive";
 import { CODEX_BINARY_NAME } from "./cliSetup";
 import { buildCodexModeMapping } from "./codexModeMapping";
-import { isSupportedCodexAcpPath } from "./codexVersion";
+import { isSupportedCodexAcpPath, resolveSupportedCodexAcpPackage } from "./codexVersion";
+
+const codexBinaryManager = new CodexBinaryManager();
+
+export function getCodexBinaryManager(): CodexBinaryManager {
+  return codexBinaryManager;
+}
 
 export function updateCodexFields(partial: Partial<CodexBackendSettings>): void {
   updateAgentModeBackendFields("codex", partial);
@@ -143,9 +151,26 @@ export const CodexBackendDescriptor: BackendDescriptor = {
   },
 
   getInstallState(settings: CopilotSettings): InstallState {
-    return isSupportedCodexAcpPath(settings.agentMode?.backends?.codex?.binaryPath)
-      ? { kind: "ready", source: "custom" }
-      : { kind: "absent" };
+    const configured = settings.agentMode?.backends?.codex;
+    if (!configured?.binaryPath) return { kind: "absent" };
+    try {
+      const installed = resolveSupportedCodexAcpPackage(configured.binaryPath);
+      const source = configured.binarySource ?? "custom";
+      // A supported older bundle stays selectable for the managed Update action.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/379
+      if (source === "managed" && installed.version !== CODEX_BUNDLE_VERSION) {
+        return {
+          kind: "incompatible",
+          source,
+          currentVersion: installed.version,
+          minVersion: CODEX_BUNDLE_VERSION,
+          message: `Codex adapter ${installed.version} does not match this Copilot release (${CODEX_BUNDLE_VERSION}).`,
+        };
+      }
+      return { kind: "ready", source };
+    } catch {
+      return { kind: "absent" };
+    }
   },
 
   getResolvedBinaryPath(settings: CopilotSettings): string | null {
@@ -155,7 +180,12 @@ export const CodexBackendDescriptor: BackendDescriptor = {
   subscribeInstallState(_plugin: CopilotPlugin, cb: () => void): () => void {
     return subscribeToSettingsChange((prev, next) => {
       if (
-        prev.agentMode?.backends?.codex?.binaryPath !== next.agentMode?.backends?.codex?.binaryPath
+        prev.agentMode?.backends?.codex?.binaryPath !==
+          next.agentMode?.backends?.codex?.binaryPath ||
+        prev.agentMode?.backends?.codex?.binaryVersion !==
+          next.agentMode?.backends?.codex?.binaryVersion ||
+        prev.agentMode?.backends?.codex?.binarySource !==
+          next.agentMode?.backends?.codex?.binarySource
       ) {
         cb();
       }
@@ -164,6 +194,20 @@ export const CodexBackendDescriptor: BackendDescriptor = {
 
   openInstallUI(plugin: CopilotPlugin): void {
     new CodexInstallModal(plugin.app).open();
+  },
+
+  async onPluginLoad(): Promise<void> {
+    // A new vault or plugin lifecycle must not inherit a previous installation failure.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/368
+    codexBinaryManager.forgetSettledError();
+  },
+
+  managedInstall: {
+    getState: () => codexBinaryManager.getActionState(),
+    subscribe: (_plugin, onChange) => codexBinaryManager.subscribeRuntimeState(onChange),
+    run: async () => {
+      await codexBinaryManager.install();
+    },
   },
 
   async applySelection(session: ModelSelectionSession, selection: ModelSelection): Promise<void> {

--- a/src/settings/deviceProfiles.test.ts
+++ b/src/settings/deviceProfiles.test.ts
@@ -24,223 +24,275 @@ function makeSettings(agentMode: AgentMode, settingsVersion = 6): CopilotSetting
 const DEVICE_A = "device-a";
 const DEVICE_B = "device-b";
 
-describe("dehydrateDeviceProfile", () => {
-  it("moves device-specific flat fields into deviceProfiles[deviceId] and strips them", () => {
-    const settings = makeSettings(
-      makeAgentMode({
+describe("deviceProfiles", () => {
+  describe("dehydrateDeviceProfile()", () => {
+    it("moves device-specific flat fields into deviceProfiles[deviceId] and strips them", () => {
+      const settings = makeSettings(
+        makeAgentMode({
+          claudeCli: { path: "/a/claude" },
+          backends: {
+            codex: {
+              binaryPath: "/a/codex",
+              binaryVersion: "1.10.0-r1",
+              binarySource: "managed",
+              envOverrides: { FOO: "1" },
+            },
+            opencode: {
+              binaryPath: "/a/opencode",
+              binaryVersion: "1.2.3",
+              binarySource: "custom",
+              probeSessionId: "sess-1",
+            },
+          },
+        })
+      );
+
+      const out = dehydrateDeviceProfile(settings, DEVICE_A);
+
+      // Flat fields stripped from the top level.
+      expect(out.agentMode.claudeCli).toBeUndefined();
+      expect(out.agentMode.backends.codex?.binaryPath).toBeUndefined();
+      expect(out.agentMode.backends.opencode?.binaryPath).toBeUndefined();
+
+      // Moved into this device's segment.
+      expect(out.agentMode.deviceProfiles?.[DEVICE_A]).toEqual({
+        claudeCliPath: "/a/claude",
+        codex: {
+          binaryPath: "/a/codex",
+          binaryVersion: "1.10.0-r1",
+          binarySource: "managed",
+          envOverrides: { FOO: "1" },
+        },
+        opencode: {
+          binaryPath: "/a/opencode",
+          binaryVersion: "1.2.3",
+          binarySource: "custom",
+          probeSessionId: "sess-1",
+        },
+      });
+    });
+
+    it("keeps synced (non-device) prefs like defaultModel in the flat backends slice", () => {
+      const settings = makeSettings(
+        makeAgentMode({
+          backends: {
+            codex: { binaryPath: "/a/codex", defaultModel: { baseModelId: "gpt-5", effort: null } },
+            claude: { enableThinking: true, envOverrides: { BAR: "2" } },
+          },
+        })
+      );
+
+      const out = dehydrateDeviceProfile(settings, DEVICE_A);
+
+      expect(out.agentMode.backends.codex?.defaultModel).toEqual({
+        baseModelId: "gpt-5",
+        effort: null,
+      });
+      expect(out.agentMode.backends.claude?.enableThinking).toBe(true);
+      // Device-specific bits moved out.
+      expect(out.agentMode.backends.codex?.binaryPath).toBeUndefined();
+      expect(out.agentMode.deviceProfiles?.[DEVICE_A]?.codex?.binaryPath).toBe("/a/codex");
+      expect(out.agentMode.deviceProfiles?.[DEVICE_A]?.claude?.envOverrides).toEqual({ BAR: "2" });
+    });
+
+    it("preserves other devices' segments and removes own when empty", () => {
+      const settings = makeSettings(
+        makeAgentMode({
+          deviceProfiles: { [DEVICE_B]: { claudeCliPath: "/b/claude" } },
+        })
+      );
+
+      const out = dehydrateDeviceProfile(settings, DEVICE_A);
+
+      // Device A has nothing configured → no own segment created.
+      expect(out.agentMode.deviceProfiles?.[DEVICE_A]).toBeUndefined();
+      // Device B's segment untouched.
+      expect(out.agentMode.deviceProfiles?.[DEVICE_B]).toEqual({ claudeCliPath: "/b/claude" });
+    });
+  });
+
+  describe("hydrateDeviceProfile()", () => {
+    it("populates flat fields from this device's segment", () => {
+      const settings = makeSettings(
+        makeAgentMode({
+          deviceProfiles: {
+            [DEVICE_A]: {
+              claudeCliPath: "/a/claude",
+              opencode: {
+                binaryPath: "/a/opencode",
+                binaryVersion: "9.9",
+                binarySource: "managed",
+              },
+            },
+          },
+        })
+      );
+
+      const out = hydrateDeviceProfile(settings, DEVICE_A);
+
+      expect(out.agentMode.claudeCli?.path).toBe("/a/claude");
+      expect(out.agentMode.backends.opencode?.binaryPath).toBe("/a/opencode");
+      expect(out.agentMode.backends.opencode?.binarySource).toBe("managed");
+    });
+
+    it("ignores stale global flat fields when this device has no segment", () => {
+      // A synced data.json may still carry another device's flat paths. With no
+      // segment of its own, this device must treat them as not configured.
+      const settings = makeSettings(
+        makeAgentMode({
+          claudeCli: { path: "/stale/claude" },
+          backends: { codex: { binaryPath: "/stale/codex" } },
+          deviceProfiles: { [DEVICE_B]: { claudeCliPath: "/b/claude" } },
+        })
+      );
+      const out = hydrateDeviceProfile(settings, DEVICE_A);
+      expect(out.agentMode.claudeCli).toBeUndefined();
+      expect(out.agentMode.backends.codex?.binaryPath).toBeUndefined();
+    });
+
+    it("merges segment fields onto synced backend prefs without clobbering them", () => {
+      const settings = makeSettings(
+        makeAgentMode({
+          backends: { codex: { defaultModel: { baseModelId: "gpt-5", effort: null } } },
+          deviceProfiles: { [DEVICE_A]: { codex: { binaryPath: "/a/codex" } } },
+        })
+      );
+
+      const out = hydrateDeviceProfile(settings, DEVICE_A);
+
+      expect(out.agentMode.backends.codex?.defaultModel).toEqual({
+        baseModelId: "gpt-5",
+        effort: null,
+      });
+      expect(out.agentMode.backends.codex?.binaryPath).toBe("/a/codex");
+    });
+
+    it("keeps a Codex managed install's ownership and version on the same device", () => {
+      const settings = makeSettings(
+        makeAgentMode({
+          deviceProfiles: {
+            [DEVICE_A]: {
+              codex: {
+                binaryPath: "/a/codex",
+                binaryVersion: "1.10.0-r1",
+                binarySource: "managed",
+              },
+            },
+          },
+        })
+      );
+
+      const out = hydrateDeviceProfile(settings, DEVICE_A);
+
+      expect(out.agentMode.backends.codex).toMatchObject({
+        binaryPath: "/a/codex",
+        binaryVersion: "1.10.0-r1",
+        binarySource: "managed",
+      });
+    });
+
+    it("drops stale device-specific flat fields, taking device fields only from the profile", () => {
+      // A synced data.json may carry another device's opencode binaryVersion/
+      // binarySource as flat values. Hydrate ignores them and takes device fields
+      // only from this device's segment, which configures binaryPath alone.
+      const settings = makeSettings(
+        makeAgentMode({
+          backends: { opencode: { binaryVersion: "9.9", binarySource: "managed" } },
+          deviceProfiles: { [DEVICE_A]: { opencode: { binaryPath: "/a/oc" } } },
+        })
+      );
+
+      const out = hydrateDeviceProfile(settings, DEVICE_A);
+
+      expect(out.agentMode.backends.opencode?.binaryPath).toBe("/a/oc");
+      expect(out.agentMode.backends.opencode?.binaryVersion).toBeUndefined();
+      expect(out.agentMode.backends.opencode?.binarySource).toBeUndefined();
+    });
+
+    it("restores the same flat fields for the same device", () => {
+      const agentMode = makeAgentMode({
         claudeCli: { path: "/a/claude" },
         backends: {
-          codex: { binaryPath: "/a/codex", envOverrides: { FOO: "1" } },
-          opencode: {
-            binaryPath: "/a/opencode",
-            binaryVersion: "1.2.3",
-            binarySource: "custom",
-            probeSessionId: "sess-1",
+          opencode: { binaryPath: "/a/oc", binaryVersion: "1.0", binarySource: "custom" },
+          codex: { defaultModel: { baseModelId: "gpt-5", effort: null }, binaryPath: "/a/cx" },
+        },
+      });
+      const settings = makeSettings(agentMode);
+
+      const disk = dehydrateDeviceProfile(settings, DEVICE_A);
+      const restored = hydrateDeviceProfile(disk, DEVICE_A);
+
+      expect(restored.agentMode.claudeCli?.path).toBe("/a/claude");
+      expect(restored.agentMode.backends.opencode?.binaryPath).toBe("/a/oc");
+      expect(restored.agentMode.backends.codex?.binaryPath).toBe("/a/cx");
+      expect(restored.agentMode.backends.codex?.defaultModel?.baseModelId).toBe("gpt-5");
+    });
+
+    it("isolates devices: a path configured on A is invisible to B but survives B's save", () => {
+      // Device A configures and saves.
+      const aDisk = dehydrateDeviceProfile(
+        makeSettings(makeAgentMode({ claudeCli: { path: "/a/claude" } })),
+        DEVICE_A
+      );
+
+      // Synced to device B and loaded: B sees no path of its own.
+      const bLoaded = hydrateDeviceProfile(aDisk, DEVICE_B);
+      expect(bLoaded.agentMode.claudeCli).toBeUndefined();
+
+      // B configures its own path and saves.
+      const bConfigured = {
+        ...bLoaded,
+        agentMode: { ...bLoaded.agentMode, claudeCli: { path: "/b/claude" } },
+      } as CopilotSettings;
+      const bDisk = dehydrateDeviceProfile(bConfigured, DEVICE_B);
+
+      // Both segments coexist; each device resolves its own binary.
+      expect(bDisk.agentMode.deviceProfiles?.[DEVICE_A]?.claudeCliPath).toBe("/a/claude");
+      expect(bDisk.agentMode.deviceProfiles?.[DEVICE_B]?.claudeCliPath).toBe("/b/claude");
+      expect(hydrateDeviceProfile(bDisk, DEVICE_A).agentMode.claudeCli?.path).toBe("/a/claude");
+      expect(hydrateDeviceProfile(bDisk, DEVICE_B).agentMode.claudeCli?.path).toBe("/b/claude");
+    });
+  });
+
+  describe("sanitizeSettings()", () => {
+    it("preserves a valid profile map and drops empty/invalid entries", () => {
+      const raw = {
+        agentMode: {
+          deviceProfiles: {
+            [DEVICE_A]: {
+              claudeCliPath: "/a/claude",
+              opencode: { binaryPath: "/a/oc", binaryVersion: "1", binarySource: "custom" },
+              codex: { envOverrides: { GOOD: "1", "bad-key": "x" } },
+            },
+            [DEVICE_B]: {}, // empty → dropped
+            "": { claudeCliPath: "/x" }, // empty key → dropped
           },
         },
-      })
-    );
+      };
 
-    const out = dehydrateDeviceProfile(settings, DEVICE_A);
+      const out = sanitizeSettings(raw as unknown as CopilotSettings);
+      const profiles = out.agentMode.deviceProfiles ?? {};
 
-    // Flat fields stripped from the top level.
-    expect(out.agentMode.claudeCli).toBeUndefined();
-    expect(out.agentMode.backends.codex?.binaryPath).toBeUndefined();
-    expect(out.agentMode.backends.opencode?.binaryPath).toBeUndefined();
-
-    // Moved into this device's segment.
-    expect(out.agentMode.deviceProfiles?.[DEVICE_A]).toEqual({
-      claudeCliPath: "/a/claude",
-      codex: { binaryPath: "/a/codex", envOverrides: { FOO: "1" } },
-      opencode: {
-        binaryPath: "/a/opencode",
-        binaryVersion: "1.2.3",
-        binarySource: "custom",
-        probeSessionId: "sess-1",
-      },
+      expect(profiles[DEVICE_A]?.claudeCliPath).toBe("/a/claude");
+      expect(profiles[DEVICE_A]?.opencode?.binarySource).toBe("custom");
+      // Invalid env key dropped, valid kept.
+      expect(profiles[DEVICE_A]?.codex?.envOverrides).toEqual({ GOOD: "1" });
+      expect(profiles[DEVICE_B]).toBeUndefined();
+      expect(profiles[""]).toBeUndefined();
     });
-  });
 
-  it("keeps synced (non-device) prefs like defaultModel in the flat backends slice", () => {
-    const settings = makeSettings(
-      makeAgentMode({
-        backends: {
-          codex: { binaryPath: "/a/codex", defaultModel: { baseModelId: "gpt-5", effort: null } },
-          claude: { enableThinking: true, envOverrides: { BAR: "2" } },
-        },
-      })
-    );
-
-    const out = dehydrateDeviceProfile(settings, DEVICE_A);
-
-    expect(out.agentMode.backends.codex?.defaultModel).toEqual({
-      baseModelId: "gpt-5",
-      effort: null,
-    });
-    expect(out.agentMode.backends.claude?.enableThinking).toBe(true);
-    // Device-specific bits moved out.
-    expect(out.agentMode.backends.codex?.binaryPath).toBeUndefined();
-    expect(out.agentMode.deviceProfiles?.[DEVICE_A]?.codex?.binaryPath).toBe("/a/codex");
-    expect(out.agentMode.deviceProfiles?.[DEVICE_A]?.claude?.envOverrides).toEqual({ BAR: "2" });
-  });
-
-  it("preserves other devices' segments and removes own when empty", () => {
-    const settings = makeSettings(
-      makeAgentMode({
-        deviceProfiles: { [DEVICE_B]: { claudeCliPath: "/b/claude" } },
-      })
-    );
-
-    const out = dehydrateDeviceProfile(settings, DEVICE_A);
-
-    // Device A has nothing configured → no own segment created.
-    expect(out.agentMode.deviceProfiles?.[DEVICE_A]).toBeUndefined();
-    // Device B's segment untouched.
-    expect(out.agentMode.deviceProfiles?.[DEVICE_B]).toEqual({ claudeCliPath: "/b/claude" });
-  });
-});
-
-describe("hydrateDeviceProfile", () => {
-  it("populates flat fields from this device's segment", () => {
-    const settings = makeSettings(
-      makeAgentMode({
-        deviceProfiles: {
-          [DEVICE_A]: {
-            claudeCliPath: "/a/claude",
-            opencode: { binaryPath: "/a/opencode", binaryVersion: "9.9", binarySource: "managed" },
+    it("marks every unannotated Codex path as custom ownership (https://github.com/Brevilabs/obsidian-copilot-private/issues/368)", () => {
+      const out = sanitizeSettings({
+        agentMode: {
+          backends: { codex: { binaryPath: "/flat/codex" } },
+          deviceProfiles: {
+            [DEVICE_A]: { codex: { binaryPath: "/profile/codex" } },
           },
         },
-      })
-    );
+      } as unknown as CopilotSettings);
 
-    const out = hydrateDeviceProfile(settings, DEVICE_A);
-
-    expect(out.agentMode.claudeCli?.path).toBe("/a/claude");
-    expect(out.agentMode.backends.opencode?.binaryPath).toBe("/a/opencode");
-    expect(out.agentMode.backends.opencode?.binarySource).toBe("managed");
-  });
-
-  it("ignores stale global flat fields when this device has no segment", () => {
-    // A synced data.json may still carry another device's flat paths. With no
-    // segment of its own, this device must treat them as not configured.
-    const settings = makeSettings(
-      makeAgentMode({
-        claudeCli: { path: "/stale/claude" },
-        backends: { codex: { binaryPath: "/stale/codex" } },
-        deviceProfiles: { [DEVICE_B]: { claudeCliPath: "/b/claude" } },
-      })
-    );
-    const out = hydrateDeviceProfile(settings, DEVICE_A);
-    expect(out.agentMode.claudeCli).toBeUndefined();
-    expect(out.agentMode.backends.codex?.binaryPath).toBeUndefined();
-  });
-
-  it("merges segment fields onto synced backend prefs without clobbering them", () => {
-    const settings = makeSettings(
-      makeAgentMode({
-        backends: { codex: { defaultModel: { baseModelId: "gpt-5", effort: null } } },
-        deviceProfiles: { [DEVICE_A]: { codex: { binaryPath: "/a/codex" } } },
-      })
-    );
-
-    const out = hydrateDeviceProfile(settings, DEVICE_A);
-
-    expect(out.agentMode.backends.codex?.defaultModel).toEqual({
-      baseModelId: "gpt-5",
-      effort: null,
+      expect(out.agentMode.backends.codex?.binarySource).toBe("custom");
+      expect(out.agentMode.deviceProfiles?.[DEVICE_A]?.codex?.binarySource).toBe("custom");
     });
-    expect(out.agentMode.backends.codex?.binaryPath).toBe("/a/codex");
-  });
-
-  it("drops stale device-specific flat fields, taking device fields only from the profile", () => {
-    // A synced data.json may carry another device's opencode binaryVersion/
-    // binarySource as flat values. Hydrate ignores them and takes device fields
-    // only from this device's segment, which configures binaryPath alone.
-    const settings = makeSettings(
-      makeAgentMode({
-        backends: { opencode: { binaryVersion: "9.9", binarySource: "managed" } },
-        deviceProfiles: { [DEVICE_A]: { opencode: { binaryPath: "/a/oc" } } },
-      })
-    );
-
-    const out = hydrateDeviceProfile(settings, DEVICE_A);
-
-    expect(out.agentMode.backends.opencode?.binaryPath).toBe("/a/oc");
-    expect(out.agentMode.backends.opencode?.binaryVersion).toBeUndefined();
-    expect(out.agentMode.backends.opencode?.binarySource).toBeUndefined();
-  });
-});
-
-describe("hydrate ∘ dehydrate round trip", () => {
-  it("restores the same flat fields for the same device", () => {
-    const agentMode = makeAgentMode({
-      claudeCli: { path: "/a/claude" },
-      backends: {
-        opencode: { binaryPath: "/a/oc", binaryVersion: "1.0", binarySource: "custom" },
-        codex: { defaultModel: { baseModelId: "gpt-5", effort: null }, binaryPath: "/a/cx" },
-      },
-    });
-    const settings = makeSettings(agentMode);
-
-    const disk = dehydrateDeviceProfile(settings, DEVICE_A);
-    const restored = hydrateDeviceProfile(disk, DEVICE_A);
-
-    expect(restored.agentMode.claudeCli?.path).toBe("/a/claude");
-    expect(restored.agentMode.backends.opencode?.binaryPath).toBe("/a/oc");
-    expect(restored.agentMode.backends.codex?.binaryPath).toBe("/a/cx");
-    expect(restored.agentMode.backends.codex?.defaultModel?.baseModelId).toBe("gpt-5");
-  });
-
-  it("isolates devices: a path configured on A is invisible to B but survives B's save", () => {
-    // Device A configures and saves.
-    const aDisk = dehydrateDeviceProfile(
-      makeSettings(makeAgentMode({ claudeCli: { path: "/a/claude" } })),
-      DEVICE_A
-    );
-
-    // Synced to device B and loaded: B sees no path of its own.
-    const bLoaded = hydrateDeviceProfile(aDisk, DEVICE_B);
-    expect(bLoaded.agentMode.claudeCli).toBeUndefined();
-
-    // B configures its own path and saves.
-    const bConfigured = {
-      ...bLoaded,
-      agentMode: { ...bLoaded.agentMode, claudeCli: { path: "/b/claude" } },
-    } as CopilotSettings;
-    const bDisk = dehydrateDeviceProfile(bConfigured, DEVICE_B);
-
-    // Both segments coexist; each device resolves its own binary.
-    expect(bDisk.agentMode.deviceProfiles?.[DEVICE_A]?.claudeCliPath).toBe("/a/claude");
-    expect(bDisk.agentMode.deviceProfiles?.[DEVICE_B]?.claudeCliPath).toBe("/b/claude");
-    expect(hydrateDeviceProfile(bDisk, DEVICE_A).agentMode.claudeCli?.path).toBe("/a/claude");
-    expect(hydrateDeviceProfile(bDisk, DEVICE_B).agentMode.claudeCli?.path).toBe("/b/claude");
-  });
-});
-
-describe("sanitizeSettings round-trips deviceProfiles", () => {
-  it("preserves a valid profile map and drops empty/invalid entries", () => {
-    const raw = {
-      agentMode: {
-        deviceProfiles: {
-          [DEVICE_A]: {
-            claudeCliPath: "/a/claude",
-            opencode: { binaryPath: "/a/oc", binaryVersion: "1", binarySource: "custom" },
-            codex: { envOverrides: { GOOD: "1", "bad-key": "x" } },
-          },
-          [DEVICE_B]: {}, // empty → dropped
-          "": { claudeCliPath: "/x" }, // empty key → dropped
-        },
-      },
-    };
-
-    const out = sanitizeSettings(raw as unknown as CopilotSettings);
-    const profiles = out.agentMode.deviceProfiles ?? {};
-
-    expect(profiles[DEVICE_A]?.claudeCliPath).toBe("/a/claude");
-    expect(profiles[DEVICE_A]?.opencode?.binarySource).toBe("custom");
-    // Invalid env key dropped, valid kept.
-    expect(profiles[DEVICE_A]?.codex?.envOverrides).toEqual({ GOOD: "1" });
-    expect(profiles[DEVICE_B]).toBeUndefined();
-    expect(profiles[""]).toBeUndefined();
   });
 });

--- a/src/settings/deviceProfiles.ts
+++ b/src/settings/deviceProfiles.ts
@@ -42,7 +42,7 @@ function omitKeys<T extends object>(obj: T, keys: readonly string[]): T {
 }
 
 /** Device-specific field names per backend slice, removed on save / set on load. */
-const CODEX_DEVICE_KEYS = ["binaryPath", "envOverrides"] as const;
+const CODEX_DEVICE_KEYS = ["binaryPath", "binaryVersion", "binarySource", "envOverrides"] as const;
 const CLAUDE_DEVICE_KEYS = ["envOverrides"] as const;
 const OPENCODE_DEVICE_KEYS = [
   "binaryPath",
@@ -63,6 +63,10 @@ function buildProfileFromFlat(agentMode: AgentMode): DeviceAgentProfile {
   if (codexSrc) {
     const codex: NonNullable<DeviceAgentProfile["codex"]> = {};
     if (codexSrc.binaryPath) codex.binaryPath = codexSrc.binaryPath;
+    if (codexSrc.binaryVersion) codex.binaryVersion = codexSrc.binaryVersion;
+    if (codexSrc.binaryPath && codexSrc.binarySource) {
+      codex.binarySource = codexSrc.binarySource;
+    }
     if (codexSrc.envOverrides) codex.envOverrides = codexSrc.envOverrides;
     if (hasOwnKeys(codex)) profile.codex = codex;
   }

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -367,8 +367,10 @@ export interface ClaudeBackendSettings {
 
 /** Settings slice owned by the Codex backend. */
 export interface CodexBackendSettings {
-  /** Path to the user-provided `codex-acp` binary. */
+  binaryVersion?: string;
+  /** Path to the configured `codex-acp` package entry. */
   binaryPath?: string;
+  binarySource?: "managed" | "custom";
   /** Sticky model preference — `{ baseModelId, effort }`. Unset = use the agent's default. */
   defaultModel?: ModelSelection | null;
   /** Sticky permission-mode preference (default/plan/auto). Unset = the agent's natural starting mode. */
@@ -420,6 +422,8 @@ export interface DeviceAgentProfile {
   claudeCliPath?: string;
   codex?: {
     binaryPath?: string;
+    binaryVersion?: string;
+    binarySource?: "managed" | "custom";
     envOverrides?: Record<string, string>;
   };
   opencode?: {
@@ -1589,8 +1593,18 @@ function sanitizeClaudeBackendSettings(raw: unknown): ClaudeBackendSettings {
 function sanitizeCodexBackendSettings(raw: unknown): CodexBackendSettings {
   if (!raw || typeof raw !== "object") return {};
   const r = raw as Record<string, unknown>;
+  const binaryPath = nonEmptyString(r.binaryPath);
+  const rawSource = r.binarySource;
   return {
-    binaryPath: nonEmptyString(r.binaryPath),
+    binaryPath,
+    binaryVersion: binaryPath ? nonEmptyString(r.binaryVersion) : undefined,
+    // Never take ownership of an existing or cross-device path.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/368
+    binarySource: binaryPath
+      ? rawSource === "managed" || rawSource === "custom"
+        ? rawSource
+        : "custom"
+      : undefined,
     defaultModel: sanitizeDefaultModel(r.defaultModel),
     defaultMode: sanitizeDefaultMode(r.defaultMode),
     envOverrides: sanitizeEnvOverrides(r.envOverrides),
@@ -1635,6 +1649,12 @@ function sanitizeDeviceAgentProfile(raw: unknown): DeviceAgentProfile | undefine
     const codex: NonNullable<DeviceAgentProfile["codex"]> = {};
     const binaryPath = nonEmptyString(codexRaw.binaryPath);
     if (binaryPath) codex.binaryPath = binaryPath;
+    const binaryVersion = binaryPath ? nonEmptyString(codexRaw.binaryVersion) : undefined;
+    if (binaryVersion) codex.binaryVersion = binaryVersion;
+    const rawSource = codexRaw.binarySource;
+    if (binaryPath) {
+      codex.binarySource = rawSource === "managed" || rawSource === "custom" ? rawSource : "custom";
+    }
     const envOverrides = sanitizeEnvOverrides(codexRaw.envOverrides);
     if (envOverrides) codex.envOverrides = envOverrides;
     if (Object.keys(codex).length > 0) out.codex = codex;


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#379

## Why

Codex setup currently requires users to install and maintain their own adapter. A managed installation should download the tested adapter and its Codex runtime without requiring Node.js or npm.

## What

Connect verified native downloads to the shared managed lifecycle. Stage and verify both executables before selecting a replacement, preserve the prior selection on failure, and expose managed Update progress.

Store version and ownership per device. Existing custom/npm adapters remain user-owned, and path changes use the same operation lock.

## Non goal

The full install/sign-in dialog and running-session/profile ownership safeguards are separate changes. There is no compatibility or migration path for the unshipped npm-managed installer, global npm uninstall, credential copying, or forced ownership of custom software.

## Screenshot

Not applicable: this change adds the native installation backend and settings wiring. The existing Configure dialog's visual layout and controls are unchanged.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Archive, manager, resolver, descriptor, and profile tests cover installation and selection contracts |
| A defect would fail CI or be obvious on first use | ✅ | Deterministic failures reject installation before selection; platform launch failures appear during verification |
| A revert fully restores prior state, including persisted data | ❌ | Selected native paths and ownership/version settings persist after reverting |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Release manifests and checksums are validated before system tar extracts the runtime |
| No public API, plugin API, message, or on-disk contract changes | ❌ | Native provenance and per-device binary metadata become installation contracts |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Installation and custom-path changes use the shared operation lock |
| No hot-path behavior lacks deterministic coverage | ✅ | Native/npm launch resolution and update classification have unit coverage |
| No new dependency | ✅ | Archive support and fflate are already provided by the base |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Release availability and OS executable compatibility surface during Codex installation |

Review: Inspect CodexBinaryManager.installPipeline in src/agentMode/backends/codex/CodexBinaryManager.ts, getInstallState and managedInstall in src/agentMode/backends/codex/descriptor.ts, CodexConfigContainer in src/agentMode/backends/codex/CodexInstallModal.tsx, Codex sanitization in src/settings/model.ts, and CODEX_DEVICE_KEYS/buildProfileFromFlat in src/settings/deviceProfiles.ts. Follow Verification, including failed replacement and custom ownership.

## Verification

1. Once the pinned native release is available, load a disposable test-vault configuration selecting an older managed native bundle. Open Agent Chat and Settings. Both should show Update required, including an older installation with a packaging-revision suffix. Start Update and expect shared progress, then a ready installation.
2. Force download, checksum, extraction, and executable-verification failures. Confirm the previous native bundle remains selected and usable. Cancel a pending install, then retry successfully.
3. With a release archive and adjacent manifest for this machine, set `CODEX_BUNDLE_TEST_ARCHIVE` to the archive and run `npm test -- --runInBand src/agentMode/backends/codex/codexArchive.test.ts`. Expect the extracted runtime to print CLI help with an isolated HOME/CODEX_HOME and empty PATH.
4. In Codex Configure, apply a supported custom adapter, then clear it. The file must remain on disk. Try an invalid path and a path change during installation; the prior selection must survive rejection. Restart Obsidian and verify device-local ownership and version metadata persist.

## Note

Keep draft until the complete setup flow and supported-platform release checks are reviewed. No browser authentication or authenticated conversation is claimed here.

