### PR TITLE
[Agent Mode] - Step 1: Add the shared managed binary configuration view

### DIFF
--- a/src/agentMode/backends/shared/ui/ManagedBinaryConfigView.stories.tsx
+++ b/src/agentMode/backends/shared/ui/ManagedBinaryConfigView.stories.tsx
@@ -1,0 +1,69 @@
+import {
+  ManagedBinaryConfigView,
+  type ManagedBinarySource,
+  type ManagedBinaryConfigActions,
+  type ManagedBinaryConfigViewProps,
+  type ManagedBinaryInfo,
+} from "@/agentMode/backends/shared/ui/ManagedBinaryConfigView";
+import React from "react";
+import type { Meta, StoryObj } from "@/lib/story";
+
+const ACTIONS: ManagedBinaryConfigActions = {
+  install: () => undefined,
+  cancelInstall: () => undefined,
+  uninstall: () => undefined,
+  upgrade: () => undefined,
+  saveCustomPath: () => Promise.resolve(null),
+  clearCustomPath: () => Promise.resolve(),
+  detectCustomPath: () => Promise.resolve(null),
+};
+
+const MANAGED: ManagedBinaryInfo = {
+  platform: "darwin-arm64",
+  version: "1.10.0",
+  destination: "~/.obsidian-copilot/agent",
+  run: { kind: "idle" },
+};
+
+/**
+ * Every story renders through this stateful wrapper so the gallery can exercise
+ * the source switch for real: `args.source` seeds the first render (keeping each
+ * story's captured state), then clicking a segment swaps the visible branch.
+ */
+const InteractiveConfigView: React.FC<Partial<ManagedBinaryConfigViewProps>> = (props) => {
+  const [source, setSource] = React.useState<ManagedBinarySource>(props.source ?? "managed");
+  return (
+    <ManagedBinaryConfigView
+      {...(props as ManagedBinaryConfigViewProps)}
+      source={source}
+      onSourceChange={setSource}
+    />
+  );
+};
+
+const meta = {
+  title: "Agent Mode/Managed Binary Config View",
+  component: ManagedBinaryConfigView,
+  args: {
+    title: "Configure agent",
+    binaryName: "agent",
+    managedDescription: "Let Copilot download and manage the agent tested for this release.",
+    customDescription: "Point Agent Mode at a binary you already have on disk.",
+    customPathPlaceholder: "/absolute/path/to/agent",
+    customPathNotFoundHint: "No agent found. Apply a custom path or choose Managed by Copilot.",
+    upgradeLabel: "Upgrade to latest",
+    state: { kind: "absent" },
+    source: "managed",
+    onSourceChange: () => undefined,
+    activeSource: null,
+    managed: MANAGED,
+    customPath: "",
+    upgradeRun: { kind: "idle" },
+    actions: ACTIONS,
+    onClose: () => undefined,
+  },
+  parameters: { gallery: { host: "modal", layout: "padded" } },
+} satisfies Meta<ManagedBinaryConfigViewProps>;
+export default meta;
+
+export const SourceTabs: StoryObj<ManagedBinaryConfigViewProps> = { render: InteractiveConfigView };

--- a/src/agentMode/backends/shared/ui/ManagedBinaryConfigView.stories.tsx
+++ b/src/agentMode/backends/shared/ui/ManagedBinaryConfigView.stories.tsx
@@ -132,3 +132,23 @@ export const UpgradeError: StoryObj<ManagedBinaryConfigViewProps> = {
     upgradeRun: { kind: "error", message: "Download failed. Check your connection and try again." },
   },
 };
+
+export const ConfigurationRunning: StoryObj<ManagedBinaryConfigViewProps> = {
+  render: InteractiveConfigView,
+  args: {
+    managed: {
+      ...MANAGED,
+      canCancel: false,
+      run: { kind: "running", label: "Configuring…", percent: 0 },
+    },
+  },
+};
+
+export const RetainedManagedDownloads: StoryObj<ManagedBinaryConfigViewProps> = {
+  render: InteractiveConfigView,
+  args: {
+    activeSource: "custom",
+    state: { kind: "ready", source: "custom" },
+    managed: { ...MANAGED, hasDownloads: true },
+  },
+};

