### PR TITLE
[Agent Mode] - Step 3: Add the shared managed binary lifecycle

### DIFF
--- a/src/agentMode/backends/shared/ManagedBinaryManager.test.ts
+++ b/src/agentMode/backends/shared/ManagedBinaryManager.test.ts
@@ -1,0 +1,233 @@
+import {
+  ManagedBinaryManager,
+  type BinarySettings,
+  type InstalledBinary,
+  type ManagedBinaryInstallOptions,
+} from "@/agentMode/backends/shared/ManagedBinaryManager";
+import {
+  ManagedInstallAbortError,
+  ManagedInstallOperationInFlightError,
+} from "@/agentMode/backends/shared/managedInstall";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+jest.mock("@/logger", () => ({ logInfo: jest.fn(), logWarn: jest.fn(), logError: jest.fn() }));
+
+class TestBinaryManager extends ManagedBinaryManager<number> {
+  settings: BinarySettings = {};
+  validate = jest.fn(async (binaryPath: string) => ({ version: "1.2.3", path: binaryPath }));
+  pipeline = jest.fn(
+    async (options: ManagedBinaryInstallOptions<number> & { signal: AbortSignal }) => {
+      options.onProgress?.(50);
+      return { version: "1.2.3", path: "/managed/binary" };
+    }
+  );
+
+  constructor(private dataDir: string) {
+    super("Test agent");
+  }
+  getDataDir(): string {
+    return this.dataDir;
+  }
+  protected readBinarySettings(): BinarySettings {
+    return this.settings;
+  }
+  protected updateBinarySettings(settings: BinarySettings): void {
+    this.settings = settings;
+  }
+  protected validateCustomBinary(binaryPath: string): Promise<InstalledBinary> {
+    return this.validate(binaryPath);
+  }
+  protected installPipeline(
+    options: ManagedBinaryInstallOptions<number> & { signal: AbortSignal }
+  ): Promise<InstalledBinary> {
+    return this.pipeline(options);
+  }
+}
+
+describe("ManagedBinaryManager", () => {
+  describe("ManagedBinaryManager", () => {
+    let tempDir: string;
+    let manager: TestBinaryManager;
+    let customPath: string;
+
+    beforeEach(() => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "managed-binary-test-"));
+      manager = new TestBinaryManager(path.join(tempDir, "managed"));
+      customPath = path.join(tempDir, "custom-binary");
+      fs.writeFileSync(customPath, "binary", { mode: 0o755 });
+    });
+    afterEach(() => fs.rmSync(tempDir, { recursive: true, force: true }));
+
+    describe("getRuntimeState()", () => {
+      it("keeps the idle snapshot stable between reads", () => {
+        expect(manager.getRuntimeState()).toEqual({ kind: "idle" });
+        expect(manager.getRuntimeState()).toBe(manager.getRuntimeState());
+      });
+    });
+    describe("subscribeRuntimeState()", () => {
+      it("publishes operation changes until unsubscribed", async () => {
+        const listener = jest.fn();
+        const unsubscribe = manager.subscribeRuntimeState(listener);
+        await manager.setCustomBinaryPath(null);
+        expect(listener).toHaveBeenCalledTimes(2);
+        unsubscribe();
+        await manager.setCustomBinaryPath(null);
+        expect(listener).toHaveBeenCalledTimes(2);
+      });
+    });
+    describe("install()", () => {
+      it("https://github.com/Brevilabs/obsidian-copilot-private/issues/368 publishes backend progress, returns the installation, and ignores progress after completion", async () => {
+        const progress = jest.fn();
+        const snapshots: unknown[] = [];
+        manager.subscribeRuntimeState(() => snapshots.push(manager.getRuntimeState()));
+        await expect(manager.install({ onProgress: progress })).resolves.toEqual({
+          version: "1.2.3",
+          path: "/managed/binary",
+        });
+        expect(progress).toHaveBeenCalledWith(50);
+        const idle = manager.getRuntimeState();
+        manager.pipeline.mock.calls[0][0].onProgress?.(75);
+        expect(manager.getRuntimeState()).toBe(idle);
+        expect(snapshots).toEqual([
+          { kind: "installing", progress: null },
+          { kind: "installing", progress: 50 },
+          { kind: "idle" },
+        ]);
+      });
+      it("https://github.com/Brevilabs/obsidian-copilot-private/issues/368 prevents custom selection and removal from overwriting a running install", async () => {
+        let finish!: (value: InstalledBinary) => void;
+        manager.pipeline.mockImplementationOnce(() => new Promise((resolve) => (finish = resolve)));
+        const installing = manager.install();
+        await expect(manager.setCustomBinaryPath(null)).rejects.toBeInstanceOf(
+          ManagedInstallOperationInFlightError
+        );
+        await expect(manager.uninstall()).rejects.toBeInstanceOf(
+          ManagedInstallOperationInFlightError
+        );
+        expect(manager.getRuntimeState()).toEqual({ kind: "installing", progress: null });
+        finish({ version: "1.2.3", path: "/managed/binary" });
+        await installing;
+      });
+    });
+    describe("isBusy()", () => {
+      it("holds the lock until custom validation settles", async () => {
+        expect(manager.isBusy()).toBe(false);
+        const selecting = manager.setCustomBinaryPath(customPath);
+        expect(manager.isBusy()).toBe(true);
+        await selecting;
+        expect(manager.isBusy()).toBe(false);
+      });
+    });
+    describe("cancelCurrentOperation()", () => {
+      it("https://github.com/Brevilabs/obsidian-copilot-private/issues/368 aborts installation and leaves no retry error", async () => {
+        manager.pipeline.mockImplementationOnce(
+          ({ signal }) =>
+            new Promise((_resolve, reject) => {
+              signal.addEventListener("abort", () => reject(new ManagedInstallAbortError()));
+            })
+        );
+        const installing = manager.install();
+        manager.cancelCurrentOperation();
+        await expect(installing).rejects.toThrow("Aborted");
+        expect(manager.getRuntimeState()).toEqual({ kind: "idle" });
+        expect(manager.isBusy()).toBe(false);
+        manager.cancelCurrentOperation();
+      });
+    });
+    describe("forgetSettledError()", () => {
+      it("clears a prior failure so a reopened lifecycle starts idle", async () => {
+        manager.pipeline.mockRejectedValueOnce(new Error("failed"));
+        await expect(manager.install()).rejects.toThrow("failed");
+        expect(manager.getRuntimeState()).toEqual({ kind: "error", message: "failed" });
+        manager.forgetSettledError();
+        expect(manager.getRuntimeState()).toEqual({ kind: "idle" });
+      });
+    });
+    describe("downloadsSize()", () => {
+      it("counts nested downloaded files and excludes external custom binaries", async () => {
+        const nested = path.join(manager.getDataDir(), "1.2.3");
+        fs.mkdirSync(nested, { recursive: true });
+        fs.writeFileSync(path.join(nested, "binary"), "12345");
+        fs.writeFileSync(path.join(manager.getDataDir(), "manifest"), "123");
+        await expect(manager.downloadsSize()).resolves.toBe(8);
+      });
+      it("reports zero before any managed package is installed", async () => {
+        await expect(manager.downloadsSize()).resolves.toBe(0);
+      });
+    });
+    describe("uninstall()", () => {
+      it("https://github.com/Brevilabs/obsidian-copilot-private/issues/368 removes all managed versions and clears the managed selection", async () => {
+        fs.mkdirSync(path.join(manager.getDataDir(), "1.2.3"), { recursive: true });
+        manager.settings = {
+          binaryPath: "/managed/binary",
+          binaryVersion: "1.2.3",
+          binarySource: "managed",
+        };
+        await manager.uninstall();
+        expect(fs.existsSync(manager.getDataDir())).toBe(false);
+        expect(fs.existsSync(customPath)).toBe(true);
+        expect(manager.settings).toEqual({
+          binaryPath: undefined,
+          binaryVersion: undefined,
+          binarySource: undefined,
+        });
+      });
+      it("https://github.com/Brevilabs/obsidian-copilot-private/issues/368 preserves the selected custom binary while reclaiming downloads", async () => {
+        fs.mkdirSync(manager.getDataDir(), { recursive: true });
+        await manager.setCustomBinaryPath(customPath);
+        const selected = manager.settings;
+        await manager.uninstall();
+        expect(fs.existsSync(manager.getDataDir())).toBe(false);
+        expect(fs.existsSync(customPath)).toBe(true);
+        expect(manager.settings).toEqual(selected);
+      });
+    });
+    describe("setCustomBinaryPath()", () => {
+      it("validates a custom executable and persists the backend-reported version", async () => {
+        await manager.setCustomBinaryPath(customPath);
+        expect(manager.validate).toHaveBeenCalledWith(customPath);
+        expect(manager.settings).toEqual({
+          binaryPath: customPath,
+          binaryVersion: "1.2.3",
+          binarySource: "custom",
+        });
+      });
+      it("https://github.com/Brevilabs/obsidian-copilot-private/issues/368 clears a selection without deleting its files", async () => {
+        await manager.setCustomBinaryPath(customPath);
+        await manager.setCustomBinaryPath(null);
+        expect(manager.settings.binaryPath).toBeUndefined();
+        expect(fs.existsSync(customPath)).toBe(true);
+      });
+      it.each([
+        "missing",
+        "directory",
+        ...(process.platform === "win32" ? [] : ["not-executable"]),
+      ])(
+        "https://github.com/Brevilabs/obsidian-copilot-private/issues/368 rejects a %s path without replacing the current selection",
+        async (kind) => {
+          const candidate = path.join(tempDir, kind);
+          if (kind === "directory") fs.mkdirSync(candidate);
+          if (kind === "not-executable") fs.writeFileSync(candidate, "", { mode: 0o644 });
+          manager.settings = {
+            binaryPath: customPath,
+            binaryVersion: "1.2.3",
+            binarySource: "custom",
+          };
+          await expect(manager.setCustomBinaryPath(candidate)).rejects.toThrow();
+          expect(manager.settings.binaryPath).toBe(customPath);
+          expect(manager.validate).not.toHaveBeenCalled();
+        }
+      );
+      it("keeps the configured binary when backend version validation fails", async () => {
+        manager.settings = { binaryPath: "/previous" };
+        manager.validate.mockRejectedValueOnce(new Error("unsupported version"));
+        await expect(manager.setCustomBinaryPath(customPath)).rejects.toThrow(
+          "unsupported version"
+        );
+        expect(manager.settings.binaryPath).toBe("/previous");
+      });
+    });
+  });
+});

