### PR TITLE
Render relevant note previews as Markdown

### DIFF
--- a/docs/vault-search-and-indexing.md
+++ b/docs/vault-search-and-indexing.md
@@ -61,6 +61,8 @@ The scope is a retrieval preference, not a security boundary. Keep Miyo's regist
 
 ### Relevant Notes
 
+Hover over a relevant note to read its Markdown preview, with formatted headings, lists, code, and links. The preview hides note properties and scrolls for longer notes.
+
 In Agent Chat, select the **Relevant Notes** tab, then **Open in separate pane** at the bottom to keep the notes alongside your conversation. This button stays available below the results, including while notes are loading or the list is empty. Closing the separate pane brings the Relevant Notes tab back to chat.
 
 Miyo is the source of Relevant Notes results and similarity percentages; Copilot's legacy local embedding index no longer scores this pane. Copilot keeps Miyo's result order. Direct links and backlinks annotate notes returned by Miyo but never add their own rows. Relevant Notes does not apply Copilot's inclusion or exclusion patterns; the registered folder's Miyo scope determines which notes can appear.

--- a/src/components/chat-components/ui/RelevantNoteRow.stories.tsx
+++ b/src/components/chat-components/ui/RelevantNoteRow.stories.tsx
@@ -4,9 +4,67 @@ import {
   type RelevantNoteRowProps,
 } from "@/components/chat-components/ui/RelevantNoteRow";
 import { useRelevantNoteRowTransitions } from "@/components/chat-components/ui/useRelevantNoteRowTransitions";
+import { AppContext, useApp } from "@/context";
 import type { Meta, StoryObj } from "@/lib/story";
 import type { RelevantNoteEntry } from "@/search/findRelevantNotes";