--- a/src/agentMode/backends/shared/ui/ManagedBinaryConfigView.stories.tsx
+++ b/src/agentMode/backends/shared/ui/ManagedBinaryConfigView.stories.tsx
@@ -67,3 +67,68 @@ const meta = {
 export default meta;
 
 export const SourceTabs: StoryObj<ManagedBinaryConfigViewProps> = { render: InteractiveConfigView };
+
+export const ManagedReady: StoryObj<ManagedBinaryConfigViewProps> = {
+  render: InteractiveConfigView,
+  args: { state: { kind: "ready", source: "managed" }, activeSource: "managed" },
+};
+
+export const CustomReady: StoryObj<ManagedBinaryConfigViewProps> = {
+  render: InteractiveConfigView,
+  args: {
+    state: { kind: "ready", source: "custom" },
+    source: "custom",
+    activeSource: "custom",
+    customPath: "/opt/homebrew/bin/agent",
+  },
+};
+
+export const Installing: StoryObj<ManagedBinaryConfigViewProps> = {
+  render: InteractiveConfigView,
+  args: {
+    managed: {
+      ...MANAGED,
+      run: { kind: "running", label: "Extracting archive…", percent: 98 },
+    },
+  },
+};
+
+export const InstallError: StoryObj<ManagedBinaryConfigViewProps> = {
+  render: InteractiveConfigView,
+  args: {
+    managed: {
+      ...MANAGED,
+      run: { kind: "error", message: "The downloaded archive could not be extracted. Try again." },
+    },
+  },
+};
+
+export const Incompatible: StoryObj<ManagedBinaryConfigViewProps> = {
+  render: InteractiveConfigView,
+  args: {
+    activeSource: "managed",
+    state: {
+      kind: "incompatible",
+      source: "managed",
+      currentVersion: "1.0.0",
+      minVersion: MANAGED.version,
+      message: "The installed agent is not supported. Update to the version tested with Copilot.",
+    },
+  },
+};
+
+export const Upgrading: StoryObj<ManagedBinaryConfigViewProps> = {
+  render: InteractiveConfigView,
+  args: {
+    ...Incompatible.args,
+    upgradeRun: { kind: "running", label: "Downloading archive…", percent: 42 },
+  },
+};
+
+export const UpgradeError: StoryObj<ManagedBinaryConfigViewProps> = {
+  render: InteractiveConfigView,
+  args: {
+    ...Incompatible.args,
+    upgradeRun: { kind: "error", message: "Download failed. Check your connection and try again." },
+  },
+};

--- a/src/agentMode/backends/shared/ui/ManagedBinaryConfigView.test.tsx
+++ b/src/agentMode/backends/shared/ui/ManagedBinaryConfigView.test.tsx
@@ -1,0 +1,276 @@
+import type { InstallState } from "@/agentMode/session/types";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import {
+  ManagedBinaryConfigView,
+  type ManagedBinaryConfigActions,
+  type ManagedBinaryConfigViewProps,
+  type ManagedBinaryInfo,
+} from "./ManagedBinaryConfigView";
+
+const MANAGED: ManagedBinaryInfo = {
+  platform: "darwin-arm64",
+  version: "0.15.6",
+  destination: "~/.obsidian-copilot/opencode",
+  run: { kind: "idle" },
+};
+
+const OUTDATED: InstallState = {
+  kind: "incompatible",
+  source: "managed",
+  currentVersion: "0.14.2",
+  minVersion: "0.15.6",
+  message: "opencode v0.14.2 is not supported. Copilot requires opencode v0.15.6 or newer.",
+};
+
+const IN_USE_MANAGED =
+  "The managed binary is in use right now — apply a path here to switch to it.";
+const IN_USE_CUSTOM =
+  "Your own binary is in use right now — download the managed copy to switch to it.";
+
+const makeActions = (): jest.Mocked<ManagedBinaryConfigActions> => ({
+  install: jest.fn(),
+  cancelInstall: jest.fn(),
+  uninstall: jest.fn(),
+  upgrade: jest.fn(),
+  saveCustomPath: jest.fn().mockResolvedValue(null),
+  clearCustomPath: jest.fn().mockResolvedValue(undefined),
+  detectCustomPath: jest.fn().mockResolvedValue(null),
+});
+
+const renderView = (
+  overrides: Partial<ManagedBinaryConfigViewProps> = {}
+): { actions: jest.Mocked<ManagedBinaryConfigActions>; onSourceChange: jest.Mock } => {
+  const actions = overrides.actions ?? makeActions();
+  const onSourceChange = jest.fn();
+  render(
+    <ManagedBinaryConfigView
+      title="Configure opencode"
+      binaryName="opencode"
+      managedDescription="Download opencode."
+      customDescription="Use your own binary."
+      customPathPlaceholder="/absolute/path/to/opencode"
+      customPathNotFoundHint="No binary found."
+      upgradeLabel={
+        overrides.activeSource === "custom" ? "Run opencode upgrade" : "Upgrade to latest"
+      }
+      state={{ kind: "absent" }}
+      source="managed"
+      onSourceChange={onSourceChange}
+      activeSource={null}
+      managed={MANAGED}
+      customPath=""
+      upgradeRun={{ kind: "idle" }}
+      actions={actions}
+      onClose={jest.fn()}
+      {...overrides}
+    />
+  );
+  return { actions: actions as jest.Mocked<ManagedBinaryConfigActions>, onSourceChange };
+};
+
+describe("ManagedBinaryConfigView", () => {
+  describe("ManagedBinaryConfigView()", () => {
+    it("offers the two binary sources as one mutually exclusive choice", () => {
+      renderView();
+
+      const group = screen.getByRole("radiogroup", { name: "opencode binary source" });
+      const options = screen.getAllByRole("radio");
+      expect(group.contains(options[0])).toBe(true);
+      expect(options.map((o) => o.textContent)).toEqual(["Managed by Copilot", "My own binary"]);
+      expect(options.map((o) => o.getAttribute("aria-checked"))).toEqual(["true", "false"]);
+    });
+
+    it("reports a source switch upward without persisting or destroying anything", () => {
+      const { actions, onSourceChange } = renderView({
+        state: { kind: "ready", source: "custom" },
+        activeSource: "custom",
+        customPath: "/opt/homebrew/bin/opencode",
+      });
+
+      fireEvent.click(screen.getByRole("radio", { name: "Managed by Copilot" }));
+
+      expect(onSourceChange).toHaveBeenCalledWith("managed");
+      expect(actions.saveCustomPath).not.toHaveBeenCalled();
+      expect(actions.clearCustomPath).not.toHaveBeenCalled();
+      expect(actions.install).not.toHaveBeenCalled();
+      expect(actions.uninstall).not.toHaveBeenCalled();
+      expect(actions.upgrade).not.toHaveBeenCalled();
+    });
+
+    it("names the active source only when it differs from the source being viewed", () => {
+      renderView({ source: "managed", activeSource: "custom" });
+
+      expect(screen.getByText(IN_USE_CUSTOM)).toBeTruthy();
+      expect(screen.queryByText(IN_USE_MANAGED)).toBeNull();
+    });
+
+    it("names the managed binary when the custom path is being viewed instead", () => {
+      renderView({ source: "custom", activeSource: "managed" });
+
+      expect(screen.getByText(IN_USE_MANAGED)).toBeTruthy();
+      expect(screen.queryByText(IN_USE_CUSTOM)).toBeNull();
+    });
+
+    it("omits the in-use note when the viewed source is the active one", () => {
+      renderView({ source: "managed", activeSource: "managed" });
+
+      expect(screen.queryByText(IN_USE_CUSTOM)).toBeNull();
+      expect(screen.queryByText(IN_USE_MANAGED)).toBeNull();
+    });
+
+    it("omits the in-use note when nothing is installed yet", () => {
+      renderView({ source: "custom", activeSource: null });
+
+      expect(screen.queryByText(IN_USE_MANAGED)).toBeNull();
+      expect(screen.queryByText(IN_USE_CUSTOM)).toBeNull();
+    });
+
+    it("shows the download target and a single install action when nothing is managed yet", () => {
+      const { actions } = renderView();
+
+      expect(screen.getByText("darwin-arm64")).toBeTruthy();
+      expect(screen.getByText("v0.15.6 (pinned)")).toBeTruthy();
+      expect(screen.getByText("~/.obsidian-copilot/opencode")).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Uninstall" })).toBeNull();
+
+      fireEvent.click(screen.getByRole("button", { name: "Download & install" }));
+      expect(actions.install).toHaveBeenCalledTimes(1);
+    });
+
+    it("swaps the install action for Reinstall and Uninstall once the managed copy is in use", () => {
+      const { actions } = renderView({
+        state: { kind: "ready", source: "managed" },
+        activeSource: "managed",
+      });
+
+      expect(screen.queryByRole("button", { name: "Download & install" })).toBeNull();
+      fireEvent.click(screen.getByRole("button", { name: "Reinstall" }));
+      fireEvent.click(screen.getByRole("button", { name: "Uninstall" }));
+
+      expect(actions.install).toHaveBeenCalledTimes(1);
+      expect(actions.uninstall).toHaveBeenCalledTimes(1);
+    });
+
+    it("replaces the managed controls with progress and a Cancel while an install runs", () => {
+      const { actions } = renderView({
+        managed: {
+          ...MANAGED,
+          run: { kind: "running", label: "Extracting archive…", percent: 98 },
+        },
+      });
+
+      expect(screen.getByText("Extracting archive…")).toBeTruthy();
+      expect(screen.getByRole("progressbar")).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Download & install" })).toBeNull();
+
+      fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+      expect(actions.cancelInstall).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps the source choice disabled while a managed install is running", () => {
+      const { onSourceChange } = renderView({
+        managed: {
+          ...MANAGED,
+          run: { kind: "running", label: "Extracting archive…", percent: 98 },
+        },
+      });
+
+      const customSource = screen.getByRole<HTMLButtonElement>("radio", {
+        name: "My own binary",
+      });
+      expect(customSource.disabled).toBe(true);
+      fireEvent.click(customSource);
+      expect(onSourceChange).not.toHaveBeenCalled();
+      expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
+    });
+
+    it("surfaces a failed install without hiding the retry", () => {
+      renderView({ managed: { ...MANAGED, run: { kind: "error", message: "tar exited with 1" } } });
+
+      expect(screen.getByText("tar exited with 1")).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Download & install" })).toBeTruthy();
+    });
+
+    it("renders the path field with Auto-detect and Apply when no custom path is set", async () => {
+      const { actions } = renderView({ source: "custom" });
+
+      const input = screen.getByPlaceholderText<HTMLInputElement>("/absolute/path/to/opencode");
+      expect(input.value).toBe("");
+      expect(screen.queryByRole("button", { name: "Clear" })).toBeNull();
+
+      fireEvent.change(input, { target: { value: "/usr/local/bin/opencode" } });
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+      });
+      expect(actions.saveCustomPath).toHaveBeenCalledWith("/usr/local/bin/opencode");
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Auto-detect" }));
+      });
+      expect(actions.detectCustomPath).toHaveBeenCalledTimes(1);
+    });
+
+    it("offers Clear instead of Apply once a custom path is applied", async () => {
+      const { actions } = renderView({
+        source: "custom",
+        state: { kind: "ready", source: "custom" },
+        activeSource: "custom",
+        customPath: "/opt/homebrew/bin/opencode",
+      });
+
+      expect(
+        screen.getByPlaceholderText<HTMLInputElement>("/absolute/path/to/opencode").value
+      ).toBe("/opt/homebrew/bin/opencode");
+      expect(screen.queryByRole("button", { name: "Apply" })).toBeNull();
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+      });
+      expect(actions.clearCustomPath).toHaveBeenCalledTimes(1);
+    });
+
+    it("surfaces the outdated message with an in-dialog upgrade for the managed binary", () => {
+      const { actions } = renderView({ state: OUTDATED, activeSource: "managed" });
+
+      expect(screen.getByRole("alert").textContent).toContain("is not supported");
+      fireEvent.click(screen.getByRole("button", { name: "Upgrade to latest" }));
+      expect(actions.upgrade).toHaveBeenCalledTimes(1);
+    });
+
+    it("labels the upgrade as the custom binary's own command when that is the active source", () => {
+      renderView({ state: { ...OUTDATED, source: "custom" }, activeSource: "custom" });
+
+      expect(screen.getByRole("button", { name: "Run opencode upgrade" })).toBeTruthy();
+    });
+
+    it("replaces the upgrade button with its progress while the upgrade runs", () => {
+      renderView({
+        state: OUTDATED,
+        activeSource: "managed",
+        upgradeRun: { kind: "running", label: "Resolving platform asset…", percent: 0 },
+      });
+
+      expect(screen.getByText("Resolving platform asset…")).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Upgrade to latest" })).toBeNull();
+    });
+
+    it("keeps the upgrade button beside the reason it failed", () => {
+      renderView({
+        state: OUTDATED,
+        activeSource: "managed",
+        upgradeRun: { kind: "error", message: "GitHub API rate-limited" },
+      });
+
+      expect(screen.getByText("GitHub API rate-limited")).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Upgrade to latest" })).toBeTruthy();
+    });
+
+    it("shows no warning strip while the install state is healthy", () => {
+      renderView({ state: { kind: "ready", source: "managed" }, activeSource: "managed" });
+
+      expect(screen.queryByRole("alert")).toBeNull();
+      expect(screen.getByText("Ready")).toBeTruthy();
+    });
+  });
+});

