### PR TITLE
[Codex effort] - Step 3: Apply saved models to multi-agent answers

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -117,7 +117,7 @@ Each answer appears in its own tab, with **Summary** first. If one answerer fail
 
 Multi-agent answers are designed for read-only research, not edits. Copilot denies explicit vault edit, delete, and move tools, along with tools it cannot classify. Retrieval Skills can still run their own scripts under the agent's permissions, so multi-agent answers are not a security sandbox. Use only trusted Skills, and use a regular single-agent turn when you want files changed.
 
-The default model and effort saved for each mentioned agent are used for its answer. If an agent is not installed or ready, configure it before adding it to the prompt.
+The default model and effort saved for each mentioned agent are used for its answer. If the summary fails, its tab shows the error and any partial summary; the individual answers remain available. If an agent is not installed or ready, configure it before adding it to the prompt.
 
 ## Skills across agents
 

--- a/src/agentMode/backends/claude/descriptor.ts
+++ b/src/agentMode/backends/claude/descriptor.ts
@@ -1,4 +1,5 @@
 import { resolveEffort } from "@/lib/model-effort";
+import type { ModelSelectionSession } from "@/agentMode/session/types";
 import { logWarn } from "@/logger";
 import type CopilotPlugin from "@/main";
 import { requireNodeModule } from "@/utils/desktopRuntime";
@@ -300,7 +301,11 @@ export const ClaudeBackendDescriptor: ClaudeDescriptor = {
     return isClaudePlanModePlanFilePath(absolutePath);
   },
 
