### PR TITLE
[Agent Mode] - Step 8: Share cancellable browser sign-in with Claude

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -36,8 +36,10 @@ The Claude backend runs through Claude Code on your computer:
 
 1. Open **Basic → Agents → Claude → Configure**.
 2. Select **Auto-detect**, or enter the absolute path to the `claude` executable.
-3. Select **Sign in** if Claude Code is not already authenticated.
+3. Select **Sign in** if Claude Code is not already authenticated, then finish in your browser. If the page does not open, select **Open sign-in page**. You can cancel and try again.
 4. Enable the models you want and choose a default.
+
+Claude Code stores the credentials on your computer. Copilot checks its sign-in status when the login finishes. To run the login command yourself, expand **Sign in using a terminal instead**.
 
 Claude models and billing come from your Claude Code account. Models added under **BYOK** do not join the Claude model list.
 

--- a/src/agentMode/backends/claude/ClaudeInstallModal.tsx
+++ b/src/agentMode/backends/claude/ClaudeInstallModal.tsx
@@ -66,6 +66,8 @@ const ClaudeConfigContainer: React.FC<{
         onSignIn: auth.signIn,
         signingIn: auth.signingIn,
         url: auth.url,
+        onCancel: auth.cancelSignIn,
+        failed: auth.failed,
       }}
       onClose={onClose}
     />

--- a/src/agentMode/backends/claude/claudeAuth.test.ts
+++ b/src/agentMode/backends/claude/claudeAuth.test.ts
@@ -1,46 +1,68 @@
-import { parseClaudeAuthStatusOutput } from "./claudeAuth";
+import { signInWithCli } from "@/agentMode/backends/shared/cliSignIn";
+jest.mock("@/agentMode/backends/shared/cliSignIn", () => ({ signInWithCli: jest.fn() }));
+import { parseClaudeAuthStatusOutput, signInToClaude } from "./claudeAuth";
 