--- a/src/agentMode/backends/shared/ui/ManagedBinaryConfigView.test.tsx
+++ b/src/agentMode/backends/shared/ui/ManagedBinaryConfigView.test.tsx
@@ -71,7 +71,7 @@ const renderView = (
 
 describe("ManagedBinaryConfigView", () => {
   describe("ManagedBinaryConfigView()", () => {
-    it("offers the two binary sources as one mutually exclusive choice", () => {
+    it("offers the two binary sources as one mutually exclusive choice (https://github.com/Brevilabs/obsidian-copilot-private/issues/368)", () => {
       renderView();
 
       const group = screen.getByRole("radiogroup", { name: "opencode binary source" });
@@ -81,7 +81,7 @@ describe("ManagedBinaryConfigView", () => {
       expect(options.map((o) => o.getAttribute("aria-checked"))).toEqual(["true", "false"]);
     });
 
-    it("reports a source switch upward without persisting or destroying anything", () => {
+    it("reports a source switch upward without persisting or destroying anything (https://github.com/Brevilabs/obsidian-copilot-private/issues/368)", () => {
       const { actions, onSourceChange } = renderView({
         state: { kind: "ready", source: "custom" },
         activeSource: "custom",
@@ -98,35 +98,35 @@ describe("ManagedBinaryConfigView", () => {
       expect(actions.upgrade).not.toHaveBeenCalled();
     });
 
-    it("names the active source only when it differs from the source being viewed", () => {
+    it("names the active source only when it differs from the source being viewed (https://github.com/Brevilabs/obsidian-copilot-private/issues/368)", () => {
       renderView({ source: "managed", activeSource: "custom" });
 
       expect(screen.getByText(IN_USE_CUSTOM)).toBeTruthy();
       expect(screen.queryByText(IN_USE_MANAGED)).toBeNull();
     });
 
-    it("names the managed binary when the custom path is being viewed instead", () => {
+    it("names the managed binary when the custom path is being viewed instead (https://github.com/Brevilabs/obsidian-copilot-private/issues/368)", () => {
       renderView({ source: "custom", activeSource: "managed" });
 
       expect(screen.getByText(IN_USE_MANAGED)).toBeTruthy();
       expect(screen.queryByText(IN_USE_CUSTOM)).toBeNull();
     });
 
-    it("omits the in-use note when the viewed source is the active one", () => {
+    it("omits the in-use note when the viewed source is the active one (https://github.com/Brevilabs/obsidian-copilot-private/issues/368)", () => {
       renderView({ source: "managed", activeSource: "managed" });
 
       expect(screen.queryByText(IN_USE_CUSTOM)).toBeNull();
       expect(screen.queryByText(IN_USE_MANAGED)).toBeNull();
     });
 
-    it("omits the in-use note when nothing is installed yet", () => {
+    it("omits the in-use note when nothing is installed yet (https://github.com/Brevilabs/obsidian-copilot-private/issues/368)", () => {
       renderView({ source: "custom", activeSource: null });
 
       expect(screen.queryByText(IN_USE_MANAGED)).toBeNull();
       expect(screen.queryByText(IN_USE_CUSTOM)).toBeNull();
     });
 
-    it("shows the download target and a single install action when nothing is managed yet", () => {
+    it("shows the download target and a single install action when nothing is managed yet (https://github.com/Brevilabs/obsidian-copilot-private/issues/368)", () => {
       const { actions } = renderView();
 
       expect(screen.getByText("darwin-arm64")).toBeTruthy();
@@ -138,7 +138,7 @@ describe("ManagedBinaryConfigView", () => {
       expect(actions.install).toHaveBeenCalledTimes(1);
     });
 
-    it("swaps the install action for Reinstall and Uninstall once the managed copy is in use", () => {
+    it("swaps the install action for Reinstall and Uninstall once the managed copy is in use (https://github.com/Brevilabs/obsidian-copilot-private/issues/368)", () => {
       const { actions } = renderView({
         state: { kind: "ready", source: "managed" },
         activeSource: "managed",
@@ -152,7 +152,7 @@ describe("ManagedBinaryConfigView", () => {
       expect(actions.uninstall).toHaveBeenCalledTimes(1);
     });
 
-    it("replaces the managed controls with progress and a Cancel while an install runs", () => {
+    it("replaces the managed controls with progress and a Cancel while an install runs (https://github.com/Brevilabs/obsidian-copilot-private/issues/368)", () => {
       const { actions } = renderView({
         managed: {
           ...MANAGED,
@@ -168,7 +168,7 @@ describe("ManagedBinaryConfigView", () => {
       expect(actions.cancelInstall).toHaveBeenCalledTimes(1);
     });
 
-    it("keeps the source choice disabled while a managed install is running", () => {
+    it("keeps the source choice disabled while a managed install is running (https://github.com/Brevilabs/obsidian-copilot-private/issues/368)", () => {
       const { onSourceChange } = renderView({
         managed: {
           ...MANAGED,
@@ -185,14 +185,14 @@ describe("ManagedBinaryConfigView", () => {
       expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
     });
 
-    it("surfaces a failed install without hiding the retry", () => {
+    it("surfaces a failed install without hiding the retry (https://github.com/Brevilabs/obsidian-copilot-private/issues/368)", () => {
       renderView({ managed: { ...MANAGED, run: { kind: "error", message: "tar exited with 1" } } });
 
       expect(screen.getByText("tar exited with 1")).toBeTruthy();
       expect(screen.getByRole("button", { name: "Download & install" })).toBeTruthy();
     });
 
-    it("renders the path field with Auto-detect and Apply when no custom path is set", async () => {
+    it("renders the path field with Auto-detect and Apply when no custom path is set (https://github.com/Brevilabs/obsidian-copilot-private/issues/368)", async () => {
       const { actions } = renderView({ source: "custom" });
 
       const input = screen.getByPlaceholderText<HTMLInputElement>("/absolute/path/to/opencode");
@@ -211,7 +211,7 @@ describe("ManagedBinaryConfigView", () => {
       expect(actions.detectCustomPath).toHaveBeenCalledTimes(1);
     });
 
-    it("offers Clear instead of Apply once a custom path is applied", async () => {
+    it("offers Clear instead of Apply once a custom path is applied (https://github.com/Brevilabs/obsidian-copilot-private/issues/368)", async () => {
       const { actions } = renderView({
         source: "custom",
         state: { kind: "ready", source: "custom" },
@@ -230,7 +230,7 @@ describe("ManagedBinaryConfigView", () => {
       expect(actions.clearCustomPath).toHaveBeenCalledTimes(1);
     });
 
-    it("surfaces the outdated message with an in-dialog upgrade for the managed binary", () => {
+    it("surfaces the outdated message with an in-dialog upgrade for the managed binary (https://github.com/Brevilabs/obsidian-copilot-private/issues/368)", () => {
       const { actions } = renderView({ state: OUTDATED, activeSource: "managed" });
 
       expect(screen.getByRole("alert").textContent).toContain("is not supported");
@@ -238,13 +238,13 @@ describe("ManagedBinaryConfigView", () => {
       expect(actions.upgrade).toHaveBeenCalledTimes(1);
     });
 
-    it("labels the upgrade as the custom binary's own command when that is the active source", () => {
+    it("labels the upgrade as the custom binary's own command when that is the active source (https://github.com/Brevilabs/obsidian-copilot-private/issues/368)", () => {
       renderView({ state: { ...OUTDATED, source: "custom" }, activeSource: "custom" });
 
       expect(screen.getByRole("button", { name: "Run opencode upgrade" })).toBeTruthy();
     });
 
-    it("replaces the upgrade button with its progress while the upgrade runs", () => {
+    it("replaces the upgrade button with its progress while the upgrade runs (https://github.com/Brevilabs/obsidian-copilot-private/issues/368)", () => {
       renderView({
         state: OUTDATED,
         activeSource: "managed",
@@ -255,7 +255,7 @@ describe("ManagedBinaryConfigView", () => {
       expect(screen.queryByRole("button", { name: "Upgrade to latest" })).toBeNull();
     });
 
-    it("keeps the upgrade button beside the reason it failed", () => {
+    it("keeps the upgrade button beside the reason it failed (https://github.com/Brevilabs/obsidian-copilot-private/issues/368)", () => {
       renderView({
         state: OUTDATED,
         activeSource: "managed",
@@ -266,7 +266,7 @@ describe("ManagedBinaryConfigView", () => {
       expect(screen.getByRole("button", { name: "Upgrade to latest" })).toBeTruthy();
     });
 
-    it("shows no warning strip while the install state is healthy", () => {
+    it("shows no warning strip while the install state is healthy (https://github.com/Brevilabs/obsidian-copilot-private/issues/368)", () => {
       renderView({ state: { kind: "ready", source: "managed" }, activeSource: "managed" });
 
       expect(screen.queryByRole("alert")).toBeNull();

--- a/src/agentMode/backends/shared/ui/ManagedBinaryConfigView.test.tsx
+++ b/src/agentMode/backends/shared/ui/ManagedBinaryConfigView.test.tsx
@@ -112,6 +112,32 @@ describe("ManagedBinaryConfigView", () => {
       expect(screen.queryByText(IN_USE_CUSTOM)).toBeNull();
     });
 
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/379 keeps noncancellable configuration progress visible without Cancel", () => {
+      renderView({
+        managed: {
+          ...MANAGED,
+          canCancel: false,
+          run: { kind: "running", label: "Configuring…", percent: 0 },
+        },
+      });
+      expect(screen.getByText("Configuring…")).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+      expect(screen.getByRole<HTMLButtonElement>("radio", { name: "My own binary" }).disabled).toBe(
+        true
+      );
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/379 removes retained downloads without replacing a custom selection", () => {
+      const { actions } = renderView({
+        activeSource: "custom",
+        managed: { ...MANAGED, hasDownloads: true },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Uninstall" }));
+      expect(actions.uninstall).toHaveBeenCalledTimes(1);
+      expect(actions.install).not.toHaveBeenCalled();
+      expect(screen.getByRole("button", { name: "Download & install" })).toBeTruthy();
+    });
+
     it("omits the in-use note when the viewed source is the active one (https://github.com/Brevilabs/obsidian-copilot-private/issues/368)", () => {
       renderView({ source: "managed", activeSource: "managed" });
 

--- a/src/agentMode/backends/shared/ui/ManagedBinaryConfigView.tsx
+++ b/src/agentMode/backends/shared/ui/ManagedBinaryConfigView.tsx
@@ -1,0 +1,262 @@
+import { BinaryPathSetting } from "@/agentMode/backends/shared/BinaryPathSetting";
+import {
+  ConfigDialogShell,
+  ConfigSection,
+  ConfigWarningStrip,
+} from "@/agentMode/backends/shared/ui/ConfigDialogShell";
+import type { InstallState } from "@/agentMode/session/types";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { SegmentedControl, type SegmentedControlOption } from "@/components/ui/segmented-control";
+import { cn } from "@/lib/utils";
+import React from "react";
+
+/** Which of the two setup paths a binary came from. Mirrors the persisted `binarySource`. */
+export type ManagedBinarySource = "managed" | "custom";
+
+/**
+ * Display-ready progress of a long-running binary-manager call. The container
+ * pre-formats the label and percentage so this view never has to interpret a
+ * manager `ProgressEvent`.
+ */
+export type ManagedBinaryRunState =
+  | { kind: "idle" }
+  | { kind: "running"; label: string; percent: number }
+  | { kind: "error"; message: string };
+
+/** What the managed download would install here, plus any install in flight. */
+export interface ManagedBinaryInfo {
+  /** Host target the pinned release asset is picked for, e.g. `darwin-arm64`. */
+  platform: string;
+  /** Pinned binary version the managed download installs. */
+  version: string;
+  /** Display-formatted install root. */
+  destination: string;
+  run: ManagedBinaryRunState;
+}
+
+/** Every side effect the dialog can trigger, supplied by the container so the view stays pure. */
+export interface ManagedBinaryConfigActions {
+  /** Download and install the pinned managed binary; also backs Reinstall. */
+  install: () => void;
+  /** Abort an install in flight. */
+  cancelInstall: () => void;
+  /** Reclaim every downloaded managed copy. Owns its own confirmation step. */
+  uninstall: () => void;
+  /** Upgrade whichever binary is active — the managed download or the user's own. */
+  upgrade: () => void;
+  /** Validate and persist a user-supplied path. Resolves to an error message, or null on success. */
+  saveCustomPath: (path: string) => Promise<string | null>;
+  /** Forget the user-supplied path. */
+  clearCustomPath: () => Promise<void>;
+  /** Look for a binary already present on this machine. */
+  detectCustomPath: () => Promise<string | null>;
+}
+
+export interface ManagedBinaryConfigProps {
+  /** Readiness of the configured binary; drives the header badge and the warning strip. */
+  state: InstallState;
+  /**
+   * The setup path currently being viewed. Local view state: switching it shows
+   * the other path's controls and persists nothing.
+   */
+  source: ManagedBinarySource;
+  onSourceChange: (source: ManagedBinarySource) => void;
+  /** Source of the binary actually in use, or null when none is installed. */
+  activeSource: ManagedBinarySource | null;
+  managed: ManagedBinaryInfo;
+  /** Persisted custom binary path; empty when the active install isn't a custom one. */
+  customPath: string;
+  /** Progress/error of the in-dialog upgrade offered by the warning strip. */
+  upgradeRun: ManagedBinaryRunState;
+  actions: ManagedBinaryConfigActions;
+  onClose: () => void;
+  searchedDirs?: () => string[];
+}
+
+export interface ManagedBinaryConfigViewProps extends ManagedBinaryConfigProps {
+  title: string;
+  binaryName: string;
+  managedDescription: React.ReactNode;
+  customDescription: React.ReactNode;
+  customPathPlaceholder: string;
+  customPathNotFoundHint: string;
+  upgradeLabel: string;
+  children?: React.ReactNode;
+}
+
+const SOURCE_OPTIONS: SegmentedControlOption<ManagedBinarySource>[] = [
+  { label: "Managed by Copilot", value: "managed" },
+  { label: "My own binary", value: "custom" },
+];
+
+/**
+ * The managed-download body: what would be installed where, and the buttons that
+ * act on it. Renders the download progress and its Cancel while an install runs.
+ */
+interface ManagedBinaryInstallProps {
+  managed: ManagedBinaryInfo;
+  /** Whether the managed copy is the binary in use, which is what turns Install into Reinstall. */
+  installed: boolean;
+  actions: ManagedBinaryConfigActions;
+}
+
+const ManagedBinaryInstall: React.FC<ManagedBinaryInstallProps> = ({
+  managed,
+  installed,
+  actions,
+}) => {
+  const { run } = managed;
+
+  if (run.kind === "running") {
+    return (
+      <div className="tw-flex tw-flex-col tw-gap-2">
+        <p className="tw-my-0 tw-text-sm">{run.label}</p>
+        <Progress value={run.percent} />
+        <div className="tw-flex tw-justify-end">
+          <Button variant="ghost" size="default" onClick={actions.cancelInstall}>
+            Cancel
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="tw-flex tw-flex-col tw-gap-2">
+      {/* Preflight is off, so the browser's own `dl` margins and 40px `dd` indent
+          would survive and push the values out of their grid track. */}
+      <dl className="tw-my-0 tw-grid tw-grid-cols-[max-content_1fr] tw-gap-x-4 tw-gap-y-1 tw-text-sm [&>dd]:tw-ml-0">
+        <dt className="tw-text-muted">Platform</dt>
+        <dd className="tw-font-mono">{managed.platform}</dd>
+        <dt className="tw-text-muted">Version</dt>
+        <dd className="tw-font-mono">v{managed.version} (pinned)</dd>
+        <dt className="tw-text-muted">Destination</dt>
+        <dd className="tw-break-all tw-font-mono tw-text-xs">{managed.destination}</dd>
+      </dl>
+      {run.kind === "error" && (
+        <pre className="tw-my-0 tw-max-h-32 tw-overflow-auto tw-whitespace-pre-wrap tw-rounded tw-bg-secondary tw-p-2 tw-text-xs tw-text-error">
+          {run.message}
+        </pre>
+      )}
+      <div className="tw-flex tw-justify-end tw-gap-2">
+        {installed ? (
+          <>
+            <Button variant="secondary" size="default" onClick={actions.install}>
+              Reinstall
+            </Button>
+            <Button variant="destructive" size="default" onClick={actions.uninstall}>
+              Uninstall
+            </Button>
+          </>
+        ) : (
+          <Button variant="default" size="default" onClick={actions.install}>
+            Download &amp; install
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Shared managed/custom configuration body. The selected tab only chooses which
+ * controls are visible; containers own installation, path changes, and notices.
+ */
+export const ManagedBinaryConfigView: React.FC<ManagedBinaryConfigViewProps> = ({
+  state,
+  source,
+  onSourceChange,
+  activeSource,
+  managed,
+  customPath,
+  upgradeRun,
+  actions,
+  onClose,
+  title,
+  binaryName,
+  managedDescription,
+  customDescription,
+  customPathPlaceholder,
+  customPathNotFoundHint,
+  searchedDirs,
+  upgradeLabel,
+  children,
+}) => (
+  <ConfigDialogShell
+    title={title}
+    state={state}
+    warning={
+      <ConfigWarningStrip
+        state={state}
+        action={
+          upgradeRun.kind === "running" ? (
+            <>
+              <p className="tw-my-0 tw-text-xs">{upgradeRun.label}</p>
+              <Progress value={upgradeRun.percent} />
+            </>
+          ) : (
+            <div className="tw-flex tw-items-center tw-justify-end tw-gap-2">
+              {upgradeRun.kind === "error" && (
+                <span className="tw-text-xs tw-text-error">{upgradeRun.message}</span>
+              )}
+              <Button variant="default" size="sm" onClick={actions.upgrade}>
+                {upgradeLabel}
+              </Button>
+            </div>
+          )
+        }
+      />
+    }
+    onClose={onClose}
+  >
+    <ConfigSection>
+      <SegmentedControl
+        aria-label={`${binaryName} binary source`}
+        // Flex items are blockified, which would stretch the control across the
+        // band and leave the segments floating in an empty track.
+        className={cn("tw-self-start")}
+        options={SOURCE_OPTIONS}
+        value={source}
+        onChange={onSourceChange}
+        disabled={managed.run.kind === "running"}
+      />
+      {source === "managed" ? (
+        <>
+          <p className="tw-my-0 tw-text-sm tw-text-muted">{managedDescription}</p>
+          {activeSource === "custom" && (
+            <p className="tw-my-0 tw-text-sm tw-text-muted">
+              Your own binary is in use right now — download the managed copy to switch to it.
+            </p>
+          )}
+          <ManagedBinaryInstall
+            managed={managed}
+            installed={activeSource === "managed"}
+            actions={actions}
+          />
+        </>
+      ) : (
+        <>
+          <p className="tw-my-0 tw-text-sm tw-text-muted">{customDescription}</p>
+          {activeSource === "managed" && (
+            <p className="tw-my-0 tw-text-sm tw-text-muted">
+              The managed binary is in use right now — apply a path here to switch to it.
+            </p>
+          )}
+          <BinaryPathSetting
+            binaryName={binaryName}
+            placeholder={customPathPlaceholder}
+            initialPath={customPath}
+            notFoundHint={customPathNotFoundHint}
+            onSave={actions.saveCustomPath}
+            onClear={actions.clearCustomPath}
+            persistOnAutoDetect
+            detect={actions.detectCustomPath}
+            searchedDirs={searchedDirs}
+          />
+        </>
+      )}
+    </ConfigSection>
+    {children}
+  </ConfigDialogShell>
+);

--- a/src/agentMode/backends/shared/ui/ManagedBinaryConfigView.tsx
+++ b/src/agentMode/backends/shared/ui/ManagedBinaryConfigView.tsx
@@ -33,6 +33,10 @@ export interface ManagedBinaryInfo {
   /** Display-formatted install root. */
   destination: string;
   run: ManagedBinaryRunState;
+  /** Whether this operation supports cancellation. Defaults to true. */
+  canCancel?: boolean;
+  /** Retained managed files may exist while a custom binary is active. */
+  hasDownloads?: boolean;
 }
 
 /** Every side effect the dialog can trigger, supplied by the container so the view stays pure. */
@@ -115,11 +119,15 @@ const ManagedBinaryInstall: React.FC<ManagedBinaryInstallProps> = ({
       <div className="tw-flex tw-flex-col tw-gap-2">
         <p className="tw-my-0 tw-text-sm">{run.label}</p>
         <Progress value={run.percent} />
-        <div className="tw-flex tw-justify-end">
-          <Button variant="ghost" size="default" onClick={actions.cancelInstall}>
-            Cancel
-          </Button>
-        </div>
+        {/* Configuration operations hold the lock but cannot safely be interrupted.
+            https://github.com/Brevilabs/obsidian-copilot-private/issues/379 */}
+        {managed.canCancel !== false && (
+          <div className="tw-flex tw-justify-end">
+            <Button variant="ghost" size="default" onClick={actions.cancelInstall}>
+              Cancel
+            </Button>
+          </div>
+        )}
       </div>
     );
   }
@@ -144,20 +152,18 @@ const ManagedBinaryInstall: React.FC<ManagedBinaryInstallProps> = ({
         </pre>
       )}
       <div className="tw-flex tw-justify-end tw-gap-2">
-        {/* Only an active managed installation offers destructive removal.
-            https://github.com/Brevilabs/obsidian-copilot-private/issues/368 */}
-        {installed ? (
-          <>
-            <Button variant="secondary" size="default" onClick={actions.install}>
-              Reinstall
-            </Button>
-            <Button variant="destructive" size="default" onClick={actions.uninstall}>
-              Uninstall
-            </Button>
-          </>
-        ) : (
-          <Button variant="default" size="default" onClick={actions.install}>
-            Download &amp; install
+        <Button
+          variant={installed ? "secondary" : "default"}
+          size="default"
+          onClick={actions.install}
+        >
+          {installed ? "Reinstall" : "Download & install"}
+        </Button>
+        {/* Switching to a custom binary must not hide removal of retained downloads.
+            https://github.com/Brevilabs/obsidian-copilot-private/issues/379 */}
+        {(managed.hasDownloads ?? installed) && (
+          <Button variant="destructive" size="default" onClick={actions.uninstall}>
+            Uninstall
           </Button>
         )}
       </div>

--- a/src/agentMode/backends/shared/ui/ManagedBinaryConfigView.tsx
+++ b/src/agentMode/backends/shared/ui/ManagedBinaryConfigView.tsx
@@ -108,6 +108,8 @@ const ManagedBinaryInstall: React.FC<ManagedBinaryInstallProps> = ({
 }) => {
   const { run } = managed;
 
+  // Keep cancellation available while the shared installer owns the operation.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/368
   if (run.kind === "running") {
     return (
       <div className="tw-flex tw-flex-col tw-gap-2">
@@ -134,12 +136,16 @@ const ManagedBinaryInstall: React.FC<ManagedBinaryInstallProps> = ({
         <dt className="tw-text-muted">Destination</dt>
         <dd className="tw-break-all tw-font-mono tw-text-xs">{managed.destination}</dd>
       </dl>
+      {/* Failed downloads must leave their explanation beside the retry action.
+          https://github.com/Brevilabs/obsidian-copilot-private/issues/368 */}
       {run.kind === "error" && (
         <pre className="tw-my-0 tw-max-h-32 tw-overflow-auto tw-whitespace-pre-wrap tw-rounded tw-bg-secondary tw-p-2 tw-text-xs tw-text-error">
           {run.message}
         </pre>
       )}
       <div className="tw-flex tw-justify-end tw-gap-2">
+        {/* Only an active managed installation offers destructive removal.
+            https://github.com/Brevilabs/obsidian-copilot-private/issues/368 */}
         {installed ? (
           <>
             <Button variant="secondary" size="default" onClick={actions.install}>
@@ -189,6 +195,8 @@ export const ManagedBinaryConfigView: React.FC<ManagedBinaryConfigViewProps> = (
     warning={
       <ConfigWarningStrip
         state={state}
+        // Keep update progress and failures attached to the shared warning.
+        // https://github.com/Brevilabs/obsidian-copilot-private/issues/368
         action={
           upgradeRun.kind === "running" ? (
             <>
@@ -219,8 +227,12 @@ export const ManagedBinaryConfigView: React.FC<ManagedBinaryConfigViewProps> = (
         options={SOURCE_OPTIONS}
         value={source}
         onChange={onSourceChange}
+        // Prevent path edits from competing with the running install.
+        // https://github.com/Brevilabs/obsidian-copilot-private/issues/368
         disabled={managed.run.kind === "running"}
       />
+      {/* Switching setup paths must not change ownership until an action succeeds.
+          https://github.com/Brevilabs/obsidian-copilot-private/issues/368 */}
       {source === "managed" ? (
         <>
           <p className="tw-my-0 tw-text-sm tw-text-muted">{managedDescription}</p>


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#368

## Why

OpenCode's managed and custom binary controls need to be reused by Codex without duplicating their behavior.

## What

Provide the existing controls as a shared, props-driven view with gallery fixtures and unit coverage. Production dialogs keep their current implementation until they adopt the view.

## Non goal

No backend adoption, installation policy, settings writes, or authentication changes.

## Screenshot

No production visual change. The gallery fixture exposes the extracted controls.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Shared-view tests cover tabs, progress, warnings, and action routing. |
| A defect would fail CI or be obvious on first use | ✅ | Deterministic view tests exercise visible controls. |
| A revert fully restores prior state, including persisted data | ✅ | No settings or downloaded files change. |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | The caller retains validation and side effects. |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Only an internal React prop contract is added. |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | No runtime subscriptions or operations change. |
| No hot-path behavior lacks deterministic coverage | ✅ | Source switching and action callbacks are tested. |
| No new dependency | ✅ | No dependency changes. |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | The gallery exposes each configuration state. |

Review: Inspect the shared gallery fixture and run Verification 1-2.

## Verification

1. Open the component gallery's Managed Binary Config View / SourceTabs fixture at 300 and 600px. Switch the tabs; each should show only its own controls.
2. Run the adjacent ManagedBinaryConfigView tests. Confirm install, cancel, uninstall, upgrade, and custom-path callbacks route to the supplied actions.
