### PR TITLE
Fix the agent model picker footer border and corners

### DIFF
--- a/src/components/ui/ModelEffortPicker.stories.tsx
+++ b/src/components/ui/ModelEffortPicker.stories.tsx
@@ -33,6 +33,14 @@ export const ConcreteEffort = {
     },
   },
 } satisfies StoryObj<Props>;
+export const HighEffort: StoryObj<Props> = {
+  args: {
+    override: {
+      ...ConcreteEffort.args.override,
+      effort: { ...ConcreteEffort.args.override.effort, value: "high" },
+    },
+  },
+};
 export const NoEffortControl: StoryObj<Props> = {
   args: {
     override: {

--- a/src/components/ui/ModelEffortPicker.tsx
+++ b/src/components/ui/ModelEffortPicker.tsx
@@ -220,7 +220,7 @@ export function ModelEffortPicker({ override, className }: ModelEffortPickerProp
         </Button>
       </PopoverTrigger>
       <PopoverContent
-        className="tw-w-[380px] tw-p-0"
+        className="tw-w-[380px] tw-overflow-hidden tw-p-0"
         align="start"
         side="top"
         sideOffset={4}
@@ -294,7 +294,7 @@ export function ModelEffortPicker({ override, className }: ModelEffortPickerProp
           })}
         </div>
         {/* Effort stepper for the drafted model — commit fires on popover close. */}
-        <div className="tw-border-t tw-border-solid tw-border-border tw-bg-secondary tw-px-3 tw-py-2">
+        <div className="tw-border-0 tw-border-t tw-border-solid tw-border-border tw-bg-secondary tw-px-3 tw-py-2">
           <EffortFooter options={draftOptions} value={draftEffort} onChange={setDraftEffort} />
         </div>
       </PopoverContent>


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#390

## Why

The Agent Chat model picker's Effort footer has a double border and square corners protruding from the rounded outline.

## What

The footer now has one top divider and follows the picker's rounded outer border.

## Non goal

Changes to model availability, effort values, selection behavior, or shared popovers

## Screenshot

Matching live Obsidian gallery states, used to keep the model and effort fixture stable across plugin reloads; the corrected picker was also inspected in Agent Chat

| Before | After |
| --- | --- |
| ![Before: double footer border and square corners](https://github.com/user-attachments/assets/82e30e7e-bc3e-49d0-80ee-be5eef619b21) | ![After: single divider and rounded outline](https://github.com/user-attachments/assets/11af84ca-f32c-4d56-b23b-fbf95c8745b9) |

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Cosmetic border and corner change verified in Obsidian |
| A defect would fail CI or be obvious on first use | ✅ | Footer outline visible whenever the picker opens |
| A revert fully restores prior state, including persisted data | ✅ | No persisted changes |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Styling only |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Existing contracts unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Selection lifecycle unchanged |
| No hot-path behavior lacks deterministic coverage | ✅ | No hot-path behavior changed |
| No new dependency | ✅ | Dependency manifests unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Confined to the model picker outline |

Review: follow Verification, checking both bottom corners and slider focus visibility

## Verification

1. Open Agent Chat's model picker and check for a single outer outline with rounded bottom corners and one divider above Effort.
2. Move effort from low to high using the keyboard, then choose a model without effort options; confirm the footer remains clean and the slider focus indicator stays visible.