-describe("parseClaudeAuthStatusOutput", () => {
-  it("reports signed in with a label from email + subscription", () => {
-    const out = JSON.stringify({
-      loggedIn: true,
-      authMethod: "claude.ai",
-      apiProvider: "firstParty",
-      email: "zero@example.com",
-      subscriptionType: "max",
+describe("claudeAuth", () => {
+  describe("parseClaudeAuthStatusOutput()", () => {
+    it("reports signed in with a label from email + subscription", () => {
+      const out = JSON.stringify({
+        loggedIn: true,
+        authMethod: "claude.ai",
+        apiProvider: "firstParty",
+        email: "zero@example.com",
+        subscriptionType: "max",
+      });
+      expect(parseClaudeAuthStatusOutput(out)).toEqual({
+        loggedIn: true,
+        label: "zero@example.com (max)",
+      });
     });
-    expect(parseClaudeAuthStatusOutput(out)).toEqual({
-      loggedIn: true,
-      label: "zero@example.com (max)",
+
+    it("falls back to apiProvider + authMethod when email/subscription are absent", () => {
+      const out = JSON.stringify({
+        loggedIn: true,
+        apiProvider: "bedrock",
+        authMethod: "aws",
+      });
+      expect(parseClaudeAuthStatusOutput(out)).toEqual({
+        loggedIn: true,
+        label: "bedrock (aws)",
+      });
+    });
+
+    it("reports signed out for loggedIn:false", () => {
+      expect(parseClaudeAuthStatusOutput(JSON.stringify({ loggedIn: false }))).toEqual({
+        loggedIn: false,
+      });
+    });
+
+    it("treats malformed / non-JSON output as signed out", () => {
+      expect(parseClaudeAuthStatusOutput("not json")).toEqual({ loggedIn: false });
+      expect(parseClaudeAuthStatusOutput("")).toEqual({ loggedIn: false });
+    });
+
+    it("treats a payload missing loggedIn as signed out", () => {
+      expect(parseClaudeAuthStatusOutput(JSON.stringify({ email: "x@y.z" }))).toEqual({
+        loggedIn: false,
+      });
     });
   });
 
-  it("falls back to apiProvider + authMethod when email/subscription are absent", () => {
-    const out = JSON.stringify({
-      loggedIn: true,
-      apiProvider: "bedrock",
-      authMethod: "aws",
-    });
-    expect(parseClaudeAuthStatusOutput(out)).toEqual({
-      loggedIn: true,
-      label: "bedrock (aws)",
-    });
-  });
-
-  it("reports signed out for loggedIn:false", () => {
-    expect(parseClaudeAuthStatusOutput(JSON.stringify({ loggedIn: false }))).toEqual({
-      loggedIn: false,
-    });
-  });
-
-  it("treats malformed / non-JSON output as signed out", () => {
-    expect(parseClaudeAuthStatusOutput("not json")).toEqual({ loggedIn: false });
-    expect(parseClaudeAuthStatusOutput("")).toEqual({ loggedIn: false });
-  });
-
-  it("treats a payload missing loggedIn as signed out", () => {
-    expect(parseClaudeAuthStatusOutput(JSON.stringify({ email: "x@y.z" }))).toEqual({
-      loggedIn: false,
+  describe("signInToClaude()", () => {
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/379 preserves Claude browser-login arguments through the shared subprocess lifecycle", () => {
+      const controller = { done: Promise.resolve({ loggedIn: false }), cancel: jest.fn() };
+      jest.mocked(signInWithCli).mockReturnValue(controller);
+      const handlers = { signal: new AbortController().signal, onUrl: jest.fn() };
+      expect(signInToClaude("/bin/claude", { ANTHROPIC_API_KEY: "test-only" }, handlers)).toBe(
+        controller
+      );
+      expect(signInWithCli).toHaveBeenCalledWith(
+        "/bin/claude",
+        ["auth", "login", "--claudeai"],
+        { ANTHROPIC_API_KEY: "test-only" },
+        expect.any(Function),
+        handlers
+      );
     });
   });
 });

--- a/src/agentMode/backends/claude/claudeAuth.ts
+++ b/src/agentMode/backends/claude/claudeAuth.ts
@@ -9,17 +9,18 @@
  * listener, and persisting credentials to the OS keychain. We never read or
  * write the token ourselves; we only invoke the CLI and re-read its status.
  */
-import { logInfo, logWarn } from "@/logger";
+import { logWarn } from "@/logger";
 import { err2String } from "@/utils";
 import { requireNodeModule } from "@/utils/desktopRuntime";
 
-type Readable = import("node:stream").Readable;
+import {
+  signInWithCli,
+  type SignInHandlers,
+  type CliSignInController,
+} from "@/agentMode/backends/shared/cliSignIn";
 
 /** `claude auth status` is a quick local read; cap it so a wedged CLI can't hang the UI. */
 const STATUS_TIMEOUT_MS = 10_000;
-
-/** First http(s) URL on a line — the OAuth page the CLI prints as a browser fallback. */
-const URL_PATTERN = /\bhttps?:\/\/[^\s'"]+/;
 
 export interface ClaudeAuthStatus {
   loggedIn: boolean;
@@ -88,92 +89,26 @@ export async function getClaudeAuthStatus(
   }
 }
 
-export interface SignInHandlers {
-  /** Called once with the OAuth URL the CLI prints (browser-open fallback). */
-  onUrl?: (url: string) => void;
-  /** Called per stdout/stderr line for progress display. */
-  onLine?: (line: string) => void;
-}
+export type {
+  SignInHandlers,
+  CliSignInController as ClaudeSignInController,
+} from "@/agentMode/backends/shared/cliSignIn";
 
-export interface ClaudeSignInController {
-  /** Resolves with the post-login status once the CLI exits. Never rejects. */
-  done: Promise<ClaudeAuthStatus>;
-  /** Terminate the login subprocess (SIGTERM) — for teardown. */
-  cancel: () => void;
-}
-
-/**
- * Run `claude auth login`. The CLI opens the system browser itself and runs a
- * loopback callback listener; we stream its output (so callers can show the
- * printed URL as a clickable fallback) and, on exit, re-read `auth status` as
- * the source of truth. stdin is closed so a CLI build that would otherwise wait
- * for a pasted code fails fast instead of hanging.
+/** Runs Claude's browser sign-in and reads its authoritative status afterward.
+ * @param claudePath - Resolved CLI used by Claude sessions.
+ * @param env - Session environment, including profile overrides.
+ * @param handlers - Browser fallback and cancellation callbacks.
  */
 export function signInToClaude(
   claudePath: string,
   env: NodeJS.ProcessEnv,
   handlers: SignInHandlers = {}
-): ClaudeSignInController {
-  const { spawn } = requireNodeModule<typeof import("node:child_process")>("child_process");
-  logInfo("[AgentMode] spawning claude auth login");
-  const child = spawn(claudePath, ["auth", "login", "--claudeai"], {
+): CliSignInController {
+  return signInWithCli(
+    claudePath,
+    ["auth", "login", "--claudeai"],
     env,
-    stdio: ["ignore", "pipe", "pipe"],
-    windowsHide: true,
-  });
-
-  let urlSeen = false;
-  const handleLine = (line: string): void => {
-    handlers.onLine?.(line);
-    if (urlSeen) return;
-    const match = URL_PATTERN.exec(line);
-    if (match) {
-      urlSeen = true;
-      handlers.onUrl?.(match[0]);
-    }
-  };
-  attachLineReader(child.stdout, handleLine);
-  attachLineReader(child.stderr, handleLine);
-
-  const done = new Promise<ClaudeAuthStatus>((resolve) => {
-    child.on("error", (err) => {
-      logWarn("[AgentMode] claude auth login spawn error", err2String(err));
-      resolve({ loggedIn: false });
-    });
-    child.on("close", () => {
-      void getClaudeAuthStatus(claudePath, env).then(resolve, () => resolve({ loggedIn: false }));
-    });
-  });
-
-  return {
-    done,
-    cancel: () => {
-      try {
-        child.kill("SIGTERM");
-      } catch (e) {
-        logWarn("[AgentMode] claude auth login kill failed", err2String(e));
-      }
-    },
-  };
-}
-
-/** Emit complete (newline-delimited) lines from a piped child stream. */
-function attachLineReader(stream: Readable | null, onLine: (line: string) => void): void {
-  if (!stream) return;
-  stream.setEncoding("utf8");
-  let buffer = "";
-  stream.on("data", (chunk: string) => {
-    buffer += chunk;
-    let idx = buffer.indexOf("\n");
-    while (idx >= 0) {
-      const line = buffer.slice(0, idx).replace(/\r$/, "");
-      buffer = buffer.slice(idx + 1);
-      if (line.length > 0) onLine(line);
-      idx = buffer.indexOf("\n");
-    }
-  });
-  stream.on("end", () => {
-    const rest = buffer.trim();
-    if (rest.length > 0) onLine(rest);
-  });
+    () => getClaudeAuthStatus(claudePath, env),
+    handlers
+  );
 }

--- a/src/agentMode/backends/claude/ui/ClaudeConfigView.stories.tsx
+++ b/src/agentMode/backends/claude/ui/ClaudeConfigView.stories.tsx
@@ -71,6 +71,7 @@ export const SigningIn: StoryObj<ClaudeConfigViewProps> = {
       status: { signedIn: false },
       onSignIn: () => undefined,
       signingIn: true,
+      onCancel: () => undefined,
       url: null,
     },
   },
@@ -86,6 +87,7 @@ export const OAuthFallback: StoryObj<ClaudeConfigViewProps> = {
       status: { signedIn: false },
       onSignIn: () => undefined,
       signingIn: true,
+      onCancel: () => undefined,
       url: "https://claude.ai/oauth/authorize?code=example",
     },
   },
@@ -98,5 +100,19 @@ export const LongPath: StoryObj<ClaudeConfigViewProps> = {
     binaryPath:
       "/Users/zero/Library/Application Support/fnm/node-versions/v22.11.0/installation/bin/claude",
     hasBinaryPathOverride: true,
+  },
+};
+
+export const SignInRetry: StoryObj<ClaudeConfigViewProps> = {
+  args: {
+    state: { kind: "ready", source: "custom" },
+    binaryPath: "/Users/zero/.local/bin/claude",
+    auth: {
+      status: { signedIn: false },
+      onSignIn: () => undefined,
+      signingIn: false,
+      url: null,
+      failed: true,
+    },
   },
 };

--- a/src/agentMode/backends/claude/ui/ClaudeConfigView.stories.tsx
+++ b/src/agentMode/backends/claude/ui/ClaudeConfigView.stories.tsx
@@ -1,3 +1,4 @@
+import { FULL_BLEED_MODAL_CLASS } from "@/components/modals/ReactModal";
 import {
   ClaudeConfigView,
   type ClaudeConfigViewProps,
@@ -32,7 +33,9 @@ const meta = {
     },
     onClose: () => undefined,
   },
-  parameters: { gallery: { host: "modal", layout: "padded" } },
+  parameters: {
+    gallery: { host: "modal", layout: "fullscreen", modalClass: FULL_BLEED_MODAL_CLASS },
+  },
 } satisfies Meta<ClaudeConfigViewProps>;
 export default meta;
 
@@ -114,5 +117,12 @@ export const SignInRetry: StoryObj<ClaudeConfigViewProps> = {
       url: null,
       failed: true,
     },
+  },
+};
+
+export const CheckingSignIn: StoryObj<ClaudeConfigViewProps> = {
+  args: {
+    state: { kind: "ready", source: "custom" },
+    auth: { status: null, onSignIn: () => undefined, signingIn: false, url: null },
   },
 };

--- a/src/agentMode/backends/claude/ui/ClaudeConfigView.test.tsx
+++ b/src/agentMode/backends/claude/ui/ClaudeConfigView.test.tsx
@@ -131,6 +131,22 @@ describe("ClaudeConfigView", () => {
       expect(screen.queryByRole("button", { name: "Sign in" })).toBeNull();
     });
 
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/379 keeps cancellation and Retry outside the copyable command so narrow dialogs can wrap", () => {
+      const onCancel = jest.fn();
+      const onSignIn = jest.fn();
+      renderView({
+        state: { kind: "ready", source: "custom" },
+        auth: { status: { signedIn: false }, onSignIn, signingIn: true, url: null, onCancel },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Cancel sign-in" }));
+      expect(onCancel).toHaveBeenCalledTimes(1);
+      expect(
+        screen
+          .getByText(commandBlock(CLAUDE_AUTH_COMMAND))
+          .parentElement?.contains(screen.getByRole("button", { name: "Cancel sign-in" }))
+      ).toBe(false);
+    });
+
     it("hides the in-app sign-in action while auth status is still loading", () => {
       renderView({
         state: { kind: "ready", source: "custom" },

--- a/src/agentMode/backends/claude/ui/ClaudeConfigView.test.tsx
+++ b/src/agentMode/backends/claude/ui/ClaudeConfigView.test.tsx
@@ -44,7 +44,7 @@ describe("ClaudeConfigView", () => {
       renderView({ binaryPath: "/usr/local/bin/claude", hasBinaryPathOverride: true });
 
       const input = screen.getByDisplayValue("/usr/local/bin/claude");
-      const steps = screen.getByText("Don't have it yet?");
+      const steps = screen.getByText("Set up Claude Code");
       expect(input.compareDocumentPosition(steps) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     });
 
@@ -117,7 +117,7 @@ describe("ClaudeConfigView", () => {
       expect(screen.queryByRole("button", { name: "Signing in…" })).toBeNull();
     });
 
-    it("hides the in-app sign-in action when the backend is authenticated", () => {
+    it("shows the signed-in account for https://github.com/Brevilabs/obsidian-copilot-private/issues/379", () => {
       renderView({
         state: { kind: "ready", source: "custom" },
         auth: {
@@ -128,6 +128,7 @@ describe("ClaudeConfigView", () => {
         },
       });
 
+      expect(screen.getByText("Signed in as zero@example.com.")).toBeTruthy();
       expect(screen.queryByRole("button", { name: "Sign in" })).toBeNull();
     });
 
@@ -147,11 +148,14 @@ describe("ClaudeConfigView", () => {
       ).toBe(false);
     });
 
-    it("hides the in-app sign-in action while auth status is still loading", () => {
+    it("shows checking progress for https://github.com/Brevilabs/obsidian-copilot-private/issues/379", () => {
       renderView({
         state: { kind: "ready", source: "custom" },
         auth: { status: null, onSignIn: jest.fn(), signingIn: false, url: null },
       });
+      expect(
+        screen.getByRole<HTMLButtonElement>("button", { name: "Checking sign-in…" }).disabled
+      ).toBe(true);
 
       expect(screen.queryByRole("button", { name: "Sign in" })).toBeNull();
     });

--- a/src/agentMode/backends/claude/ui/ClaudeConfigView.tsx
+++ b/src/agentMode/backends/claude/ui/ClaudeConfigView.tsx
@@ -7,21 +7,12 @@ import {
   ConfigWarningStrip,
 } from "@/agentMode/backends/shared/ui/ConfigDialogShell";
 import { CommandBlock, SetupStep } from "@/agentMode/backends/shared/ui/SetupSteps";
-import type { BackendAuthStatus, InstallState } from "@/agentMode/session/types";
-import { Button } from "@/components/ui/button";
+import type { InstallState } from "@/agentMode/session/types";
+import { SignInAction, type SignInActionProps } from "@/agentMode/backends/shared/ui/SignInAction";
 import React from "react";
 
 /** In-app equivalent of the sign-in command, for backends that can run it themselves. */
-export interface ClaudeAuthProps {
-  /** Latest probed sign-in state; the action stays hidden until signed out is confirmed. */
-  status: BackendAuthStatus | null;
-  /** Start the CLI's interactive sign-in. */
-  onSignIn: () => void;
-  /** True while a sign-in is running, so the button can't be fired twice. */
-  signingIn: boolean;
-  /** Browser fallback printed by the CLI when it cannot open OAuth itself. */
-  url: string | null;
-}
+export type ClaudeAuthProps = SignInActionProps;
 
 export interface ClaudeConfigViewProps {
   /** Readiness of the resolved CLI; drives the header badge and the warning strip. */
@@ -101,29 +92,10 @@ export const ClaudeConfigView: React.FC<ClaudeConfigViewProps> = ({
           <CommandBlock command={CLAUDE_INSTALL_COMMAND} />
         </SetupStep>
         <SetupStep index={2} title="Sign in">
-          <CommandBlock
-            command={CLAUDE_AUTH_COMMAND}
-            action={
-              state.kind === "ready" && auth.status?.signedIn === false ? (
-                auth.signingIn && auth.url ? (
-                  <Button asChild variant="secondary" size="sm">
-                    <a href={auth.url} target="_blank" rel="noopener noreferrer">
-                      Open sign-in page
-                    </a>
-                  </Button>
-                ) : (
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    onClick={auth.onSignIn}
-                    disabled={auth.signingIn}
-                  >
-                    {auth.signingIn ? "Signing in…" : "Sign in"}
-                  </Button>
-                )
-              ) : undefined
-            }
-          />
+          <CommandBlock command={CLAUDE_AUTH_COMMAND} />
+          {/* Cancellation and Retry copy must wrap independently of the copyable command.
+              https://github.com/Brevilabs/obsidian-copilot-private/issues/379 */}
+          {state.kind === "ready" && auth.status?.signedIn === false && <SignInAction {...auth} />}
           <p className="tw-my-0 tw-text-sm tw-text-muted">
             Copilot inherits whatever credentials the Claude Code CLI holds — there is no key to
             paste here.

--- a/src/agentMode/backends/claude/ui/ClaudeConfigView.tsx
+++ b/src/agentMode/backends/claude/ui/ClaudeConfigView.tsx
@@ -84,7 +84,7 @@ export const ClaudeConfigView: React.FC<ClaudeConfigViewProps> = ({
       />
     </ConfigSection>
 
-    <ConfigSection title="Don't have it yet?">
+    <ConfigSection title="Set up Claude Code">
       {/* The section's own gap sets the rhythm inside a step, so the steps need a
           wider one to read as two items rather than one run of controls. */}
       <div className="tw-flex tw-flex-col tw-gap-4">
@@ -92,14 +92,20 @@ export const ClaudeConfigView: React.FC<ClaudeConfigViewProps> = ({
           <CommandBlock command={CLAUDE_INSTALL_COMMAND} />
         </SetupStep>
         <SetupStep index={2} title="Sign in">
-          <CommandBlock command={CLAUDE_AUTH_COMMAND} />
-          {/* Cancellation and Retry copy must wrap independently of the copyable command.
-              https://github.com/Brevilabs/obsidian-copilot-private/issues/379 */}
-          {state.kind === "ready" && auth.status?.signedIn === false && <SignInAction {...auth} />}
           <p className="tw-my-0 tw-text-sm tw-text-muted">
-            Copilot inherits whatever credentials the Claude Code CLI holds — there is no key to
-            paste here.
+            Sign in with your Claude account in your browser. Claude Code saves your credentials on
+            this machine for Copilot to use.
           </p>
+          {/* Keep account status and browser actions visible throughout sign-in so a successful
+              login does not leave users staring at another login command.
+              https://github.com/Brevilabs/obsidian-copilot-private/issues/379 */}
+          {state.kind === "ready" && <SignInAction {...auth} />}
+          <details className="tw-text-sm tw-text-muted">
+            <summary className="tw-cursor-pointer">Sign in using a terminal instead</summary>
+            <div className="tw-mt-2">
+              <CommandBlock command={CLAUDE_AUTH_COMMAND} />
+            </div>
+          </details>
         </SetupStep>
       </div>
     </ConfigSection>

--- a/src/agentMode/backends/shared/cliSignIn.test.ts
+++ b/src/agentMode/backends/shared/cliSignIn.test.ts
@@ -1,0 +1,169 @@
+import { signInWithCli } from "./cliSignIn";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+const mockSpawn = jest.fn();
+const mockExec = jest.fn();
+jest.mock("@/utils/desktopRuntime", () => ({
+  requireNodeModule: (id: string) =>
+    id === "child_process"
+      ? { spawn: mockSpawn, execFile: mockExec }
+      : jest.requireActual(`node:${id}`),
+}));
+const ISSUE = "https://github.com/Brevilabs/obsidian-copilot-private/issues/379";
+describe("cliSignIn", () => {
+  describe("signInWithCli()", () => {
+    let child: EventEmitter & {
+      stdout: PassThrough;
+      stderr: PassThrough;
+      kill: jest.Mock;
+      pid: number;
+    };
+    beforeEach(() => {
+      child = Object.assign(new EventEmitter(), {
+        stdout: new PassThrough(),
+        stderr: new PassThrough(),
+        kill: jest.fn(),
+        pid: 12345,
+      });
+      mockSpawn.mockReset().mockReturnValue(child);
+      jest.spyOn(process, "kill").mockReturnValue(true);
+    });
+    afterEach(() => jest.restoreAllMocks());
+    it(`offers the printed browser fallback and reads authoritative status after exit: ${ISSUE}`, async () => {
+      const read = jest.fn().mockResolvedValue({ loggedIn: false });
+      const onUrl = jest.fn();
+      const login = signInWithCli("/adapter", ["cli", "login"], { CODEX_HOME: "/profile" }, read, {
+        onUrl,
+      });
+      child.stderr.write("Open https://auth.openai.com/sign-");
+      child.stderr.write("in\n");
+      expect(onUrl).toHaveBeenCalledWith("https://auth.openai.com/sign-in");
+      child.emit("close", 0);
+      await expect(login.done).resolves.toEqual({ loggedIn: false });
+      expect(read).toHaveBeenCalledTimes(1);
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "/adapter",
+        ["cli", "login"],
+        expect.objectContaining({ env: { CODEX_HOME: "/profile" }, windowsHide: true })
+      );
+    });
+    it.each(["cancel", "abort"])(
+      `terminates login on %s and ignores stale success: ${ISSUE}`,
+      async (action) => {
+        const controller = new AbortController();
+        const read = jest.fn().mockResolvedValue({ loggedIn: true });
+        const login = signInWithCli("/adapter", [], {}, read, { signal: controller.signal });
+        if (action === "cancel") login.cancel();
+        else controller.abort();
+        child.emit("close", 0);
+        await expect(login.done).resolves.toEqual({ loggedIn: false });
+        expect(process.kill).toHaveBeenCalledWith(-12345, "SIGTERM");
+        expect(read).not.toHaveBeenCalled();
+      }
+    );
+    it(`does not signal a reaped process while its status probe finishes: ${ISSUE}`, async () => {
+      let resolveStatus!: (status: { loggedIn: boolean }) => void;
+      const login = signInWithCli(
+        "/adapter",
+        [],
+        {},
+        () =>
+          new Promise((resolve) => {
+            resolveStatus = resolve;
+          })
+      );
+      child.emit("exit", 0);
+      child.emit("close", 0);
+      login.cancel();
+      await expect(login.done).resolves.toEqual({ loggedIn: false });
+      resolveStatus({ loggedIn: true });
+      expect(process.kill).not.toHaveBeenCalled();
+    });
+    it(`waits for scoped Windows tree termination before Retry: ${ISSUE}`, async () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+      let complete!: (error: Error | null) => void;
+      mockExec.mockImplementation((_command, _args, _options, callback) => {
+        complete = callback;
+      });
+      try {
+        const login = signInWithCli("adapter.exe", [], {}, jest.fn());
+        let completed = false;
+        void login.done.then(() => {
+          completed = true;
+        });
+        login.cancel();
+        child.emit("exit", 1);
+        child.emit("close", 1);
+        await Promise.resolve();
+        expect(completed).toBe(false);
+        expect(mockExec).toHaveBeenCalledWith(
+          "taskkill",
+          ["/PID", "12345", "/T", "/F"],
+          { windowsHide: true },
+          expect.any(Function)
+        );
+        complete(null);
+        await expect(login.done).resolves.toEqual({ loggedIn: false });
+        login.cancel();
+        expect(mockExec).toHaveBeenCalledTimes(1);
+      } finally {
+        Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+      }
+    });
+    (process.platform === "win32" ? it.skip : it)(
+      `Cancel and dialog abort stop a real proxy's child listener before Retry: ${ISSUE}`,
+      async () => {
+        jest.mocked(process.kill).mockRestore();
+        const node = jest.requireActual<typeof import("node:child_process")>("node:child_process");
+        const net = jest.requireActual<typeof import("node:net")>("node:net");
+        mockSpawn.mockImplementation(node.spawn);
+        const runtimeScript =
+          'require("net").createServer().listen(0,"127.0.0.1",function(){console.log("READY " + this.address().port)});';
+        const proxyScript = `require("child_process").spawn(process.execPath,["-e",${JSON.stringify(runtimeScript)}],{stdio:["ignore","inherit","inherit"]});setInterval(()=>{},1000);`;
+        for (const action of ["cancel", "abort"]) {
+          let ready!: (port: number) => void;
+          const portReady = new Promise<number>((resolve) => {
+            ready = resolve;
+          });
+          const abort = new AbortController();
+          const login = signInWithCli(process.execPath, ["-e", proxyScript], {}, jest.fn(), {
+            signal: abort.signal,
+            onLine: (line) => {
+              if (line.startsWith("READY ")) ready(Number(line.slice(6)));
+            },
+          });
+          const proxy = mockSpawn.mock.results.at(-1)!
+            .value as import("node:child_process").ChildProcess;
+          try {
+            const port = await portReady;
+            if (action === "cancel") login.cancel();
+            else abort.abort();
+            await expect(login.done).resolves.toEqual({ loggedIn: false });
+            await new Promise<void>((resolve, reject) => {
+              const socket = net.connect(port, "127.0.0.1");
+              socket.once("error", () => resolve());
+              socket.once("connect", () => {
+                socket.destroy();
+                reject(new Error("Login listener survived cancellation"));
+              });
+            });
+            expect(proxy.exitCode !== null || proxy.signalCode !== null).toBe(true);
+          } finally {
+            if (proxy.exitCode === null && proxy.signalCode === null && proxy.pid)
+              process.kill(-proxy.pid, "SIGKILL");
+          }
+        }
+      },
+      10_000
+    );
+    it(`settles a failed spawn so Retry can launch again: ${ISSUE}`, async () => {
+      const login = signInWithCli("missing", [], {}, jest.fn());
+      child.emit("error", new Error("ENOENT"));
+      await expect(login.done).resolves.toEqual({ loggedIn: false });
+      const retry = signInWithCli("found", [], {}, async () => ({ loggedIn: true }));
+      child.emit("close", 0);
+      await expect(retry.done).resolves.toEqual({ loggedIn: true });
+    });
+  });
+});

--- a/src/agentMode/backends/shared/cliSignIn.test.ts
+++ b/src/agentMode/backends/shared/cliSignIn.test.ts
@@ -47,6 +47,34 @@ describe("cliSignIn", () => {
         expect.objectContaining({ env: { CODEX_HOME: "/profile" }, windowsHide: true })
       );
     });
+    it(`rejects diagnostic URLs and offers the later authorization URL: ${ISSUE}`, async () => {
+      const onUrl = jest.fn();
+      const login = signInWithCli("/adapter", [], {}, async () => ({ loggedIn: true }), {
+        onUrl,
+        acceptUrl: (url) => new URL(url).hostname === "auth.openai.com",
+      });
+      child.stdout.write("Help: https://example.com/help\n");
+      expect(onUrl).not.toHaveBeenCalled();
+      child.stderr.write("Open https://auth.openai.com/authorize\n");
+      expect(onUrl).toHaveBeenCalledTimes(1);
+      expect(onUrl).toHaveBeenCalledWith("https://auth.openai.com/authorize");
+      child.emit("close", 0);
+      await login.done;
+    });
+    it(`stops descendants after proxy exit and waits for their pipes to close: ${ISSUE}`, async () => {
+      const read = jest.fn();
+      const login = signInWithCli("/adapter", [], {}, read);
+      const done = jest.fn();
+      void login.done.then(done);
+      child.emit("exit", 0);
+      login.cancel();
+      await Promise.resolve();
+      expect(process.kill).toHaveBeenCalledWith(-12345, "SIGTERM");
+      expect(done).not.toHaveBeenCalled();
+      child.emit("close", 0);
+      await expect(login.done).resolves.toEqual({ loggedIn: false });
+      expect(read).not.toHaveBeenCalled();
+    });
     it.each(["cancel", "abort"])(
       `terminates login on %s and ignores stale success: ${ISSUE}`,
       async (action) => {
@@ -78,6 +106,25 @@ describe("cliSignIn", () => {
       await expect(login.done).resolves.toEqual({ loggedIn: false });
       resolveStatus({ loggedIn: true });
       expect(process.kill).not.toHaveBeenCalled();
+    });
+    it(`waits for descendant pipes without targeting a reaped Windows PID: ${ISSUE}`, async () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+      mockExec.mockReset();
+      try {
+        const login = signInWithCli("adapter.exe", [], {}, jest.fn());
+        const done = jest.fn();
+        void login.done.then(done);
+        child.emit("exit", 0);
+        login.cancel();
+        await Promise.resolve();
+        expect(done).not.toHaveBeenCalled();
+        expect(mockExec).not.toHaveBeenCalled();
+        child.emit("close", 0);
+        await expect(login.done).resolves.toEqual({ loggedIn: false });
+      } finally {
+        Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+      }
     });
     it(`waits for scoped Windows tree termination before Retry: ${ISSUE}`, async () => {
       const originalPlatform = process.platform;
@@ -121,13 +168,17 @@ describe("cliSignIn", () => {
         const runtimeScript =
           'require("net").createServer().listen(0,"127.0.0.1",function(){console.log("READY " + this.address().port)});';
         const proxyScript = `require("child_process").spawn(process.execPath,["-e",${JSON.stringify(runtimeScript)}],{stdio:["ignore","inherit","inherit"]});setInterval(()=>{},1000);`;
-        for (const action of ["cancel", "abort"]) {
+        for (const action of ["cancel", "abort", "proxy-exit"]) {
           let ready!: (port: number) => void;
           const portReady = new Promise<number>((resolve) => {
             ready = resolve;
           });
           const abort = new AbortController();
-          const login = signInWithCli(process.execPath, ["-e", proxyScript], {}, jest.fn(), {
+          const script =
+            action === "proxy-exit"
+              ? proxyScript.replace("setInterval(()=>{},1000);", "process.exit(0);")
+              : proxyScript;
+          const login = signInWithCli(process.execPath, ["-e", script], {}, jest.fn(), {
             signal: abort.signal,
             onLine: (line) => {
               if (line.startsWith("READY ")) ready(Number(line.slice(6)));
@@ -137,7 +188,10 @@ describe("cliSignIn", () => {
             .value as import("node:child_process").ChildProcess;
           try {
             const port = await portReady;
-            if (action === "cancel") login.cancel();
+            if (action === "proxy-exit" && proxy.exitCode === null) {
+              await new Promise<void>((resolve) => proxy.once("exit", () => resolve()));
+            }
+            if (action === "cancel" || action === "proxy-exit") login.cancel();
             else abort.abort();
             await expect(login.done).resolves.toEqual({ loggedIn: false });
             await new Promise<void>((resolve, reject) => {
@@ -150,8 +204,13 @@ describe("cliSignIn", () => {
             });
             expect(proxy.exitCode !== null || proxy.signalCode !== null).toBe(true);
           } finally {
-            if (proxy.exitCode === null && proxy.signalCode === null && proxy.pid)
-              process.kill(-proxy.pid, "SIGKILL");
+            if (proxy.pid) {
+              try {
+                process.kill(-proxy.pid, "SIGKILL");
+              } catch {
+                /* Already stopped. */
+              }
+            }
           }
         }
       },

--- a/src/agentMode/backends/shared/cliSignIn.ts
+++ b/src/agentMode/backends/shared/cliSignIn.ts
@@ -1,0 +1,144 @@
+import { requireNodeModule } from "@/utils/desktopRuntime";
+import { logWarn } from "@/logger";
+type Readable = import("node:stream").Readable;
+export interface CliAuthStatus {
+  loggedIn: boolean;
+  label?: string;
+}
+export interface SignInHandlers {
+  onUrl?: (url: string) => void;
+  onLine?: (line: string) => void;
+  signal?: AbortSignal;
+  /** Select the backend's authorization page when CLI output also contains diagnostic URLs. */
+  acceptUrl?: (url: string) => boolean;
+}
+export interface CliSignInController {
+  done: Promise<CliAuthStatus>;
+  cancel: () => void;
+}
+
+/** Owns the browser-login subprocess used by Claude and Codex; credentials stay with their CLI.
+ * @param command - Resolved adapter or CLI executable.
+ * @param args - Backend-specific browser-login arguments.
+ * @param env - Environment used by runtime sessions and status probes.
+ * @param readStatus - Authoritative check after the login process exits.
+ * @param handlers - Progress, browser fallback, and cancellation for the caller.
+ */
+export function signInWithCli(
+  command: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  readStatus: () => Promise<CliAuthStatus>,
+  handlers: SignInHandlers = {}
+): CliSignInController {
+  const { spawn, execFile } =
+    requireNodeModule<typeof import("node:child_process")>("child_process");
+  let child: ReturnType<typeof spawn>;
+  let resolveDone: (status: CliAuthStatus) => void;
+  const done = new Promise<CliAuthStatus>((resolve) => {
+    resolveDone = resolve;
+  });
+  let cancelled = false;
+  let settled = false;
+  let exited = false;
+  let closed = false;
+  let treeStopped = true;
+  const finish = (status: CliAuthStatus): void => {
+    if (settled) return;
+    settled = true;
+    handlers.signal?.removeEventListener("abort", cancel);
+    resolveDone(status);
+  };
+  const cancel = (): void => {
+    if (settled || cancelled) return;
+    cancelled = true;
+    // The ACP CLI proxy does not forward signals. Stop its owned tree before allowing Retry.
+    // Never signal a reaped PID, including while its final status probe is still pending.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/379
+    if (!child?.pid || exited) {
+      finish({ loggedIn: false });
+      return;
+    }
+    try {
+      if (process.platform === "win32") {
+        treeStopped = false;
+        execFile(
+          "taskkill",
+          ["/PID", String(child.pid), "/T", "/F"],
+          { windowsHide: true },
+          (error) => {
+            treeStopped = true;
+            if (error) logWarn("[AgentMode] Login process-tree cancellation failed", error);
+            if (closed) finish({ loggedIn: false });
+          }
+        );
+      } else {
+        process.kill(-child.pid, "SIGTERM");
+      }
+    } catch (error) {
+      logWarn("[AgentMode] Login cancellation failed", error);
+    }
+  };
+  // Closing the initiating dialog or cancelling must never publish a late successful login.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/379
+  if (handlers.signal?.aborted) {
+    cancel();
+    return { done, cancel };
+  }
+  try {
+    child = spawn(command, args, {
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+      detached: process.platform !== "win32",
+    });
+  } catch {
+    finish({ loggedIn: false });
+    return { done, cancel };
+  }
+  handlers.signal?.addEventListener("abort", cancel, { once: true });
+  let urlSeen = false;
+  const handleLine = (line: string): void => {
+    if (settled || cancelled) return;
+    handlers.onLine?.(line);
+    const match = /\bhttps?:\/\/[^\s'"]+/.exec(line);
+    if (!urlSeen && match && (!handlers.acceptUrl || handlers.acceptUrl(match[0]))) {
+      urlSeen = true;
+      handlers.onUrl?.(match[0]);
+    }
+  };
+  attachLineReader(child.stdout, handleLine);
+  attachLineReader(child.stderr, handleLine);
+  child.on("error", () => finish({ loggedIn: false }));
+  child.on("exit", () => {
+    exited = true;
+  });
+  child.on("close", () => {
+    exited = closed = true;
+    if (cancelled) {
+      if (treeStopped) finish({ loggedIn: false });
+    } else if (!settled) void readStatus().then(finish, () => finish({ loggedIn: false }));
+  });
+  return { done, cancel };
+}
+
+/** Emit complete (newline-delimited) lines from a piped child stream. */
+function attachLineReader(stream: Readable | null, onLine: (line: string) => void): void {
+  if (!stream) return;
+  stream.setEncoding("utf8");
+  let buffer = "";
+  stream.on("data", (chunk: string) => {
+    buffer += chunk;
+    let idx = buffer.indexOf("\n");
+    while (idx >= 0) {
+      const line = buffer.slice(0, idx).replace(/\r$/, "");
+      buffer = buffer.slice(idx + 1);
+      if (line.length > 0) onLine(line);
+      idx = buffer.indexOf("\n");
+    }
+  });
+  stream.on("end", () => {
+    const rest = buffer.trim();
+    if (rest.length > 0) onLine(rest);
+  });
+}

--- a/src/agentMode/backends/shared/cliSignIn.ts
+++ b/src/agentMode/backends/shared/cliSignIn.ts
@@ -53,14 +53,18 @@ export function signInWithCli(
     if (settled || cancelled) return;
     cancelled = true;
     // The ACP CLI proxy does not forward signals. Stop its owned tree before allowing Retry.
-    // Never signal a reaped PID, including while its final status probe is still pending.
+    // A POSIX process group can outlive its leader while descendants retain the pipes.
+    // Once those pipes close, cancellation must not signal a potentially reused identifier.
     // https://github.com/Brevilabs/obsidian-copilot-private/issues/379
-    if (!child?.pid || exited) {
+    if (!child?.pid || closed) {
       finish({ loggedIn: false });
       return;
     }
     try {
       if (process.platform === "win32") {
+        // taskkill addresses a PID, not a group. After exit, await pipe closure instead
+        // of targeting a PID that Windows may have reassigned.
+        if (exited) return;
         treeStopped = false;
         execFile(
           "taskkill",
@@ -102,6 +106,8 @@ export function signInWithCli(
     if (settled || cancelled) return;
     handlers.onLine?.(line);
     const match = /\bhttps?:\/\/[^\s'"]+/.exec(line);
+    // Diagnostic links must not consume the fallback before the authorization URL arrives.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/379
     if (!urlSeen && match && (!handlers.acceptUrl || handlers.acceptUrl(match[0]))) {
       urlSeen = true;
       handlers.onUrl?.(match[0]);

--- a/src/agentMode/backends/shared/ui/SignInAction.stories.tsx
+++ b/src/agentMode/backends/shared/ui/SignInAction.stories.tsx
@@ -1,0 +1,23 @@
+import { SignInAction, type SignInActionProps } from "./SignInAction";
+import type { Meta, StoryObj } from "@/lib/story";
+const meta = {
+  title: "Agent Mode/Sign In Action",
+  component: SignInAction,
+  args: {
+    status: { signedIn: false },
+    onSignIn: () => undefined,
+    signingIn: false,
+    url: null,
+    onCancel: () => undefined,
+  },
+  parameters: { gallery: { host: "modal", layout: "padded" } },
+} satisfies Meta<SignInActionProps>;
+export default meta;
+export const SignedOut: StoryObj<SignInActionProps> = {};
+export const Checking: StoryObj<SignInActionProps> = { args: { status: null } };
+export const Waiting: StoryObj<SignInActionProps> = { args: { signingIn: true } };
+export const BrowserFallback: StoryObj<SignInActionProps> = {
+  args: { signingIn: true, url: "https://auth.openai.com/authorize" },
+};
+export const Retry: StoryObj<SignInActionProps> = { args: { failed: true } };
+export const SignedIn: StoryObj<SignInActionProps> = { args: { status: { signedIn: true } } };

--- a/src/agentMode/backends/shared/ui/SignInAction.test.tsx
+++ b/src/agentMode/backends/shared/ui/SignInAction.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SignInAction } from "./SignInAction";
+const ISSUE = "https://github.com/Brevilabs/obsidian-copilot-private/issues/379";
+describe("SignInAction", () => {
+  describe("SignInAction()", () => {
+    it(`offers browser fallback and cancellation while waiting: ${ISSUE}`, () => {
+      const onCancel = jest.fn();
+      render(
+        <SignInAction
+          status={{ signedIn: false }}
+          signingIn
+          url="https://auth.openai.com/authorize"
+          onSignIn={jest.fn()}
+          onCancel={onCancel}
+        />
+      );
+      expect(screen.getByRole("link", { name: "Open sign-in page" }).getAttribute("href")).toBe(
+        "https://auth.openai.com/authorize"
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Cancel sign-in" }));
+      expect(onCancel).toHaveBeenCalled();
+    });
+    it(`offers Retry after failure and confirms authoritative success: ${ISSUE}`, () => {
+      const onSignIn = jest.fn();
+      const { rerender } = render(
+        <SignInAction
+          status={{ signedIn: false }}
+          signingIn={false}
+          url={null}
+          onSignIn={onSignIn}
+          failed
+        />
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+      expect(onSignIn).toHaveBeenCalled();
+      rerender(
+        <SignInAction
+          status={{ signedIn: true }}
+          signingIn={false}
+          url={null}
+          onSignIn={onSignIn}
+        />
+      );
+      expect(screen.getByText("Signed in.")).toBeTruthy();
+      expect(screen.queryByRole("button")).toBeNull();
+    });
+  });
+});

--- a/src/agentMode/backends/shared/ui/SignInAction.test.tsx
+++ b/src/agentMode/backends/shared/ui/SignInAction.test.tsx
@@ -32,7 +32,7 @@ describe("SignInAction", () => {
           failed
         />
       );
-      fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+      fireEvent.click(screen.getByRole("button", { name: "Try again" }));
       expect(onSignIn).toHaveBeenCalled();
       rerender(
         <SignInAction

--- a/src/agentMode/backends/shared/ui/SignInAction.tsx
+++ b/src/agentMode/backends/shared/ui/SignInAction.tsx
@@ -1,0 +1,54 @@
+import type { BackendAuthStatus } from "@/agentMode/session/types";
+import { Button } from "@/components/ui/button";
+import React from "react";
+
+export interface SignInActionProps {
+  status: BackendAuthStatus | null;
+  onSignIn: () => void;
+  signingIn: boolean;
+  url: string | null;
+  onCancel?: () => void;
+  failed?: boolean;
+}
+
+/** Browser sign-in controls shared by Claude and Codex, including recoverable browser-launch failure.
+ * https://github.com/Brevilabs/obsidian-copilot-private/issues/379
+ */
+export const SignInAction: React.FC<SignInActionProps> = (auth) => (
+  <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-2" aria-live="polite">
+    {auth.status?.signedIn ? (
+      <span>Signed in{auth.status.label ? ` as ${auth.status.label}` : ""}.</span>
+    ) : (
+      <>
+        {auth.signingIn && auth.url ? (
+          <Button asChild variant="secondary" size="sm">
+            <a href={auth.url} target="_blank" rel="noopener noreferrer">
+              Open sign-in page
+            </a>
+          </Button>
+        ) : (
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={auth.onSignIn}
+            disabled={auth.signingIn || auth.status === null}
+          >
+            {auth.signingIn
+              ? "Signing in…"
+              : auth.failed
+                ? "Retry"
+                : auth.status === null
+                  ? "Checking sign-in…"
+                  : "Sign in"}
+          </Button>
+        )}
+        {auth.signingIn && auth.onCancel && (
+          <Button variant="ghost" size="sm" onClick={auth.onCancel}>
+            Cancel sign-in
+          </Button>
+        )}
+        {auth.failed && <span>Sign-in didn't complete. Please try again.</span>}
+      </>
+    )}
+  </div>
+);

--- a/src/agentMode/backends/shared/ui/SignInAction.tsx
+++ b/src/agentMode/backends/shared/ui/SignInAction.tsx
@@ -15,39 +15,46 @@ export interface SignInActionProps {
  * https://github.com/Brevilabs/obsidian-copilot-private/issues/379
  */
 export const SignInAction: React.FC<SignInActionProps> = (auth) => (
-  <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-2" aria-live="polite">
+  <div className="tw-flex tw-flex-col tw-items-start tw-gap-2" aria-live="polite">
     {auth.status?.signedIn ? (
       <span>Signed in{auth.status.label ? ` as ${auth.status.label}` : ""}.</span>
     ) : (
       <>
-        {auth.signingIn && auth.url ? (
-          <Button asChild variant="secondary" size="sm">
-            <a href={auth.url} target="_blank" rel="noopener noreferrer">
-              Open sign-in page
-            </a>
-          </Button>
-        ) : (
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={auth.onSignIn}
-            disabled={auth.signingIn || auth.status === null}
-          >
-            {auth.signingIn
-              ? "Signing in…"
-              : auth.failed
-                ? "Retry"
-                : auth.status === null
-                  ? "Checking sign-in…"
-                  : "Sign in"}
-          </Button>
+        {auth.signingIn && (
+          <p className="tw-my-0 tw-text-sm tw-text-muted">Finish signing in in your browser.</p>
         )}
-        {auth.signingIn && auth.onCancel && (
-          <Button variant="ghost" size="sm" onClick={auth.onCancel}>
-            Cancel sign-in
-          </Button>
+        {auth.failed && (
+          <p className="tw-my-0 tw-text-sm tw-text-muted">Sign-in didn't complete. Try again.</p>
         )}
-        {auth.failed && <span>Sign-in didn't complete. Please try again.</span>}
+        <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
+          {auth.signingIn && auth.url ? (
+            <Button asChild variant="default" size="sm">
+              <a href={auth.url} target="_blank" rel="noopener noreferrer">
+                Open sign-in page
+              </a>
+            </Button>
+          ) : (
+            <Button
+              variant="default"
+              size="sm"
+              onClick={auth.onSignIn}
+              disabled={auth.signingIn || auth.status === null}
+            >
+              {auth.signingIn
+                ? "Signing in…"
+                : auth.failed
+                  ? "Try again"
+                  : auth.status === null
+                    ? "Checking sign-in…"
+                    : "Sign in"}
+            </Button>
+          )}
+          {auth.signingIn && auth.onCancel && (
+            <Button variant="ghost" size="sm" onClick={auth.onCancel}>
+              Cancel sign-in
+            </Button>
+          )}
+        </div>
       </>
     )}
   </div>

--- a/src/agentMode/session/descriptor.ts
+++ b/src/agentMode/session/descriptor.ts
@@ -64,6 +64,8 @@ export interface BackendAuthStatus {
 
 /** Progress callbacks for an interactive sign-in flow. */
 export interface BackendSignInHandlers {
+  /** Cancellation belongs to the surface that starts browser sign-in. */
+  signal?: AbortSignal;
   /** The OAuth URL to surface as a clickable browser-open fallback. */
   onUrl?: (url: string) => void;
   /** Per-line progress from the sign-in subprocess. */

--- a/src/agentMode/session/useBackendAuthState.test.tsx
+++ b/src/agentMode/session/useBackendAuthState.test.tsx
@@ -51,7 +51,6 @@ describe("useBackendAuthState", () => {
       act(() => void configDialog.result.current.signIn());
       const signInHandlers = (descriptor.auth!.signIn as jest.Mock).mock.calls[0][1];
       act(() => void signInHandlers.onUrl("https://example.com/sign-in"));
-      configDialog.unmount();
       const lateConsumer = renderHook(() => useBackendAuthState(descriptor, "late-consumer"));
       expect(lateConsumer.result.current.signingIn).toBe(true);
       expect(lateConsumer.result.current.url).toBe("https://example.com/sign-in");
@@ -75,6 +74,28 @@ describe("useBackendAuthState", () => {
         label: "zero@example.com",
       });
       expect(descriptor.auth!.getStatus).toHaveBeenCalledTimes(2);
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/379 cancels on dialog teardown and ignores a late login result", async () => {
+      const descriptor = makeDescriptor();
+      let finish!: (status: { signedIn: boolean }) => void;
+      descriptor.auth!.signIn = jest.fn(
+        () =>
+          new Promise((resolve) => {
+            finish = resolve;
+          })
+      );
+      const hook = renderHook(() => useBackendAuthState(descriptor));
+      await waitFor(() => expect(hook.result.current.status?.signedIn).toBe(false));
+      act(() => hook.result.current.signIn());
+      const handlers = (descriptor.auth!.signIn as jest.Mock).mock.calls[0][1];
+      hook.unmount();
+      expect(handlers.signal.aborted).toBe(true);
+      await act(async () => {
+        finish({ signedIn: true });
+      });
+      const observer = renderHook(() => useBackendAuthState(descriptor));
+      await waitFor(() => expect(observer.result.current.status?.signedIn).toBe(false));
     });
 
     it("re-probes when the caller's auth-relevant key changes", async () => {

--- a/src/agentMode/session/useBackendAuthState.test.tsx
+++ b/src/agentMode/session/useBackendAuthState.test.tsx
@@ -98,6 +98,138 @@ describe("useBackendAuthState", () => {
       await waitFor(() => expect(observer.result.current.status?.signedIn).toBe(false));
     });
 
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/379 aborts the owned login when the backend changes", async () => {
+      const descriptor = makeDescriptor();
+      let finish!: (status: { signedIn: boolean }) => void;
+      descriptor.auth!.signIn = jest.fn(
+        () =>
+          new Promise((resolve) => {
+            finish = resolve;
+          })
+      );
+      const hook = renderHook(({ backend }) => useBackendAuthState(backend), {
+        initialProps: { backend: descriptor },
+      });
+      await waitFor(() => expect(hook.result.current.status?.signedIn).toBe(false));
+      act(() => hook.result.current.signIn());
+      const handlers = (descriptor.auth!.signIn as jest.Mock).mock.calls[0][1];
+      hook.rerender({ backend: { id: "codex", displayName: "Codex" } as BackendDescriptor });
+      expect(handlers.signal.aborted).toBe(true);
+      await act(async () => {
+        finish({ signedIn: true });
+      });
+      expect(hook.result.current.status).toBeNull();
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/379 preserves another surface's login on observer replacement and supports explicit shared cancellation", async () => {
+      const descriptor = makeDescriptor();
+      let finish!: (status: { signedIn: boolean }) => void;
+      descriptor.auth!.signIn = jest.fn(
+        () =>
+          new Promise((resolve) => {
+            finish = resolve;
+          })
+      );
+      const owner = renderHook(() => useBackendAuthState(descriptor));
+      const observer = renderHook(({ backend }) => useBackendAuthState(backend), {
+        initialProps: { backend: descriptor },
+      });
+      await waitFor(() => expect(owner.result.current.status?.signedIn).toBe(false));
+      act(() => owner.result.current.signIn());
+      const handlers = (descriptor.auth!.signIn as jest.Mock).mock.calls[0][1];
+      observer.rerender({ backend: { id: "codex", displayName: "Codex" } as BackendDescriptor });
+      expect(handlers.signal.aborted).toBe(false);
+      observer.rerender({ backend: descriptor });
+      act(() => observer.result.current.cancelSignIn());
+      expect(handlers.signal.aborted).toBe(true);
+      expect(owner.result.current.signingIn).toBe(true);
+      await act(async () => {
+        finish({ signedIn: true });
+      });
+      expect(owner.result.current.signingIn).toBe(false);
+      expect(owner.result.current.status?.signedIn).toBe(false);
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/379 retains cached status while a newly mounted consumer refreshes it", async () => {
+      const descriptor = makeDescriptor();
+      const first = renderHook(() => useBackendAuthState(descriptor));
+      await waitFor(() => expect(first.result.current.status?.signedIn).toBe(false));
+      let finish!: (status: { signedIn: boolean }) => void;
+      descriptor.auth!.getStatus = jest.fn(
+        () =>
+          new Promise((resolve) => {
+            finish = resolve;
+          })
+      );
+      const second = renderHook(() => useBackendAuthState(descriptor));
+      await waitFor(() => expect(descriptor.auth!.getStatus).toHaveBeenCalledTimes(1));
+      expect(first.result.current.status?.signedIn).toBe(false);
+      expect(second.result.current.status?.signedIn).toBe(false);
+      await act(async () => {
+        finish({ signedIn: true });
+      });
+      expect(first.result.current.status?.signedIn).toBe(true);
+      expect(second.result.current.status?.signedIn).toBe(true);
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/379 clears a previous profile's failure before probing its replacement", async () => {
+      const descriptor = makeDescriptor();
+      descriptor.auth!.signIn = jest.fn().mockResolvedValue({ signedIn: false });
+      const hook = renderHook(({ profile }) => useBackendAuthState(descriptor, profile), {
+        initialProps: { profile: "first" },
+      });
+      await waitFor(() => expect(hook.result.current.status?.signedIn).toBe(false));
+      await act(async () => {
+        hook.result.current.signIn();
+      });
+      expect(hook.result.current.failed).toBe(true);
+      hook.rerender({ profile: "second" });
+      expect(hook.result.current.failed).toBe(false);
+      await waitFor(() => expect(hook.result.current.status?.signedIn).toBe(false));
+      expect(hook.result.current.failed).toBe(false);
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/379 waits for profile cancellation before probing or starting another login", async () => {
+      const descriptor = makeDescriptor();
+      let finish!: (status: { signedIn: boolean }) => void;
+      descriptor.auth!.signIn = jest.fn(
+        () =>
+          new Promise((resolve) => {
+            finish = resolve;
+          })
+      );
+      const hook = renderHook(({ profile }) => useBackendAuthState(descriptor, profile), {
+        initialProps: { profile: "first" },
+      });
+      await waitFor(() => expect(hook.result.current.status?.signedIn).toBe(false));
+      act(() => hook.result.current.signIn());
+      const handlers = (descriptor.auth!.signIn as jest.Mock).mock.calls[0][1];
+      act(() => {
+        handlers.onUrl("https://example.com/login");
+      });
+      hook.rerender({ profile: "second" });
+      expect(handlers.signal.aborted).toBe(true);
+      expect(hook.result.current.signingIn).toBe(true);
+      expect(hook.result.current.status).toBeNull();
+      expect(hook.result.current.url).toBeNull();
+      act(() => hook.result.current.signIn());
+      await act(async () => {});
+      expect(descriptor.auth!.getStatus).toHaveBeenCalledTimes(1);
+      expect(descriptor.auth!.signIn).toHaveBeenCalledTimes(1);
+      await act(async () => {
+        finish({ signedIn: true });
+      });
+      expect(descriptor.auth!.getStatus).toHaveBeenCalledTimes(2);
+      expect(hook.result.current.status?.signedIn).toBe(false);
+      expect(hook.result.current.signingIn).toBe(false);
+      expect(hook.result.current.failed).toBe(false);
+      act(() => hook.result.current.signIn());
+      expect(descriptor.auth!.signIn).toHaveBeenCalledTimes(2);
+      await act(async () => {
+        finish({ signedIn: true });
+      });
+    });
+
     it("re-probes when the caller's auth-relevant key changes", async () => {
       const descriptor = makeDescriptor();
       descriptor.auth!.getStatus = jest

--- a/src/agentMode/session/useBackendAuthState.ts
+++ b/src/agentMode/session/useBackendAuthState.ts
@@ -8,15 +8,18 @@ interface BackendAuthSnapshot {
   readonly status: BackendAuthStatus | null;
   readonly signingIn: boolean;
   readonly url: string | null;
+  readonly failed: boolean;
 }
 
 const EMPTY_AUTH_SNAPSHOT = Object.freeze<BackendAuthSnapshot>({
   status: null,
   signingIn: false,
   url: null,
+  failed: false,
 });
 const authSnapshots = new WeakMap<BackendAuth, BackendAuthSnapshot>();
 const authSubscribers = new WeakMap<BackendAuth, Set<() => void>>();
+const authControllers = new WeakMap<BackendAuth, AbortController>();
 const authProbeGenerations = new WeakMap<BackendAuth, number>();
 
 const getAuthSnapshot = (auth: BackendAuth): BackendAuthSnapshot =>
@@ -38,7 +41,8 @@ const updateAuthSnapshot = (auth: BackendAuth, update: Partial<BackendAuthSnapsh
   if (
     current.status === next.status &&
     current.signingIn === next.signingIn &&
-    current.url === next.url
+    current.url === next.url &&
+    current.failed === next.failed
   ) {
     return;
   }
@@ -74,6 +78,8 @@ export interface BackendAuthUiState {
   url: string | null;
   /** Start the interactive sign-in flow (no-op if already running). */
   signIn: () => void;
+  cancelSignIn: () => void;
+  failed: boolean;
 }
 
 /**
@@ -99,7 +105,13 @@ export function useBackendAuthState(
   const settingsRef = React.useRef(settings);
   settingsRef.current = settings;
 
+  const loginController = React.useRef<AbortController | null>(null);
   const auth = descriptor.auth;
+  const cancelSignIn = React.useCallback(() => {
+    if (auth) authControllers.get(auth)?.abort();
+  }, [auth]);
+  React.useEffect(() => () => loginController.current?.abort(), []);
+  const previousProbeKey = React.useRef(probeKey);
   const subscribe = React.useCallback(
     (subscriber: () => void) => (auth ? subscribeAuthState(auth, subscriber) : () => undefined),
     [auth]
@@ -111,8 +123,15 @@ export function useBackendAuthState(
   const snapshot = React.useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 
   React.useEffect(() => {
-    if (!auth || getAuthSnapshot(auth).signingIn) return;
+    if (!auth) return;
+    if (previousProbeKey.current !== probeKey) {
+      previousProbeKey.current = probeKey;
+      authControllers.get(auth)?.abort();
+      updateAuthSnapshot(auth, { signingIn: false, url: null });
+    }
+    if (getAuthSnapshot(auth).signingIn) return;
     const generation = beginAuthProbe(auth);
+    updateAuthSnapshot(auth, { status: null });
     void auth.getStatus(settingsRef.current).then(
       (s) => publishAuthProbeStatus(auth, s, generation),
       (e) => {
@@ -124,17 +143,25 @@ export function useBackendAuthState(
 
   const signIn = React.useCallback(() => {
     if (!auth || getAuthSnapshot(auth).signingIn) return;
-    beginAuthProbe(auth);
-    updateAuthSnapshot(auth, { signingIn: true, url: null });
+    const generation = beginAuthProbe(auth);
+    const controller = new AbortController();
+    loginController.current = controller;
+    authControllers.set(auth, controller);
+    updateAuthSnapshot(auth, { signingIn: true, url: null, failed: false });
     new Notice(`Opening your browser to sign in to ${descriptor.displayName}…`);
     auth
       .signIn(settingsRef.current, {
+        signal: controller.signal,
         onUrl: (url) => {
-          if (getAuthSnapshot(auth).signingIn) updateAuthSnapshot(auth, { url });
+          if (!controller.signal.aborted && getAuthSnapshot(auth).signingIn)
+            updateAuthSnapshot(auth, { url });
         },
       })
       .then((s) => {
-        updateAuthSnapshot(auth, { status: s });
+        // Cancelled or replaced probes must not publish credentials for an old profile.
+        // https://github.com/Brevilabs/obsidian-copilot-private/issues/379
+        if (controller.signal.aborted || authProbeGenerations.get(auth) !== generation) return;
+        updateAuthSnapshot(auth, { status: s, failed: !s.signedIn });
         new Notice(
           s.signedIn
             ? `Signed in to ${descriptor.displayName}${s.label ? ` as ${s.label}` : ""}.`
@@ -142,13 +169,16 @@ export function useBackendAuthState(
         );
       })
       .catch((e) => {
+        if (controller.signal.aborted) return;
+        updateAuthSnapshot(auth, { failed: true });
         logError("[AgentMode] sign-in failed", e);
         new Notice(`Sign-in to ${descriptor.displayName} failed. Please try again.`);
       })
       .finally(() => {
-        updateAuthSnapshot(auth, { signingIn: false, url: null });
+        if (authProbeGenerations.get(auth) === generation)
+          updateAuthSnapshot(auth, { signingIn: false, url: null });
       });
   }, [auth, descriptor.displayName]);
 
-  return { ...snapshot, signIn };
+  return { ...snapshot, signIn, cancelSignIn };
 }

--- a/src/agentMode/session/useBackendAuthState.ts
+++ b/src/agentMode/session/useBackendAuthState.ts
@@ -20,6 +20,7 @@ const EMPTY_AUTH_SNAPSHOT = Object.freeze<BackendAuthSnapshot>({
 const authSnapshots = new WeakMap<BackendAuth, BackendAuthSnapshot>();
 const authSubscribers = new WeakMap<BackendAuth, Set<() => void>>();
 const authControllers = new WeakMap<BackendAuth, AbortController>();
+const authSignIns = new WeakMap<BackendAuth, Promise<void>>();
 const authProbeGenerations = new WeakMap<BackendAuth, number>();
 
 const getAuthSnapshot = (auth: BackendAuth): BackendAuthSnapshot =>
@@ -110,7 +111,9 @@ export function useBackendAuthState(
   const cancelSignIn = React.useCallback(() => {
     if (auth) authControllers.get(auth)?.abort();
   }, [auth]);
-  React.useEffect(() => () => loginController.current?.abort(), []);
+  // Backend replacement must stop the login owned by this surface.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/379
+  React.useEffect(() => () => loginController.current?.abort(), [auth]);
   const previousProbeKey = React.useRef(probeKey);
   const subscribe = React.useCallback(
     (subscriber: () => void) => (auth ? subscribeAuthState(auth, subscriber) : () => undefined),
@@ -127,12 +130,16 @@ export function useBackendAuthState(
     if (previousProbeKey.current !== probeKey) {
       previousProbeKey.current = probeKey;
       authControllers.get(auth)?.abort();
-      updateAuthSnapshot(auth, { signingIn: false, url: null });
-    }
-    if (getAuthSnapshot(auth).signingIn) return;
+      // Clear the old profile's status and failure, while retaining the busy state until
+      // its process stops. Additional mounts keep the cached status during refresh.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/379
+      updateAuthSnapshot(auth, { status: null, failed: false, url: null });
+    } else if (getAuthSnapshot(auth).signingIn) return;
     const generation = beginAuthProbe(auth);
-    updateAuthSnapshot(auth, { status: null });
-    void auth.getStatus(settingsRef.current).then(
+    void (async () => {
+      await authSignIns.get(auth);
+      return auth.getStatus(settingsRef.current);
+    })().then(
       (s) => publishAuthProbeStatus(auth, s, generation),
       (e) => {
         logError("[AgentMode] auth status probe failed", e);
@@ -149,7 +156,7 @@ export function useBackendAuthState(
     authControllers.set(auth, controller);
     updateAuthSnapshot(auth, { signingIn: true, url: null, failed: false });
     new Notice(`Opening your browser to sign in to ${descriptor.displayName}…`);
-    auth
+    const pending = auth
       .signIn(settingsRef.current, {
         signal: controller.signal,
         onUrl: (url) => {
@@ -175,9 +182,10 @@ export function useBackendAuthState(
         new Notice(`Sign-in to ${descriptor.displayName} failed. Please try again.`);
       })
       .finally(() => {
-        if (authProbeGenerations.get(auth) === generation)
+        if (authControllers.get(auth) === controller)
           updateAuthSnapshot(auth, { signingIn: false, url: null });
       });
+    authSignIns.set(auth, pending);
   }, [auth, descriptor.displayName]);
 
   return { ...snapshot, signIn, cancelSignIn };

--- a/src/agentMode/ui/AgentModeStatus.test.tsx
+++ b/src/agentMode/ui/AgentModeStatus.test.tsx
@@ -48,6 +48,8 @@ describe("AgentModeStatus", () => {
         signingIn: false,
         url: null,
         signIn: jest.fn(),
+        cancelSignIn: jest.fn(),
+        failed: false,
       };
       managedInstallState = { kind: "idle" };
       jest.clearAllMocks();
@@ -163,6 +165,8 @@ describe("AgentModeStatus", () => {
         signingIn: false,
         url: null,
         signIn: jest.fn(),
+        cancelSignIn: jest.fn(),
+        failed: false,
       };
       const plugin = { app: {} } as unknown as CopilotPlugin;
       const { rerender } = render(<AgentModeStatus plugin={plugin} onInstallClick={jest.fn()} />);


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#379

## Why

Claude's in-app sign-in needs explicit cancellation and Retry, and Codex needs to reuse the same subprocess and browser-fallback behavior.

## What

Share CLI login ownership and status reconciliation. Closing the initiating dialog or cancelling stops its owned login process; replaced probes cannot publish old results. Claude now displays wrapping browser fallback, Cancel sign-in, and Retry controls below its copyable command.

## Non goal

No Codex authentication wiring, managed Codex dialog, credential copying, or embedded login page.

## Screenshot

Gallery evidence at 300px. Browser fallback is compared at the same width.

| Before | After |
| --- | --- |
| ![Claude before](https://github.com/user-attachments/assets/12347497-55f2-4548-9878-49d2ec44386b) | ![Claude after](https://github.com/user-attachments/assets/90a7fea1-5f0c-4940-a698-88c20f491b48) |

![Claude Retry](https://github.com/user-attachments/assets/1ed3d3b8-9760-4431-90d5-b4963674a48a)

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | CLI, hook, Claude auth, and control tests cover cancellation and Retry. |
| A defect would fail CI or be obvious on first use | ❌ | Real browser callbacks and credential stores require platform checks. |
| A revert fully restores prior state, including persisted data | ❌ | Successful sign-in persists credentials through the provider CLI. |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Browser URL handling and login process ownership change. |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Optional internal cancellation signal; persisted schema unchanged. |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Subprocess cancellation and stale-result handling change. |
| No hot-path behavior lacks deterministic coverage | ✅ | Spawn failures, cancellation, and replaced probes are tested. |
| No new dependency | ✅ | No dependency changes. |
| Human-only behavior stays in one feature area and surfaces quickly | ❌ | OS process-tree cancellation and provider callbacks span platforms. |

Review: Inspect signInWithCli in src/agentMode/backends/shared/cliSignIn.ts, signInToClaude in src/agentMode/backends/claude/claudeAuth.ts, useBackendAuthState in src/agentMode/session/useBackendAuthState.ts, and SignInAction in src/agentMode/backends/shared/ui/SignInAction.tsx.

## Verification

1. Inspect Claude OAuthFallback and SignInRetry gallery fixtures at 300, 400, and 600px. The fallback, Cancel sign-in, and Retry controls should wrap without horizontal overflow.
2. With an authorized test account, start Claude sign-in, cancel it, retry, and close Configure while login is pending. The owned process should stop and late results must not restore cancelled state.
3. Run shared CLI, auth-hook, and Claude auth tests, including spawn failure and a profile switch during a pending probe.

## Note

Gallery fixtures do not establish live authentication. Provider callbacks and platform process cancellation remain release checks.