--- a/src/agentMode/backends/shared/ManagedBinaryManager.test.ts
+++ b/src/agentMode/backends/shared/ManagedBinaryManager.test.ts
@@ -137,7 +137,21 @@ describe("ManagedBinaryManager", () => {
       });
     });
     describe("forgetSettledError()", () => {
-      it("clears a prior failure so a reopened lifecycle starts idle", async () => {
+      it("https://github.com/Brevilabs/obsidian-copilot-private/issues/368 preserves idle and running snapshots when a lifecycle reopens", async () => {
+        const idle = manager.getRuntimeState();
+        manager.forgetSettledError();
+        expect(manager.getRuntimeState()).toBe(idle);
+        let finish!: (value: InstalledBinary) => void;
+        manager.pipeline.mockImplementationOnce(() => new Promise((resolve) => (finish = resolve)));
+        const installing = manager.install();
+        const running = manager.getRuntimeState();
+        manager.forgetSettledError();
+        expect(manager.getRuntimeState()).toBe(running);
+        expect(manager.isBusy()).toBe(true);
+        finish({ version: "1.2.3", path: "/managed/binary" });
+        await installing;
+      });
+      it("https://github.com/Brevilabs/obsidian-copilot-private/issues/368 clears a prior failure so a reopened lifecycle starts idle", async () => {
         manager.pipeline.mockRejectedValueOnce(new Error("failed"));
         await expect(manager.install()).rejects.toThrow("failed");
         expect(manager.getRuntimeState()).toEqual({ kind: "error", message: "failed" });

--- a/src/agentMode/backends/shared/ManagedBinaryManager.ts
+++ b/src/agentMode/backends/shared/ManagedBinaryManager.ts
@@ -1,0 +1,212 @@
+import {
+  ManagedInstallAbortError,
+  ManagedInstallOperationInFlightError,
+  type ManagedInstallRuntimeState,
+} from "@/agentMode/backends/shared/managedInstall";
+import { requireNodeModule } from "@/utils/desktopRuntime";
+import { validateExecutableFile } from "@/utils/detectBinary";
+
+export interface BinarySettings {
+  binaryPath?: string;
+  binaryVersion?: string;
+  binarySource?: "managed" | "custom";
+}
+
+export interface InstalledBinary {
+  version: string;
+  path: string;
+}
+
+export interface ManagedBinaryInstallOptions<TProgress> {
+  onProgress?: (progress: TProgress) => void;
+}
+
+/**
+ * Coordinates installation, custom selection, and removal under one process-local
+ * write lock. Backends own package acquisition, version validation, and settings.
+ */
+export abstract class ManagedBinaryManager<
+  TProgress,
+  TOptions extends ManagedBinaryInstallOptions<TProgress> = ManagedBinaryInstallOptions<TProgress>,
+> {
+  private operation: AbortController | null = null;
+  private runtimeState: ManagedInstallRuntimeState<TProgress> = { kind: "idle" };
+  private readonly subscribers = new Set<() => void>();
+
+  constructor(private readonly displayName: string) {}
+
+  readonly subscribeRuntimeState = (onChange: () => void): (() => void) => {
+    this.subscribers.add(onChange);
+    return () => {
+      this.subscribers.delete(onChange);
+    };
+  };
+
+  readonly getRuntimeState = (): ManagedInstallRuntimeState<TProgress> => this.runtimeState;
+
+  private publishState(next: ManagedInstallRuntimeState<TProgress>): void {
+    this.runtimeState = next;
+    this.subscribers.forEach((notify) => notify());
+  }
+
+  /** Clears a completed failure when a new plugin lifecycle adopts this manager. */
+  forgetSettledError(): void {
+    if (this.operation || this.runtimeState.kind !== "error") return;
+    this.publishState({ kind: "idle" });
+  }
+
+  isBusy(): boolean {
+    return this.operation !== null;
+  }
+
+  cancelCurrentOperation(): void {
+    this.operation?.abort();
+  }
+
+  protected publishProgress(progress: TProgress): void {
+    // Late progress must not return a completed installation to the running state.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/368
+    if (!this.operation) return;
+    this.publishState({ kind: "installing", progress });
+  }
+
+  protected async runExclusive<T>(
+    running: ManagedInstallRuntimeState<TProgress>,
+    body: (signal: AbortSignal) => Promise<T>
+  ): Promise<T> {
+    // Reject a competing writer while every surface observes the active run.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/368
+    if (this.operation) throw new ManagedInstallOperationInFlightError(this.displayName);
+    const controller = new AbortController();
+    this.operation = controller;
+    this.publishState(running);
+    try {
+      const result = await body(controller.signal);
+      this.operation = null;
+      this.publishState({ kind: "idle" });
+      return result;
+    } catch (error) {
+      this.operation = null;
+      if (
+        error instanceof ManagedInstallAbortError ||
+        (error as Error | undefined)?.name === "AbortError"
+      ) {
+        // Cancellation should not leave subscribed surfaces asking for Retry.
+        // https://github.com/Brevilabs/obsidian-copilot-private/issues/368
+        this.publishState({ kind: "idle" });
+      } else {
+        this.publishState({
+          kind: "error",
+          message: error instanceof Error ? error.message : String(error),
+        });
+      }
+      throw error;
+    }
+  }
+
+  abstract getDataDir(): string;
+  protected abstract readBinarySettings(): BinarySettings;
+  protected abstract updateBinarySettings(settings: BinarySettings): void;
+  protected abstract validateCustomBinary(binaryPath: string): Promise<InstalledBinary>;
+  protected abstract installPipeline(
+    options: TOptions & { signal: AbortSignal }
+  ): Promise<InstalledBinary>;
+
+  /**
+   * Installs the backend package while preventing competing binary selection or removal.
+   * @param options - Backend installation options and an optional progress observer.
+   */
+  async install(options: TOptions = {} as TOptions): Promise<InstalledBinary> {
+    return this.runExclusive({ kind: "installing", progress: null }, (signal) =>
+      this.installPipeline({
+        ...options,
+        signal,
+        onProgress: (progress: TProgress) => {
+          this.publishProgress(progress);
+          options.onProgress?.(progress);
+        },
+      })
+    );
+  }
+
+  protected reclaimableDirs(): string[] {
+    return [this.getDataDir()];
+  }
+
+  /** Total disk space reclaimed by uninstall, including backend-owned legacy installs. */
+  async downloadsSize(): Promise<number> {
+    const sizes = await Promise.all(this.reclaimableDirs().map(dirSize));
+    return sizes.reduce((total, size) => total + size, 0);
+  }
+
+  /** Removes managed downloads and preserves a user-selected custom installation. */
+  async uninstall(): Promise<void> {
+    return this.runExclusive({ kind: "busy" }, async () => {
+      const fs = requireNodeModule<typeof import("node:fs")>("fs");
+      await Promise.all(
+        this.reclaimableDirs().map((dir) => fs.promises.rm(dir, { recursive: true, force: true }))
+      );
+      // Custom executables belong to the user; removing downloads must not disconnect them.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/368
+      if (this.readBinarySettings().binarySource !== "custom") this.clearBinarySettings();
+    });
+  }
+
+  /**
+   * Validates and selects a custom executable without removing managed downloads.
+   * @param binaryPath - Executable to select, or null to clear the configured selection.
+   */
+  async setCustomBinaryPath(binaryPath: string | null): Promise<void> {
+    return this.runExclusive({ kind: "busy" }, () => this.writeCustomBinaryPath(binaryPath));
+  }
+
+  protected async writeCustomBinaryPath(binaryPath: string | null): Promise<void> {
+    // Clearing a selection must leave both user-owned files and downloaded versions intact.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/368
+    if (binaryPath === null) {
+      this.clearBinarySettings();
+      return;
+    }
+    const error = await validateExecutableFile(binaryPath);
+    // Catch invalid paths before persisting a configuration that cannot launch.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/368
+    if (error) throw new Error(error);
+    const installed = await this.validateCustomBinary(binaryPath);
+    this.updateBinarySettings({
+      binaryPath: installed.path,
+      binaryVersion: installed.version,
+      binarySource: "custom",
+    });
+  }
+
+  protected clearBinarySettings(): void {
+    this.updateBinarySettings({
+      binaryPath: undefined,
+      binaryVersion: undefined,
+      binarySource: undefined,
+    });
+  }
+}
+
+async function dirSize(dir: string): Promise<number> {
+  const fs = requireNodeModule<typeof import("node:fs")>("fs");
+  const path = requireNodeModule<typeof import("node:path")>("path");
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await fs.promises.readdir(dir, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+  let total = 0;
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) total += await dirSize(full);
+    else if (entry.isFile()) {
+      total += await fs.promises.stat(full).then(
+        (stat) => stat.size,
+        () => 0
+      );
+    }
+  }
+  return total;
+}

--- a/src/agentMode/backends/shared/ManagedBinaryManager.ts
+++ b/src/agentMode/backends/shared/ManagedBinaryManager.ts
@@ -51,6 +51,8 @@ export abstract class ManagedBinaryManager<
 
   /** Clears a completed failure when a new plugin lifecycle adopts this manager. */
   forgetSettledError(): void {
+    // A reopened lifecycle must adopt an active run instead of clearing its progress.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/368
     if (this.operation || this.runtimeState.kind !== "error") return;
     this.publishState({ kind: "idle" });
   }

--- a/src/agentMode/backends/shared/managedInstall.test.ts
+++ b/src/agentMode/backends/shared/managedInstall.test.ts
@@ -1,0 +1,58 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { promoteManagedVersion } from "./managedInstall";
+
+jest.mock("@/logger", () => ({ logError: jest.fn(), logWarn: jest.fn() }));
+
+describe("managedInstall", () => {
+  describe("promoteManagedVersion()", () => {
+    let root: string;
+
+    beforeEach(() => {
+      root = fs.mkdtempSync(path.join(os.tmpdir(), "copilot-managed-install-"));
+    });
+
+    afterEach(() => {
+      fs.rmSync(root, { recursive: true, force: true });
+    });
+
+    it("atomically replaces an existing version directory and removes the old copy", async () => {
+      const stage = path.join(root, "stage");
+      const version = path.join(root, "1.0.0");
+      fs.mkdirSync(stage);
+      fs.mkdirSync(version);
+      fs.writeFileSync(path.join(stage, "new"), "new");
+      fs.writeFileSync(path.join(version, "old"), "old");
+
+      await promoteManagedVersion(stage, version, "Codex");
+
+      expect(fs.readFileSync(path.join(version, "new"), "utf8")).toBe("new");
+      expect(fs.existsSync(path.join(version, "old"))).toBe(false);
+      expect(fs.readdirSync(root)).toEqual(["1.0.0"]);
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/368 restores the prior installation when staged promotion fails", async () => {
+      const stage = path.join(root, "missing-stage");
+      const version = path.join(root, "1.0.0");
+      fs.mkdirSync(version);
+      fs.writeFileSync(path.join(version, "old"), "previous runtime");
+
+      await expect(promoteManagedVersion(stage, version, "Codex")).rejects.toThrow();
+
+      expect(fs.readFileSync(path.join(version, "old"), "utf8")).toBe("previous runtime");
+      expect(fs.readdirSync(root)).toEqual(["1.0.0"]);
+    });
+
+    it("promotes into an absent version directory", async () => {
+      const stage = path.join(root, "stage");
+      const version = path.join(root, "1.0.0");
+      fs.mkdirSync(stage);
+      fs.writeFileSync(path.join(stage, "new"), "new");
+
+      await promoteManagedVersion(stage, version, "Codex");
+
+      expect(fs.readFileSync(path.join(version, "new"), "utf8")).toBe("new");
+    });
+  });
+});

--- a/src/agentMode/backends/shared/managedInstall.ts
+++ b/src/agentMode/backends/shared/managedInstall.ts
@@ -1,0 +1,62 @@
+import { renameWithRetry } from "@/agentMode/skills/renameWithRetry";
+import { logError, logWarn } from "@/logger";
+import { requireNodeModule } from "@/utils/desktopRuntime";
+
+export type ManagedInstallRuntimeState<TProgress> =
+  | { kind: "idle" }
+  | { kind: "detecting" }
+  | { kind: "installing"; progress: TProgress | null }
+  | { kind: "busy" }
+  | { kind: "error"; message: string };
+
+/** Reports a competing process-local operation without changing the active run. */
+export class ManagedInstallOperationInFlightError extends Error {
+  constructor(displayName: string) {
+    super(`A ${displayName} setup operation is already running.`);
+    this.name = "ManagedInstallOperationInFlightError";
+  }
+}
+
+/** Marks user cancellation so the shared state returns to idle instead of Retry. */
+export class ManagedInstallAbortError extends Error {
+  constructor() {
+    super("Aborted");
+    this.name = "AbortError";
+  }
+}
+
+export async function promoteManagedVersion(
+  stageDir: string,
+  versionDir: string,
+  displayName: string
+): Promise<void> {
+  const fs = requireNodeModule<typeof import("node:fs")>("fs");
+  const randomBytes = requireNodeModule<typeof import("node:crypto")>("crypto").randomBytes;
+  let asideDir: string | null = null;
+  try {
+    await fs.promises.access(versionDir);
+    asideDir = `${versionDir}.old-${randomBytes(4).toString("hex")}`;
+    await renameWithRetry(versionDir, asideDir);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+
+  try {
+    await renameWithRetry(stageDir, versionDir);
+  } catch (error) {
+    // A failed update must leave the previously active managed adapter usable.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/368
+    if (asideDir) {
+      await renameWithRetry(asideDir, versionDir).catch((restoreError) =>
+        logError(`[AgentMode] failed to restore previous ${displayName} install`, restoreError)
+      );
+    }
+    throw error;
+  }
+
+  if (asideDir) {
+    await fs.promises
+      .rm(asideDir, { recursive: true, force: true })
+      .catch((error) => logWarn(`[AgentMode] failed to remove ${asideDir}: ${error}`));
+  }
+}


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#368

## Why

Codex needs the same operation locking, cancellation, custom-path selection, and safe replacement that OpenCode uses.

## What

Provide a reusable managed binary lifecycle with deterministic filesystem and concurrency tests. Backend-specific acquisition and settings remain supplied by each backend; production OpenCode adoption is separate.

## Non goal

No production backend wiring, downloads, version-policy changes, or cross-process locking.

## Screenshot

Not applicable: no production UI or backend wiring changes.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Manager and promotion tests cover concurrent writes and rollback. |
| A defect would fail CI or be obvious on first use | ✅ | Filesystem and cancellation failures are deterministic fixtures. |
| A revert fully restores prior state, including persisted data | ✅ | No production backend uses the new lifecycle yet. |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Executable validation delegates to the existing validator. |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Internal lifecycle types only; no persisted schema changes. |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | The reusable contract owns async cancellation and filesystem promotion. |
| No hot-path behavior lacks deterministic coverage | ✅ | Contention, failed validation, and custom-file preservation are tested. |
| No new dependency | ✅ | No dependency changes. |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Manual qualification is limited to managed binary operations. |

Review: Inspect runExclusive, install, uninstall, and setCustomBinaryPath in src/agentMode/backends/shared/ManagedBinaryManager.ts and promoteManagedVersion in src/agentMode/backends/shared/managedInstall.ts.

## Verification

1. Run the adjacent manager and promotion tests, including cancellation, competing operations, failed replacement, and failed restoration.
2. Confirm a custom selection survives uninstall and an invalid custom path leaves the previous settings unchanged.