-import React, { useState } from "react";
+import { App, TFile } from "obsidian";
+import React, { useMemo, useState } from "react";
+
+const PREVIEW_MARKDOWN = `---
+tags: [design]
+---
+# Design principles
+
+Start with a **clear question**, then gather evidence.
+
+## Review checklist
+
+- Describe the reader's goal.
+- Keep the next action visible.
+- Compare the result with the original question.
+
+> A useful preview lets you decide whether to open the note.
+
+Read [the Markdown guide](https://www.markdownguide.org/) for examples.
+
+\`\`\`typescript
+const nextAction = "Review the evidence";
+\`\`\`
+
+## Follow-up
+
+Longer notes stay inside the preview. Scroll to continue reading without losing the note actions.
+`;
+
+function MarkdownHoverPreview(props: RelevantNoteRowProps): React.ReactElement {
+  const app = useApp();
+  const previewApp = useMemo<App>(() => {
+    const file: unknown = Object.create(TFile.prototype);
+    if (!(file instanceof TFile)) throw new Error("Expected a TFile fixture");
+    Object.assign(file, {
+      name: `${props.note.note.title}.md`,
+      path: props.note.note.path,
+      basename: props.note.note.title,
+      extension: "md",
+      vault: app.vault,
+    });
+    // Supply note content without creating files in the gallery's vault.
+    return Object.assign(Object.create(app) as App, {
+      vault: Object.assign(Object.create(app.vault) as App["vault"], {
+        getAbstractFileByPath: (path: string) =>
+          path === file.path ? file : app.vault.getAbstractFileByPath(path),
+        cachedRead: (requested: TFile) =>
+          requested === file ? Promise.resolve(PREVIEW_MARKDOWN) : app.vault.cachedRead(requested),
+      }),
+    });
+  }, [app, props.note.note.path, props.note.note.title]);
+
+  return (
+    <AppContext.Provider value={previewApp}>
+      <RelevantNoteRow {...props} />
+    </AppContext.Provider>
+  );
+}
 
 function entry(title: string, score: number, links: Partial<RelevantNoteEntry["metadata"]> = {}) {
   return {
@@ -80,6 +138,10 @@ const meta = {
 export default meta;
 
 export const StrongMatch: StoryObj<RelevantNoteRowProps> = {};
+
+export const MarkdownPreview: StoryObj<RelevantNoteRowProps> = {
+  render: MarkdownHoverPreview,
+};
 
 export const WeakMatch: StoryObj<RelevantNoteRowProps> = {
   args: { note: entry("Interview notes", 0.28) },

--- a/src/components/chat-components/ui/RelevantNoteRow.test.tsx
+++ b/src/components/chat-components/ui/RelevantNoteRow.test.tsx
@@ -1,18 +1,24 @@
 /* eslint-disable @eslint-react/hooks-extra/no-unnecessary-use-prefix -- Mock exports must preserve production hook names. */
 import { RelevantNoteRow } from "@/components/chat-components/ui/RelevantNoteRow";
 import type { RelevantNoteEntry } from "@/search/findRelevantNotes";
+import { renderMarkdown } from "@/utils/renderMarkdown";
 import { fireEvent, render, screen } from "@testing-library/react";
+import { TFile } from "obsidian";
 import React from "react";
 
 const mockApp = {
   vault: {
-    getAbstractFileByPath: jest.fn(() => null),
+    getAbstractFileByPath: jest.fn<TFile | null, [string]>(() => null),
     cachedRead: jest.fn().mockResolvedValue(""),
   },
 };
 
 jest.mock("@/context", () => ({
   useApp: () => mockApp,
+}));
+
+jest.mock("@/utils/renderMarkdown", () => ({
+  renderMarkdown: jest.fn(),
 }));
 
 jest.mock("@/hooks/useNoteDrag", () => ({
@@ -43,6 +49,36 @@ function renderRow(props: Partial<React.ComponentProps<typeof RelevantNoteRow>> 
 
 describe("RelevantNoteRow", () => {
   describe("RelevantNoteRow()", () => {
+    it("renders the hover preview as Markdown with links relative to the previewed note", async () => {
+      const file: unknown = Object.create(TFile.prototype);
+      if (!(file instanceof TFile)) throw new Error("Expected a TFile fixture");
+      Object.assign(file, {
+        path: "Design principles.md",
+      });
+      mockApp.vault.getAbstractFileByPath.mockReturnValueOnce(file);
+      mockApp.vault.cachedRead.mockResolvedValueOnce(
+        "---\ntags: [design]\n---\n# Readable preview\n\n**Key idea**"
+      );
+      jest.mocked(renderMarkdown).mockImplementationOnce(async (_app, _text, target) => {
+        const heading = target.doc.createElement("h1");
+        heading.textContent = "Readable preview";
+        target.appendChild(heading);
+      });
+
+      renderRow();
+      fireEvent.mouseEnter(screen.getByText("Design principles"));
+
+      const heading = await screen.findByRole("heading", { name: "Readable preview" });
+      expect(heading.closest(".markdown-rendered")).not.toBeNull();
+      expect(renderMarkdown).toHaveBeenCalledWith(
+        mockApp,
+        "# Readable preview\n\n**Key idea**",
+        expect.any(HTMLElement),
+        file.path,
+        expect.anything()
+      );
+    });
+
     it("names the note and states how strongly it matches", () => {
       renderRow();
 

--- a/src/components/chat-components/ui/RelevantNoteRow.tsx
+++ b/src/components/chat-components/ui/RelevantNoteRow.tsx
@@ -1,3 +1,4 @@
+import { Markdown } from "@/components/Markdown";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
 import { useApp } from "@/context";
@@ -135,9 +136,11 @@ function RelevantNoteHoverCard({
         </div>
 
         {fileContent && (
-          <p className="tw-m-0 tw-max-h-64 tw-overflow-y-auto tw-whitespace-pre-line tw-text-xs tw-leading-normal tw-text-muted">
-            {fileContent}
-          </p>
+          <Markdown
+            text={fileContent}
+            sourcePath={note.note.path}
+            className="tw-m-0 tw-max-h-64 tw-overflow-y-auto tw-text-xs tw-leading-normal tw-text-muted"
+          />
         )}
 
         <div className="tw-flex tw-items-center tw-gap-2">


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#391

## Why

Relevant Notes hover previews expose raw Markdown markers, making notes harder to scan.

## What

Previews show formatted headings, emphasis, lists, links, and code, with links resolved relative to the previewed note.

## Non goal

Changes to ranking, live refresh, note loading, or Add to Chat behavior

## Screenshot

Same deterministic sample in Obsidian's component gallery, avoiding dependence on live relevance results

| Before | After |
| --- | --- |
| ![Raw Markdown preview](https://github.com/user-attachments/assets/c9e62d35-7ef4-4ca4-8f3e-a6fdfd48beb7) | ![Rendered Markdown preview](https://github.com/user-attachments/assets/a059614f-14c6-4341-ad4a-049a99fbcec6) |

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Row test covers rendered output, frontmatter removal, and note source path |
| A defect would fail CI or be obvious on first use | ✅ | Missing formatting is visible on hover and the rendering contract is tested |
| A revert fully restores prior state, including persisted data | ✅ | No settings or note writes |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Note content now enters the existing Obsidian Markdown renderer, including its link and embed handling |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Only hover-preview presentation changes |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Reuses the shared renderer's existing lifecycle |
| No hot-path behavior lacks deterministic coverage | ✅ | Preview handoff is covered by the row test; renderer cleanup and failure fallback have existing tests |
| No new dependency | ✅ | Dependency manifests unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Typography and scrolling are visible in the hover card |

Review: inspect `RelevantNoteHoverCard` in `src/components/chat-components/ui/RelevantNoteRow.tsx`, `Markdown` in `src/components/Markdown.tsx`, and `renderMarkdown` in `src/utils/renderMarkdown.ts` for note-content handling; then exercise all Verification steps

## Verification

1. Hover a Relevant Notes result containing headings, bold text, a list, and code; expect formatting with frontmatter hidden
2. Hover a long note, scroll its preview, and confirm Add to Chat and Open note remain visible
3. Try relative links, an embed, incomplete Markdown, and an empty note; confirm resolution uses the previewed note, incomplete text stays readable, and closing/reopening the card leaves it usable