-  async applySelection(session: AgentSession, selection: ModelSelection, context): Promise<void> {
+  async applySelection(
+    session: ModelSelectionSession,
+    selection: ModelSelection,
+    context
+  ): Promise<void> {
     // Claude's wire id is just the baseModelId — effort travels through
     // `setConfigOption`, not the model id. Skip the model round-trip when
     // the base hasn't changed, otherwise effort-only ticks would fire a

--- a/src/agentMode/backends/codex/descriptor.ts
+++ b/src/agentMode/backends/codex/descriptor.ts
@@ -1,5 +1,4 @@
 import { resolveEffort } from "@/lib/model-effort";
-import type { AgentSession } from "@/agentMode/session/AgentSession";
 import type CopilotPlugin from "@/main";
 import { requireNodeModule } from "@/utils/desktopRuntime";
 import { detectBinary } from "@/utils/detectBinary";
@@ -21,7 +20,12 @@ import type {
   ModelWireCodec,
   PermissionOption,
 } from "@/agentMode/session/types";
-import type { BackendDescriptor, BackendProcess, InstallState } from "@/agentMode/session/types";
+import type {
+  BackendDescriptor,
+  BackendProcess,
+  InstallState,
+  ModelSelectionSession,
+} from "@/agentMode/session/types";
 import { formatCodexModelId, parseCodexModelId } from "@/utils/codexModelId";
 import { codexAcpSearchDirs, resolveCodexAcpBinary } from "./codexBinaryResolver";
 import { CODEX_BINARY_NAME } from "./cliSetup";
@@ -162,7 +166,7 @@ export const CodexBackendDescriptor: BackendDescriptor = {
     new CodexInstallModal(plugin.app).open();
   },
 
-  async applySelection(session: AgentSession, selection: ModelSelection): Promise<void> {
+  async applySelection(session: ModelSelectionSession, selection: ModelSelection): Promise<void> {
     const options = session
       .getState()
       ?.model?.availableModels.find(

--- a/src/agentMode/backends/opencode/descriptor.test.ts
+++ b/src/agentMode/backends/opencode/descriptor.test.ts
@@ -221,12 +221,12 @@ describe("descriptor", () => {
       }
 
       it.each(["high", null])(
-        "https://github.com/Brevilabs/obsidian-copilot-private/issues/219 resets the same model only when its effort is stale: %s",
+        "https://github.com/Brevilabs/obsidian-copilot-private/issues/219 resolves missing effort on the active model without resetting it: %s",
         async (effort) => {
           const { session, applyModelWireId, setConfigOption } = makeSession({
             model: {
               current: { baseModelId: "openai/gpt-5", effort },
-              availableModels: [],
+              availableModels: [entryOffering("openai/gpt-5", ["high", "low"])],
               apply: { kind: "setConfigOption", configId: "model", effortConfigId: "effort" },
             },
             mode: null,
@@ -235,8 +235,8 @@ describe("descriptor", () => {
             baseModelId: "openai/gpt-5",
             effort: null,
           });
-          expect(applyModelWireId).toHaveBeenCalledTimes(effort === null ? 0 : 1);
-          expect(setConfigOption).not.toHaveBeenCalled();
+          expect(applyModelWireId).not.toHaveBeenCalled();
+          expect(setConfigOption).toHaveBeenCalledWith("effort", "low");
         }
       );
 

--- a/src/agentMode/backends/opencode/descriptor.test.ts
+++ b/src/agentMode/backends/opencode/descriptor.test.ts
@@ -220,6 +220,26 @@ describe("descriptor", () => {
         };
       }
 
+      it.each(["high", null])(
+        "https://github.com/Brevilabs/obsidian-copilot-private/issues/219 resets the same model only when its effort is stale: %s",
+        async (effort) => {
+          const { session, applyModelWireId, setConfigOption } = makeSession({
+            model: {
+              current: { baseModelId: "openai/gpt-5", effort },
+              availableModels: [],
+              apply: { kind: "setConfigOption", configId: "model", effortConfigId: "effort" },
+            },
+            mode: null,
+          });
+          await OpencodeBackendDescriptor.applySelection(session, {
+            baseModelId: "openai/gpt-5",
+            effort: null,
+          });
+          expect(applyModelWireId).toHaveBeenCalledTimes(effort === null ? 0 : 1);
+          expect(setConfigOption).not.toHaveBeenCalled();
+        }
+      );
+
       it("routes config-option-backed effort through the thought-level option", async () => {
         const { session, applyModelWireId, setConfigOption } = makeSession({
           model: {

--- a/src/agentMode/backends/opencode/descriptor.ts
+++ b/src/agentMode/backends/opencode/descriptor.ts
@@ -24,7 +24,7 @@ import { opencodeEnabledModelEntries, opencodeWireBaseIdFor } from "./opencodeMo
 import { OpencodeSettingsPanel } from "./OpencodeSettingsPanel";
 import { mapNodeArch, mapNodePlatform } from "./platformResolver";
 import { cacheRoot } from "@/context/conversionsLocation";
-import type { AgentSession } from "@/agentMode/session/AgentSession";
+import type { ModelSelectionSession } from "@/agentMode/session/types";
 import { simpleBinaryBackendProcess } from "@/agentMode/backends/shared/simpleBinaryBackend";
 import type {
   EffortOption,
@@ -184,7 +184,11 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
     }
   },
 
-  async applySelection(session: AgentSession, selection: ModelSelection, context): Promise<void> {
+  async applySelection(
+    session: ModelSelectionSession,
+    selection: ModelSelection,
+    context
+  ): Promise<void> {
     const apply = session.getState()?.model?.apply;
     // A config-option catalog takes bare model ids only. Effort travels through
     // its own option when the model publishes one and is dropped otherwise; a

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -1,4 +1,5 @@
 import { resolveEffort } from "@/lib/model-effort";
+import { OpencodeBackendDescriptor } from "@/agentMode/backends/opencode/descriptor";
 import { AI_SENDER, USER_SENDER } from "@/constants";
 import { ClaudeBackendDescriptor } from "@/agentMode/backends/claude/descriptor";
 import { waitFor } from "@testing-library/react";
@@ -2648,7 +2649,7 @@ describe("AgentSession.create (via start)", () => {
       backendId: "opencode",
       // Legacy unset effort must resolve to a concrete supported level.
       defaultModelSelection: { baseModelId: "openai/gpt-5", effort: null },
-      getDescriptor: () => makeConfigOptionDescriptor(),
+      getDescriptor: () => OpencodeBackendDescriptor,
     });
     await session.ready;
 

--- a/src/agentMode/session/descriptor.ts
+++ b/src/agentMode/session/descriptor.ts
@@ -7,6 +7,7 @@ import type {
   BackendConfigOption,
   BackendId,
   BackendProcess,
+  BackendState,
   EffortOption,
   EnabledModelEntry,
   ModelSelection,
@@ -17,6 +18,16 @@ import type {
   RawModeState,
   SessionId,
 } from "./types";
+
+/**
+ * The model-selection operations shared by visible chats and ephemeral fan-out
+ * sessions. Backend descriptors own selection policy; callers own state storage.
+ */
+export interface ModelSelectionSession {
+  getState(): BackendState | null;
+  applyModelWireId(wireId: string): Promise<void>;
+  setConfigOption(configId: string, value: string): Promise<void>;
+}
 
 /** UI-facing install/setup state for a backend. */
 export type InstallState =
@@ -310,10 +321,8 @@ export interface BackendDescriptor {
   readonly showModelDescriptions?: boolean;
 
   /**
-   * Apply a (baseModelId, effort) selection to a live session. The descriptor
-   * decides whether effort travels in the wire model id (suffix-style
-   * backends: codex, opencode) or via a separate `setConfigOption` call
-   * (descriptor-style: Claude SDK).
+   * Apply a model and resolved effort using this backend's protocol.
+   * Used by visible chats and ephemeral fan-out sessions alike.
    *
    * Resolve missing or invalid effort to the lowest supported level. Models
    * without an effort control omit effort; null is not a selectable default.
@@ -323,7 +332,7 @@ export interface BackendDescriptor {
    * lack the capability) and propagate everything else.
    */
   applySelection(
-    session: AgentSession,
+    session: ModelSelectionSession,
     selection: ModelSelection,
     context?: ApplySelectionContext
   ): Promise<void>;

--- a/src/agentMode/session/fanout/FanoutOrchestrator.test.ts
+++ b/src/agentMode/session/fanout/FanoutOrchestrator.test.ts
@@ -1,3 +1,6 @@
+import { OpencodeBackendDescriptor } from "@/agentMode/backends/opencode/descriptor";
+import { ClaudeBackendDescriptor } from "@/agentMode/backends/claude/descriptor";
+import { CodexBackendDescriptor } from "@/agentMode/backends/codex/descriptor";
 import type {
   BackendDescriptor,
   BackendId,
@@ -14,6 +17,13 @@ jest.mock("@/logger", () => ({
   logInfo: jest.fn(),
   logWarn: jest.fn(),
   logError: jest.fn(),
+}));
+
+jest.mock("@/agentMode/sdk/effortOption", () => ({
+  ...jest.requireActual("@/agentMode/sdk/effortOption"),
+  getCachedSdkCatalog: () => [
+    { value: "claude-sonnet-4-5", supportsEffort: true, supportedEffortLevels: ["low", "high"] },
+  ],
 }));
 
 interface MockProc {
@@ -183,193 +193,298 @@ function runInput(
   };
 }
 
-describe("createFanoutTurn", () => {
-  it("seeds one running slot per agent (insertion order) plus a pending summary", () => {
-    const turn = createFanoutTurn(["opencode", "claude", "codex"]);
-    expect(Object.keys(turn.answers)).toEqual(["opencode", "claude", "codex"]);
-    expect(turn.answers.claude).toEqual({ backendId: "claude", status: "running", text: "" });
-    expect(turn.summary).toEqual({ status: "pending", text: "" });
-  });
-});
-
-describe("FanoutOrchestrator.run", () => {
-  it("streams each agent's answer into its own slot and marks them done", async () => {
-    const { host, procs, readOnlyRegistered, readOnlyUnregistered, excludedFromHistory } = makeHost(
-      {
-        claude: { sessionId: "s-claude" },
-        codex: { sessionId: "s-codex" },
-      }
-    );
-    const orchestrator = new FanoutOrchestrator(host);
-    const controller = new AbortController();
-    const snapshots: string[] = [];
-
-    const runPromise = orchestrator.run(
-      runInput(["claude", "codex"], {
-        prompt: [{ type: "text", text: "review this" }],
-        signal: controller.signal,
-        onChange: (turn) => snapshots.push(JSON.stringify(turn.answers)),
-      })
-    );
-
-    await flush();
-    procs.get("claude")!.emit(textChunk("s-claude", "Claude says hi"));
-    procs.get("codex")!.emit(textChunk("s-codex", "Codex says hi"));
-    procs.get("claude")!.resolvePrompt();
-    procs.get("codex")!.resolvePrompt();
-    // Answers settled; the main agent (claude) now opens a summary sub-session
-    // once the post-resolve trailing-chunk grace on both answers elapses.
-    await flushPastGrace();
-    procs.get("claude")!.emit(textChunk("s-claude", "summary"));
-    procs.get("claude")!.resolvePrompt();
-
-    const turn = await runPromise;
-    expect(turn.answers.claude).toEqual({
-      backendId: "claude",
-      status: "done",
-      text: "Claude says hi",
+describe("FanoutOrchestrator", () => {
+  describe("createFanoutTurn()", () => {
+    it("seeds one running slot per agent (insertion order) plus a pending summary", () => {
+      const turn = createFanoutTurn(["opencode", "claude", "codex"]);
+      expect(Object.keys(turn.answers)).toEqual(["opencode", "claude", "codex"]);
+      expect(turn.answers.claude).toEqual({ backendId: "claude", status: "running", text: "" });
+      expect(turn.summary).toEqual({ status: "pending", text: "" });
     });
-    expect(turn.answers.codex).toEqual({
-      backendId: "codex",
-      status: "done",
-      text: "Codex says hi",
-    });
-    expect(turn.summary.status).toBe("done");
-    expect(turn.summary.text).toBe("summary");
-    // Three sub-sessions registered read-only: two answers + the summary (a
-    // second session on the main backend), all unregistered on teardown.
-    expect(readOnlyRegistered.sort()).toEqual(["s-claude", "s-claude", "s-codex"]);
-    expect(readOnlyUnregistered.sort()).toEqual(["s-claude", "s-claude", "s-codex"]);
-    // Every sub-session (incl. the summary's) is tombstoned so it never leaks
-    // into Recent Chats as a phantom native session.
-    expect(excludedFromHistory.map((e) => e.sessionId).sort()).toEqual([
-      "s-claude",
-      "s-claude",
-      "s-codex",
-    ]);
-    expect(snapshots.length).toBeGreaterThan(1);
   });
 
-  it("isolates a failed agent as an error slot while others complete", async () => {
-    const { host, procs } = makeHost({
-      claude: { sessionId: "s-claude" },
-      codex: { sessionId: "s-codex" },
+  describe("FanoutOrchestrator", () => {
+    describe("run()", () => {
+      it("https://github.com/Brevilabs/obsidian-copilot-private/issues/219 applies explicit Codex effort to both answer and summary sessions", async () => {
+        const { host, procs } = makeHost({ codex: { sessionId: "s-codex" } });
+        const proc = procs.get("codex")!.proc;
+        host.ensureBackendForFanout = async () => ({ proc, descriptor: CodexBackendDescriptor });
+        host.getDefaultSelection = () => ({ baseModelId: "example", effort: "high" });
+        jest.mocked(proc.prompt).mockImplementation(async () => {
+          procs.get("codex")!.emit(textChunk("s-codex", "answer"));
+          return { stopReason: "end_turn" };
+        });
+        await new FanoutOrchestrator(host).run(runInput(["codex"]));
+        expect(proc.setSessionModel).toHaveBeenCalledWith({
+          sessionId: "s-codex",
+          modelId: "example[high]",
+        });
+        expect(proc.setSessionModel).toHaveBeenCalledTimes(2);
+        expect(proc.setSessionConfigOption).not.toHaveBeenCalled();
+      });
+
+      it("https://github.com/Brevilabs/obsidian-copilot-private/issues/219 reports an unsupported model-only switch rather than running fan-out on a different model", async () => {
+        const { host, procs } = makeHost({ codex: { sessionId: "s-codex" } });
+        const proc = procs.get("codex")!.proc;
+        host.ensureBackendForFanout = async () => ({ proc, descriptor: CodexBackendDescriptor });
+        host.getDefaultSelection = () => ({ baseModelId: "example", effort: null });
+        const result = await new FanoutOrchestrator(host).run(runInput(["codex"]));
+        expect(result.answers.codex.status).toBe("error");
+        expect(result.answers.codex.error).toContain("Choose an explicit effort");
+        expect(proc.prompt).not.toHaveBeenCalled();
+        expect(proc.setSessionModel).not.toHaveBeenCalled();
+      });
+
+      it.each([true, false])(
+        "https://github.com/Brevilabs/obsidian-copilot-private/issues/219 uses OpenCode's refreshed effort capability after selecting the model, offered=%s",
+        async (offered) => {
+          const { host, procs } = makeHost({ opencode: { sessionId: "s-opencode" } });
+          const proc = procs.get("opencode")!.proc;
+          const initial: BackendState = {
+            model: {
+              current: { baseModelId: "provider/old", effort: null },
+              availableModels: [],
+              apply: { kind: "setConfigOption", configId: "model", effortConfigId: "old-effort" },
+            },
+            mode: null,
+          };
+          const refreshed: BackendState = {
+            model: {
+              current: { baseModelId: "provider/new", effort: null },
+              availableModels: [
+                {
+                  baseModelId: "provider/new",
+                  name: "New",
+                  provider: null,
+                  effortOptions: offered ? [{ value: "high", label: "high" }] : [],
+                },
+              ],
+              apply: { kind: "setConfigOption", configId: "model", effortConfigId: "new-effort" },
+            },
+            mode: null,
+          };
+          host.ensureBackendForFanout = async () => ({
+            proc,
+            descriptor: OpencodeBackendDescriptor,
+          });
+          host.getDefaultSelection = () => ({ baseModelId: "provider/new", effort: "high" });
+          jest
+            .mocked(proc.newSession)
+            .mockResolvedValue({ sessionId: "s-opencode", state: initial });
+          jest.mocked(proc.setSessionConfigOption).mockResolvedValue(refreshed);
+          jest.mocked(proc.prompt).mockResolvedValue({ stopReason: "end_turn" });
+
+          await new FanoutOrchestrator(host).run(runInput(["opencode"]));
+
+          expect(proc.setSessionModel).not.toHaveBeenCalled();
+          expect(jest.mocked(proc.setSessionConfigOption).mock.calls).toEqual([
+            [{ sessionId: "s-opencode", configId: "model", value: "provider/new" }],
+            ...(offered
+              ? [[{ sessionId: "s-opencode", configId: "new-effort", value: "high" }]]
+              : []),
+          ]);
+        }
+      );
+
+      it("https://github.com/Brevilabs/obsidian-copilot-private/issues/219 keeps Claude's separate effort dispatch when fan-out uses the shared descriptor contract", async () => {
+        const { host, procs } = makeHost({ claude: { sessionId: "s-claude" } });
+        const proc = procs.get("claude")!.proc;
+        const modelId = "claude-sonnet-4-5";
+        host.ensureBackendForFanout = async () => ({ proc, descriptor: ClaudeBackendDescriptor });
+        host.getDefaultSelection = () => ({ baseModelId: modelId, effort: "high" });
+        // The real descriptor uses its SDK catalog's effort option.
+        const effortOption = ClaudeBackendDescriptor.wire.effortConfigFor?.(modelId);
+        expect(effortOption).toBeTruthy();
+        jest.mocked(proc.prompt).mockResolvedValue({ stopReason: "end_turn" });
+
+        await new FanoutOrchestrator(host).run(runInput(["claude"]));
+
+        expect(proc.setSessionModel).toHaveBeenCalledWith({ sessionId: "s-claude", modelId });
+        expect(proc.setSessionConfigOption).toHaveBeenCalledWith({
+          sessionId: "s-claude",
+          configId: effortOption!.id,
+          value: "high",
+        });
+      });
+
+      it("streams each agent's answer into its own slot and marks them done", async () => {
+        const { host, procs, readOnlyRegistered, readOnlyUnregistered, excludedFromHistory } =
+          makeHost({
+            claude: { sessionId: "s-claude" },
+            codex: { sessionId: "s-codex" },
+          });
+        const orchestrator = new FanoutOrchestrator(host);
+        const controller = new AbortController();
+        const snapshots: string[] = [];
+
+        const runPromise = orchestrator.run(
+          runInput(["claude", "codex"], {
+            prompt: [{ type: "text", text: "review this" }],
+            signal: controller.signal,
+            onChange: (turn) => snapshots.push(JSON.stringify(turn.answers)),
+          })
+        );
+
+        await flush();
+        procs.get("claude")!.emit(textChunk("s-claude", "Claude says hi"));
+        procs.get("codex")!.emit(textChunk("s-codex", "Codex says hi"));
+        procs.get("claude")!.resolvePrompt();
+        procs.get("codex")!.resolvePrompt();
+        // Answers settled; the main agent (claude) now opens a summary sub-session
+        // once the post-resolve trailing-chunk grace on both answers elapses.
+        await flushPastGrace();
+        procs.get("claude")!.emit(textChunk("s-claude", "summary"));
+        procs.get("claude")!.resolvePrompt();
+
+        const turn = await runPromise;
+        expect(turn.answers.claude).toEqual({
+          backendId: "claude",
+          status: "done",
+          text: "Claude says hi",
+        });
+        expect(turn.answers.codex).toEqual({
+          backendId: "codex",
+          status: "done",
+          text: "Codex says hi",
+        });
+        expect(turn.summary.status).toBe("done");
+        expect(turn.summary.text).toBe("summary");
+        // Three sub-sessions registered read-only: two answers + the summary (a
+        // second session on the main backend), all unregistered on teardown.
+        expect(readOnlyRegistered.sort()).toEqual(["s-claude", "s-claude", "s-codex"]);
+        expect(readOnlyUnregistered.sort()).toEqual(["s-claude", "s-claude", "s-codex"]);
+        // Every sub-session (incl. the summary's) is tombstoned so it never leaks
+        // into Recent Chats as a phantom native session.
+        expect(excludedFromHistory.map((e) => e.sessionId).sort()).toEqual([
+          "s-claude",
+          "s-claude",
+          "s-codex",
+        ]);
+        expect(snapshots.length).toBeGreaterThan(1);
+      });
+
+      it("isolates a failed agent as an error slot while others complete", async () => {
+        const { host, procs } = makeHost({
+          claude: { sessionId: "s-claude" },
+          codex: { sessionId: "s-codex" },
+        });
+        const orchestrator = new FanoutOrchestrator(host);
+        const controller = new AbortController();
+
+        const runPromise = orchestrator.run(
+          runInput(["claude", "codex"], { signal: controller.signal })
+        );
+
+        await flush();
+        procs.get("claude")!.emit(textChunk("s-claude", "ok"));
+        procs.get("claude")!.resolvePrompt();
+        procs.get("codex")!.rejectPrompt(new Error("backend boom"));
+        // The main agent (claude) summarizes over the one survivor once claude's
+        // post-resolve trailing-chunk grace elapses.
+        await flushPastGrace();
+        procs.get("claude")!.resolvePrompt();
+
+        const turn = await runPromise;
+        expect(turn.answers.claude.status).toBe("done");
+        expect(turn.answers.codex.status).toBe("error");
+        expect(turn.answers.codex.error).toContain("backend boom");
+        // The failed agent is never fed as an answer AND never named to the
+        // summarizer, so the summary can't mention or speculate about it.
+        const summaryCall = (procs.get("claude")!.proc.prompt as jest.Mock).mock.calls[1][0];
+        const text = summaryCall.prompt[0].text as string;
+        expect(text).toContain("the original question");
+        expect(text).toContain("CLAUDE");
+        expect(text).not.toContain("CODEX");
+      });
+
+      it("applies the read-only sandbox id (never plan) only for backends that advertise one", async () => {
+        const { host, procs } = makeHost({
+          // codex advertises a genuine read-only sandbox; its plan id is "plan".
+          codex: { sessionId: "s-codex", readOnlyModeId: "read-only" },
+          // opencode has no readOnlyModeId → no mode switch (relies on prompt +
+          // permission layers). Stands in for any backend lacking a sandbox.
+          opencode: { sessionId: "s-opencode" },
+        });
+        const orchestrator = new FanoutOrchestrator(host);
+        const controller = new AbortController();
+
+        const runPromise = orchestrator.run(
+          runInput(["codex", "opencode"], { signal: controller.signal })
+        );
+        await flush();
+        procs.get("codex")!.resolvePrompt();
+        procs.get("opencode")!.resolvePrompt();
+        // Main agent (codex) summary turn.
+        await flushPastGrace();
+        procs.get("codex")!.resolvePrompt();
+        await runPromise;
+
+        // Applies the read-only sandbox id, NOT canonical.plan ("plan") — a backend
+        // (Claude) whose plan mode writes plan files must never be put into it here.
+        expect(procs.get("codex")!.setSessionMode).toHaveBeenCalledWith({
+          sessionId: "s-codex",
+          modeId: "read-only",
+        });
+        expect(procs.get("codex")!.setSessionMode).not.toHaveBeenCalledWith({
+          sessionId: "s-codex",
+          modeId: "plan",
+        });
+        // No readOnlyModeId → setSessionMode is never called for that backend.
+        expect(procs.get("opencode")!.setSessionMode).not.toHaveBeenCalled();
+      });
+
+      it("cancels EVERY in-flight sub-session and lands each slot terminal-cancelled on abort", async () => {
+        const { host, procs } = makeHost({
+          claude: { sessionId: "s-claude" },
+          codex: { sessionId: "s-codex" },
+        });
+        const orchestrator = new FanoutOrchestrator(host);
+        const controller = new AbortController();
+        const runPromise = orchestrator.run(
+          runInput(["claude", "codex"], { signal: controller.signal })
+        );
+
+        await flush();
+        // Both sub-sessions are mid-prompt; the user cancels the turn.
+        controller.abort();
+        // Backends honor the cancel and resolve their pending prompts.
+        procs.get("claude")!.resolvePrompt();
+        procs.get("codex")!.resolvePrompt();
+        const turn = await runPromise;
+
+        // Every in-flight sub-session got cancel called (abort listener path).
+        expect(procs.get("claude")!.cancel).toHaveBeenCalledWith({ sessionId: "s-claude" });
+        expect(procs.get("codex")!.cancel).toHaveBeenCalledWith({ sessionId: "s-codex" });
+        // No slot is left running; an abort mid-prompt is terminal-cancelled, not done.
+        expect(turn.answers.claude.status).toBe("cancelled");
+        expect(turn.answers.codex.status).toBe("cancelled");
+        // No summary sub-session ran after cancel (only the two answer prompts).
+        expect(procs.get("claude")!.promptCount()).toBe(1);
+        expect(turn.summary.status).toBe("pending");
+      });
+
+      it("lands a brief all-failed note (no fabricated summary) when zero agents succeed", async () => {
+        const { host, procs } = makeHost({
+          claude: { sessionId: "s-claude" },
+          codex: { sessionId: "s-codex" },
+        });
+        const orchestrator = new FanoutOrchestrator(host);
+        const controller = new AbortController();
+        const runPromise = orchestrator.run(
+          runInput(["claude", "codex"], { signal: controller.signal })
+        );
+
+        await flush();
+        procs.get("claude")!.rejectPrompt(new Error("boom-a"));
+        procs.get("codex")!.rejectPrompt(new Error("boom-b"));
+        const turn = await runPromise;
+
+        expect(turn.summary.status).toBe("done");
+        expect(turn.summary.text).toBe(FANOUT_ALL_FAILED_SUMMARY);
+        // No summary sub-session was dispatched — nothing to reconcile.
+        expect(procs.get("claude")!.promptCount()).toBe(1);
+        expect(procs.get("codex")!.promptCount()).toBe(1);
+      });
     });
-    const orchestrator = new FanoutOrchestrator(host);
-    const controller = new AbortController();
-
-    const runPromise = orchestrator.run(
-      runInput(["claude", "codex"], { signal: controller.signal })
-    );
-
-    await flush();
-    procs.get("claude")!.emit(textChunk("s-claude", "ok"));
-    procs.get("claude")!.resolvePrompt();
-    procs.get("codex")!.rejectPrompt(new Error("backend boom"));
-    // The main agent (claude) summarizes over the one survivor once claude's
-    // post-resolve trailing-chunk grace elapses.
-    await flushPastGrace();
-    procs.get("claude")!.resolvePrompt();
-
-    const turn = await runPromise;
-    expect(turn.answers.claude.status).toBe("done");
-    expect(turn.answers.codex.status).toBe("error");
-    expect(turn.answers.codex.error).toContain("backend boom");
-    // The failed agent is never fed as an answer AND never named to the
-    // summarizer, so the summary can't mention or speculate about it.
-    const summaryCall = (procs.get("claude")!.proc.prompt as jest.Mock).mock.calls[1][0];
-    const text = summaryCall.prompt[0].text as string;
-    expect(text).toContain("the original question");
-    expect(text).toContain("CLAUDE");
-    expect(text).not.toContain("CODEX");
-  });
-
-  it("applies the read-only sandbox id (never plan) only for backends that advertise one", async () => {
-    const { host, procs } = makeHost({
-      // codex advertises a genuine read-only sandbox; its plan id is "plan".
-      codex: { sessionId: "s-codex", readOnlyModeId: "read-only" },
-      // opencode has no readOnlyModeId → no mode switch (relies on prompt +
-      // permission layers). Stands in for any backend lacking a sandbox.
-      opencode: { sessionId: "s-opencode" },
-    });
-    const orchestrator = new FanoutOrchestrator(host);
-    const controller = new AbortController();
-
-    const runPromise = orchestrator.run(
-      runInput(["codex", "opencode"], { signal: controller.signal })
-    );
-    await flush();
-    procs.get("codex")!.resolvePrompt();
-    procs.get("opencode")!.resolvePrompt();
-    // Main agent (codex) summary turn.
-    await flushPastGrace();
-    procs.get("codex")!.resolvePrompt();
-    await runPromise;
-
-    // Applies the read-only sandbox id, NOT canonical.plan ("plan") — a backend
-    // (Claude) whose plan mode writes plan files must never be put into it here.
-    expect(procs.get("codex")!.setSessionMode).toHaveBeenCalledWith({
-      sessionId: "s-codex",
-      modeId: "read-only",
-    });
-    expect(procs.get("codex")!.setSessionMode).not.toHaveBeenCalledWith({
-      sessionId: "s-codex",
-      modeId: "plan",
-    });
-    // No readOnlyModeId → setSessionMode is never called for that backend.
-    expect(procs.get("opencode")!.setSessionMode).not.toHaveBeenCalled();
-  });
-
-  it("cancels EVERY in-flight sub-session and lands each slot terminal-cancelled on abort", async () => {
-    const { host, procs } = makeHost({
-      claude: { sessionId: "s-claude" },
-      codex: { sessionId: "s-codex" },
-    });
-    const orchestrator = new FanoutOrchestrator(host);
-    const controller = new AbortController();
-    const runPromise = orchestrator.run(
-      runInput(["claude", "codex"], { signal: controller.signal })
-    );
-
-    await flush();
-    // Both sub-sessions are mid-prompt; the user cancels the turn.
-    controller.abort();
-    // Backends honor the cancel and resolve their pending prompts.
-    procs.get("claude")!.resolvePrompt();
-    procs.get("codex")!.resolvePrompt();
-    const turn = await runPromise;
-
-    // Every in-flight sub-session got cancel called (abort listener path).
-    expect(procs.get("claude")!.cancel).toHaveBeenCalledWith({ sessionId: "s-claude" });
-    expect(procs.get("codex")!.cancel).toHaveBeenCalledWith({ sessionId: "s-codex" });
-    // No slot is left running; an abort mid-prompt is terminal-cancelled, not done.
-    expect(turn.answers.claude.status).toBe("cancelled");
-    expect(turn.answers.codex.status).toBe("cancelled");
-    // No summary sub-session ran after cancel (only the two answer prompts).
-    expect(procs.get("claude")!.promptCount()).toBe(1);
-    expect(turn.summary.status).toBe("pending");
-  });
-
-  it("lands a brief all-failed note (no fabricated summary) when zero agents succeed", async () => {
-    const { host, procs } = makeHost({
-      claude: { sessionId: "s-claude" },
-      codex: { sessionId: "s-codex" },
-    });
-    const orchestrator = new FanoutOrchestrator(host);
-    const controller = new AbortController();
-    const runPromise = orchestrator.run(
-      runInput(["claude", "codex"], { signal: controller.signal })
-    );
-
-    await flush();
-    procs.get("claude")!.rejectPrompt(new Error("boom-a"));
-    procs.get("codex")!.rejectPrompt(new Error("boom-b"));
-    const turn = await runPromise;
-
-    expect(turn.summary.status).toBe("done");
-    expect(turn.summary.text).toBe(FANOUT_ALL_FAILED_SUMMARY);
-    // No summary sub-session was dispatched — nothing to reconcile.
-    expect(procs.get("claude")!.promptCount()).toBe(1);
-    expect(procs.get("codex")!.promptCount()).toBe(1);
   });
 });

--- a/src/agentMode/session/fanout/FanoutOrchestrator.test.ts
+++ b/src/agentMode/session/fanout/FanoutOrchestrator.test.ts
@@ -235,6 +235,60 @@ describe("FanoutOrchestrator", () => {
         expect(proc.setSessionModel).not.toHaveBeenCalled();
       });
 
+      it("https://github.com/Brevilabs/obsidian-copilot-private/issues/219 exposes a summary-only model selection failure while preserving successful answers", async () => {
+        const { host, procs } = makeHost({ codex: { sessionId: "s-codex" } });
+        const proc = procs.get("codex")!.proc;
+        host.ensureBackendForFanout = async () => ({ proc, descriptor: CodexBackendDescriptor });
+        host.getDefaultSelection = jest
+          .fn()
+          .mockReturnValueOnce({ baseModelId: "example", effort: "high" })
+          .mockReturnValue({ baseModelId: "example", effort: null });
+        jest.mocked(proc.prompt).mockImplementation(async () => {
+          procs.get("codex")!.emit(textChunk("s-codex", "Successful answer"));
+          return { stopReason: "end_turn" };
+        });
+
+        const result = await new FanoutOrchestrator(host).run(runInput(["codex"]));
+
+        expect(result.answers.codex).toMatchObject({ status: "done", text: "Successful answer" });
+        expect(result.summary.status).toBe("done");
+        expect(result.summary.error).toContain(
+          "Choose an explicit effort for the Codex model."
+        );
+        expect(result.summary.complete).not.toBe(true);
+        expect(proc.prompt).toHaveBeenCalledTimes(1);
+      });
+
+      it("https://github.com/Brevilabs/obsidian-copilot-private/issues/219 clears stale OpenCode effort before both answer and summary prompts", async () => {
+        const { host, procs } = makeHost({ opencode: { sessionId: "s-opencode" } });
+        const proc = procs.get("opencode")!.proc;
+        const state: BackendState = {
+          model: {
+            current: { baseModelId: "provider/model", effort: "high" },
+            availableModels: [],
+            apply: { kind: "setConfigOption", configId: "model", effortConfigId: "effort" },
+          },
+          mode: null,
+        };
+        host.ensureBackendForFanout = async () => ({ proc, descriptor: OpencodeBackendDescriptor });
+        host.getDefaultSelection = () => ({ baseModelId: "provider/model", effort: null });
+        jest.mocked(proc.newSession).mockResolvedValue({ sessionId: "s-opencode", state });
+        jest.mocked(proc.setSessionConfigOption).mockResolvedValue(state);
+        jest.mocked(proc.prompt).mockImplementation(async () => {
+          procs.get("opencode")!.emit(textChunk("s-opencode", "answer"));
+          return { stopReason: "end_turn" };
+        });
+
+        await new FanoutOrchestrator(host).run(runInput(["opencode"]));
+
+        expect(jest.mocked(proc.setSessionConfigOption).mock.calls).toEqual([
+          [{ sessionId: "s-opencode", configId: "model", value: "provider/model" }],
+          [{ sessionId: "s-opencode", configId: "model", value: "provider/model" }],
+        ]);
+        expect(proc.prompt).toHaveBeenCalledTimes(2);
+        expect(proc.setSessionModel).not.toHaveBeenCalled();
+      });
+
       it.each([true, false])(
         "https://github.com/Brevilabs/obsidian-copilot-private/issues/219 uses OpenCode's refreshed effort capability after selecting the model, offered=%s",
         async (offered) => {

--- a/src/agentMode/session/fanout/FanoutOrchestrator.test.ts
+++ b/src/agentMode/session/fanout/FanoutOrchestrator.test.ts
@@ -252,20 +252,28 @@ describe("FanoutOrchestrator", () => {
 
         expect(result.answers.codex).toMatchObject({ status: "done", text: "Successful answer" });
         expect(result.summary.status).toBe("done");
-        expect(result.summary.error).toContain(
-          "Choose an explicit effort for the Codex model."
-        );
+        expect(result.summary.error).toContain("Choose an explicit effort for the Codex model.");
         expect(result.summary.complete).not.toBe(true);
         expect(proc.prompt).toHaveBeenCalledTimes(1);
       });
 
-      it("https://github.com/Brevilabs/obsidian-copilot-private/issues/219 clears stale OpenCode effort before both answer and summary prompts", async () => {
+      it("https://github.com/Brevilabs/obsidian-copilot-private/issues/219 applies and reports the lowest OpenCode effort before both answer and summary prompts", async () => {
         const { host, procs } = makeHost({ opencode: { sessionId: "s-opencode" } });
         const proc = procs.get("opencode")!.proc;
         const state: BackendState = {
           model: {
             current: { baseModelId: "provider/model", effort: "high" },
-            availableModels: [],
+            availableModels: [
+              {
+                baseModelId: "provider/model",
+                name: "Model",
+                provider: "provider",
+                effortOptions: [
+                  { value: "high", label: "High" },
+                  { value: "low", label: "Low" },
+                ],
+              },
+            ],
             apply: { kind: "setConfigOption", configId: "model", effortConfigId: "effort" },
           },
           mode: null,
@@ -273,7 +281,12 @@ describe("FanoutOrchestrator", () => {
         host.ensureBackendForFanout = async () => ({ proc, descriptor: OpencodeBackendDescriptor });
         host.getDefaultSelection = () => ({ baseModelId: "provider/model", effort: null });
         jest.mocked(proc.newSession).mockResolvedValue({ sessionId: "s-opencode", state });
-        jest.mocked(proc.setSessionConfigOption).mockResolvedValue(state);
+        const confirmed = {
+          ...state,
+          model: { ...state.model!, current: { baseModelId: "provider/model", effort: "low" } },
+        };
+        host.onSelectionApplied = jest.fn();
+        jest.mocked(proc.setSessionConfigOption).mockResolvedValue(confirmed);
         jest.mocked(proc.prompt).mockImplementation(async () => {
           procs.get("opencode")!.emit(textChunk("s-opencode", "answer"));
           return { stopReason: "end_turn" };
@@ -282,9 +295,10 @@ describe("FanoutOrchestrator", () => {
         await new FanoutOrchestrator(host).run(runInput(["opencode"]));
 
         expect(jest.mocked(proc.setSessionConfigOption).mock.calls).toEqual([
-          [{ sessionId: "s-opencode", configId: "model", value: "provider/model" }],
-          [{ sessionId: "s-opencode", configId: "model", value: "provider/model" }],
+          [{ sessionId: "s-opencode", configId: "effort", value: "low" }],
+          [{ sessionId: "s-opencode", configId: "effort", value: "low" }],
         ]);
+        expect(host.onSelectionApplied).toHaveBeenCalledWith("opencode", confirmed);
         expect(proc.prompt).toHaveBeenCalledTimes(2);
         expect(proc.setSessionModel).not.toHaveBeenCalled();
       });
@@ -297,7 +311,17 @@ describe("FanoutOrchestrator", () => {
           const initial: BackendState = {
             model: {
               current: { baseModelId: "provider/old", effort: null },
-              availableModels: [],
+              availableModels: [
+                {
+                  baseModelId: "provider/model",
+                  name: "Model",
+                  provider: "provider",
+                  effortOptions: [
+                    { value: "high", label: "High" },
+                    { value: "low", label: "Low" },
+                  ],
+                },
+              ],
               apply: { kind: "setConfigOption", configId: "model", effortConfigId: "old-effort" },
             },
             mode: null,

--- a/src/agentMode/session/fanout/FanoutOrchestrator.ts
+++ b/src/agentMode/session/fanout/FanoutOrchestrator.ts
@@ -209,7 +209,9 @@ export class FanoutOrchestrator {
       // the continuity replay must not prefer.
       if (outcome === "done") turn.summary.complete = true;
     } catch (err) {
-      // Errored/timed out mid-stream: partial text, NOT complete.
+      // Keep setup failures actionable even when only the summary session fails.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/219
+      turn.summary.error = err2String(err);
       logWarn(`[AgentMode] fan-out summary failed`, err);
     } finally {
       turn.summary.status = "done";

--- a/src/agentMode/session/fanout/FanoutOrchestrator.ts
+++ b/src/agentMode/session/fanout/FanoutOrchestrator.ts
@@ -1,4 +1,3 @@
-import { resolveEffort } from "@/lib/model-effort";
 import { logWarn } from "@/logger";
 import { err2String } from "@/utils";
 import type {
@@ -6,7 +5,6 @@ import type {
   BackendId,
   BackendProcess,
   BackendState,
-  ModelApplySpec,
   ModelSelection,
   PromptContent,
   SessionEvent,
@@ -277,10 +275,7 @@ export class FanoutOrchestrator {
           if (text !== null) onText(text);
         });
 
-        // Sandbox mode and model selection mutate disjoint fields, so run both
-        // round-trips concurrently. The model channel comes from the sub-session's
-        // own `BackendState.model.apply` spec, so config-option backends (opencode
-        // ≥ 1.15.13) route through the same RPC the visible session would.
+        // Sandbox mode and model selection mutate disjoint fields.
         await Promise.all([
           this.applyReadOnlyMode(proc, descriptor, sessionId),
           this.applyDefaultModel(proc, descriptor, backendId, sessionId, opened.state),
@@ -478,23 +473,8 @@ export class FanoutOrchestrator {
   }
 
   /**
-   * Switch the sub-session onto the user's configured default model AND effort.
-   * Best-effort — a missing default or unsupported switch leaves the backend's own.
-   *
-   * The orchestrator holds only a raw `(proc, sessionId)` pair, so it mirrors
-   * `AgentSession.applyModelWireId` + `descriptor.applySelection` generically off
-   * the sub-session's own `BackendState.model.apply` spec (`modelApply`):
-   *
-   *   - `setModel` spec (claude, codex, opencode ≤ 1.15.12): model via
-   *     `setSessionModel`. Effort rides the wire id (codex) or applies via a
-   *     second `setSessionConfigOption` using `wire.effortConfigFor` (Claude SDK,
-   *     where `wire.encode` drops effort) — without it, the default effort runs.
-   *
-   *   - `setConfigOption` spec (opencode ≥ 1.15.13, `session/set_model` gone): the
-   *     MODEL is set via `setSessionConfigOption` (`setSessionModel` would hit the
-   *     unsupported RPC). Effort is a sibling option only surfaced for the ACTIVE
-   *     model, so we activate the bare model first, then apply effort against the
-   *     refreshed `effortConfigId` (mirroring opencode's `applySelection`).
+   * Apply the saved model through the same backend policy as visible chats.
+   * State is local to this ephemeral session and refreshed after each write.
    */
   private async applyDefaultModel(
     proc: BackendProcess,
@@ -503,86 +483,30 @@ export class FanoutOrchestrator {
     sessionId: SessionId,
     state: BackendState
   ): Promise<void> {
-    const requested = this.host.getDefaultSelection(backendId) ?? state.model?.current;
-    if (!requested) return;
-    const modelApply = state.model?.apply;
-    const selection = {
-      ...requested,
-      effort: resolveEffort(
-        requested.effort,
-        state.model?.availableModels.find((model) => model.baseModelId === requested.baseModelId)
-          ?.effortOptions
-      ),
-    };
-    try {
-      if (modelApply?.kind === "setConfigOption") {
-        const updated = await this.applyConfigOptionModel(
-          proc,
-          descriptor,
-          sessionId,
-          requested,
-          modelApply
-        );
-        this.host.onSelectionApplied?.(backendId, updated);
-        return;
-      }
-      let updated = await proc.setSessionModel({
-        sessionId,
-        modelId: descriptor.wire.encode(selection),
-      });
-      if (selection.effort !== null) {
-        const effortConfig = descriptor.wire.effortConfigFor?.(selection.baseModelId);
-        if (effortConfig) {
-          updated = await proc.setSessionConfigOption({
-            sessionId,
-            configId: effortConfig.id,
-            value: selection.effort,
-          });
-        }
-      }
-      this.host.onSelectionApplied?.(backendId, updated);
-    } catch (e) {
-      logWarn(`[AgentMode] fan-out default model failed for ${backendId}`, e);
-    }
-  }
-
-  /**
-   * Apply model + effort for the config-option channel (opencode ≥ 1.15.13),
-   * mirroring opencode's `descriptor.applySelection`. The bare model is set first
-   * (effort dropped) so the backend surfaces the model-specific effort option;
-   * effort is then applied against the returned state's `effortConfigId`.
-   */
-  private async applyConfigOptionModel(
-    proc: BackendProcess,
-    descriptor: BackendDescriptor,
-    sessionId: SessionId,
-    selection: ModelSelection,
-    modelApply: Extract<ModelApplySpec, { kind: "setConfigOption" }>
-  ): Promise<BackendState> {
-    const bareWire = descriptor.wire.encode({
-      baseModelId: selection.baseModelId,
-      effort: null,
-    });
-    const refreshed = await proc.setSessionConfigOption({
-      sessionId,
-      configId: modelApply.configId,
-      value: bareWire,
-    });
-    const effort = resolveEffort(
-      selection.effort,
-      refreshed.model?.availableModels.find((model) => model.baseModelId === selection.baseModelId)
-        ?.effortOptions
+    const selection = this.host.getDefaultSelection(backendId) ?? state.model?.current;
+    if (!selection) return;
+    // Duplicating codec/config dispatch here bypasses backend default-effort
+    // handling. https://github.com/Brevilabs/obsidian-copilot-private/issues/219
+    await descriptor.applySelection(
+      {
+        getState: () => state,
+        applyModelWireId: async (modelId) => {
+          const apply = state.model?.apply;
+          state =
+            apply?.kind === "setConfigOption"
+              ? await proc.setSessionConfigOption({
+                  sessionId,
+                  configId: apply.configId,
+                  value: modelId,
+                })
+              : await proc.setSessionModel({ sessionId, modelId });
+        },
+        setConfigOption: async (configId, value) => {
+          state = await proc.setSessionConfigOption({ sessionId, configId, value });
+        },
+      },
+      selection
     );
-    const refreshedApply = refreshed.model?.apply;
-    const effortConfigId =
-      refreshedApply?.kind === "setConfigOption"
-        ? refreshedApply.effortConfigId
-        : modelApply.effortConfigId;
-    if (!effortConfigId || effort === null) return refreshed;
-    return proc.setSessionConfigOption({
-      sessionId,
-      configId: effortConfigId,
-      value: effort,
-    });
+    this.host.onSelectionApplied?.(backendId, state);
   }
 }

--- a/src/agentMode/session/fanout/fanoutTypes.ts
+++ b/src/agentMode/session/fanout/fanoutTypes.ts
@@ -94,6 +94,8 @@ export type FanoutSummaryStatus = "pending" | "streaming" | "done";
 export interface FanoutSummary {
   status: FanoutSummaryStatus;
   text: string;
+  /** Live failure detail; excluded from serialized answers and continuity prompts. */
+  error?: string;
   /**
    * True once the summary finished SUCCESSFULLY (not cancel/error/timeout).
    * `status` alone can't say — it is forced to `done` on every exit so the UI

--- a/src/agentMode/session/types.ts
+++ b/src/agentMode/session/types.ts
@@ -15,6 +15,7 @@ export type {
   BackendDescriptor,
   BackendSignInHandlers,
   InstallState,
+  ModelSelectionSession,
 } from "./descriptor";
 export type { CurrentPlan, PlanDecisionAction, PlanProposalDecision } from "./plan";
 

--- a/src/agentMode/ui/FanoutTurnView.stories.tsx
+++ b/src/agentMode/ui/FanoutTurnView.stories.tsx
@@ -1,0 +1,57 @@
+import { FanoutTurnView } from "@/agentMode/ui/FanoutTurnView";
+import { FANOUT_SUMMARY_OPTION } from "@/agentMode/ui/fanoutDropdown";
+import { useApp } from "@/context";
+import type { Meta, StoryObj } from "@/lib/story";
+import React from "react";
+
+type Props = React.ComponentProps<typeof FanoutTurnView>;
+
+const meta = {
+  title: "Agent/Fanout Turn",
+  component: FanoutTurnView,
+  parameters: { gallery: { host: "leaf", layout: "padded" } },
+} satisfies Meta<Props>;
+export default meta;
+
+export const SummarySetupError: StoryObj<Props> = {
+  render: function SummaryStory(args) {
+    return (
+      <FanoutTurnView
+        turn={args.turn!}
+        value={args.value!}
+        onSelect={args.onSelect!}
+        app={useApp()}
+      />
+    );
+  },
+  args: {
+    value: FANOUT_SUMMARY_OPTION,
+    onSelect: () => {},
+    turn: {
+      answers: {
+        codex: { backendId: "codex", status: "done", text: "The notes support a weekly review." },
+      },
+      summary: {
+        status: "done",
+        text: "",
+        error:
+          "This Codex adapter cannot choose effort for a model-only switch. Choose an explicit effort or update the Codex adapter.",
+      },
+    },
+  },
+};
+
+export const PartialSummaryError: StoryObj<Props> = {
+  render: SummarySetupError.render,
+  args: {
+    ...SummarySetupError.args,
+    turn: {
+      ...SummarySetupError.args!.turn!,
+      summary: {
+        status: "done",
+        text: "Both agents recommend a weekly review.",
+        error: "The summary request timed out.",
+      },
+    },
+  },
+};

--- a/src/agentMode/ui/FanoutTurnView.test.tsx
+++ b/src/agentMode/ui/FanoutTurnView.test.tsx
@@ -62,6 +62,20 @@ describe("FanoutTurnView", () => {
     expect(screen.getByTestId("agent-md").textContent).toBe("the narrative summary");
   });
 
+  it.each(["", "Partial summary"])(
+    "https://github.com/Brevilabs/obsidian-copilot-private/issues/219 shows the summary failure alongside any partial text: %s",
+    (partialText) => {
+      const t = turn([answer("opencode", "done", "Successful answer")], partialText);
+      t.summary.error = "Choose an explicit effort or update the Codex adapter.";
+      renderView(t);
+      expect(screen.getByText(t.summary.error)).toBeTruthy();
+      expect(screen.queryByText("Summary unavailable")).toBeNull();
+      if (partialText) expect(screen.getByTestId("agent-md").textContent).toBe(partialText);
+      fireEvent.click(screen.getByRole("tab", { name: /opencode/ }));
+      expect(screen.getByTestId("agent-md").textContent).toBe("Successful answer");
+    }
+  );
+
   it("shows a pending placeholder when the summary has no text yet", () => {
     const t = turn([answer("opencode", "running")], "", "pending");
     renderView(t);

--- a/src/agentMode/ui/FanoutTurnView.tsx
+++ b/src/agentMode/ui/FanoutTurnView.tsx
@@ -129,6 +129,19 @@ interface FanoutTurnBodyProps {
  */
 const FanoutTurnBody: React.FC<FanoutTurnBodyProps> = ({ turn, value, app }) => {
   if (value === FANOUT_SUMMARY_OPTION) {
+    // Partial summary text must not hide an actionable setup or stream failure.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/219
+    if (turn.summary.error) {
+      return (
+        <FanoutTerminalState app={app} partialText={turn.summary.text}>
+          <FanoutStatusLine
+            icon={<AlertTriangle className="tw-size-4 tw-text-error" />}
+            text={turn.summary.error}
+            tone="error"
+          />
+        </FanoutTerminalState>
+      );
+    }
     if (turn.summary.text) {
       return <FanoutSlotBody text={turn.summary.text} app={app} />;
     }


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#219

## Why

Multi-agent answers duplicate backend model-selection rules and swallow setup failures. An answer can therefore run with a different model from the one the user saved.

## What

Apply saved model and effort choices using the same backend policy as ordinary chats, for both answers and summaries. If selection fails, report a setup error before sending a prompt. A summary-only failure displays its actionable error beside any partial text, while successful individual answers remain available. Missing or removed effort resolves through the base PR’s shared lowest-effort policy. Confirmed selections also trigger its saved-setting repair. Preserve Claude's separate effort call and use OpenCode's effort options returned after the model switch.

## Non goal

Change model discovery, permission policy, or prompt content.

## Screenshot

The component gallery was visually verified at 300px for summary setup failure and partial-summary failure. Public captures are omitted because the available screenshots include unrelated vault content. The adjacent SummarySetupError and PartialSummaryError stories reproduce both states; UI tests verify the actionable error and continued access to individual answers.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Orchestrator and UI tests cover setup errors, summary-only failures, partial text, and OpenCode effort fallback; ordinary startup is covered too. |
| A defect would fail CI or be obvious on first use | ✅ | Tests assert RPC selection and that a failed setup sends no prompt. |
| A revert fully restores prior state, including persisted data | ✅ | No persisted schema or data migration changes. |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Existing permission and authentication behavior is unchanged. |
| No public API, plugin API, message, or on-disk contract changes | ✅ | The internal session parameter is widened to operations both callers implement. |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Async answer and summary setup now propagates model-selection failures. |
| No hot-path behavior lacks deterministic coverage | ✅ | Success, failure, and backend-specific dispatch paths are tested. |
| No new dependency | ✅ | Dependencies are unchanged. |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Remaining live checks are confined to multi-agent answers. |

Review: inspect `src/agentMode/session/fanout/FanoutOrchestrator.ts` (`applyDefaultModel`, `runReadOnlySubSession`) and `src/agentMode/session/descriptor.ts` (`ModelSelectionSession`, `BackendDescriptor.applySelection`), `src/agentMode/backends/opencode/descriptor.ts` (`applySelection`), `src/agentMode/session/AgentSession.ts` (`confirmSeededSelection`), and `src/agentMode/ui/FanoutTurnView.tsx` (`FanoutTurnBody`). Follow Verification steps 1–4, especially the failed setup. Reverting this PR restores the previous setup policy without a data rollback.

## Verification

1. Save a Codex model with an explicit effort, run a multi-agent answer, and confirm its answer and summary use that choice. Then clear the entire default with Agent default and confirm the agent uses its own selection.
2. Load an older default with missing or removed effort. With a discovered catalog, both answer and summary should apply the lowest supported effort and repair the saved value. Force a real model-selection RPC failure and confirm no prompt is sent for that session.
3. Repeat with Claude and OpenCode defaults. OpenCode should use the selected model's refreshed effort options; models without that control receive no effort call.
4. Force summary setup to fail after individual answers succeed. Their answers should remain available and the Summary tab should show the actionable error. A failure after partial summary text should show both text and error. Error details are live-only.
