### PR TITLE
Remove built-in list formatting restrictions

### DIFF
--- a/docs/system-prompts.md
+++ b/docs/system-prompts.md
@@ -9,8 +9,6 @@ Agent Chat and Quick Chat use different instruction systems:
 
 Changing one does not change the other.
 
-You can request nested lists and your preferred bullet markers in either instruction system. Copilot's built-in prompts do not restrict list indentation or bullet markers.
-
 ## Choose the right instruction tool
 
 | Use                          | Best for                                                      |

--- a/docs/system-prompts.md
+++ b/docs/system-prompts.md
@@ -9,6 +9,8 @@ Agent Chat and Quick Chat use different instruction systems:
 
 Changing one does not change the other.
 
+You can request nested lists and your preferred bullet markers in either instruction system. Copilot's built-in prompts do not restrict list indentation or bullet markers.
+
 ## Choose the right instruction tool
 
 | Use                          | Best for                                                      |

--- a/src/agentMode/backends/shared/agentSystemPrompt.test.ts
+++ b/src/agentMode/backends/shared/agentSystemPrompt.test.ts
@@ -244,9 +244,8 @@ describe("agentSystemPrompt", () => {
       expect(COPILOT_PROMPT_BASE).not.toContain("immediately add ` |` after the table heading");
     });
 
-    it("retains the LaTeX and bullet-list formatting rules", () => {
+    it("retains the LaTeX formatting rule", () => {
       expect(COPILOT_PROMPT_BASE).toMatch(/\$\.\.\.\$/);
-      expect(COPILOT_PROMPT_BASE).toContain("Never use `*` for bullets");
     });
   });
 });

--- a/src/agentMode/backends/shared/agentSystemPrompt.ts
+++ b/src/agentMode/backends/shared/agentSystemPrompt.ts
@@ -163,7 +163,6 @@ export const COPILOT_PROMPT_BASE = `You are Obsidian Copilot, an AI assistant th
 
 ## Markdown Formatting
 - Use \`$...$\` for LaTeX equations, never \`\\[...\\]\` or \`\\(...\\)\`.
-- For markdown lists, always use \`- \` (hyphen followed by exactly one space) for bullet points, with no leading spaces. Never use \`*\` for bullets.
 - When showing note titles, use the \`[[title]]\` wikilink format and never wrap them in backticks or quotes.
 - For Obsidian-internal image links, use the \`![[link]]\` format and never wrap them in backticks.
 - For web image links, use the \`![alt](url)\` format and never wrap them in backticks.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -80,8 +80,7 @@ export const DEFAULT_SYSTEM_PROMPT = `You are Obsidian Copilot, a helpful assist
   11. Always respond in the language of the user's query.
   12. Do NOT mention the additional context provided such as getCurrentTime and getTimeRangeMs if it's irrelevant to the user message.
   13. If the user mentions "tags", it most likely means tags in Obsidian note properties.
-  14. YouTube URLs: If the user provides YouTube URLs in their message, transcriptions will be automatically fetched and provided to you. You don't need to do anything special - just use the transcription content if available.
-  15. For markdown lists, always use '- ' (hyphen followed by exactly one space) for bullet points, with no leading spaces before the hyphen. Never use '*' (asterisk) for bullets.`;
+  14. YouTube URLs: If the user provides YouTube URLs in their message, transcriptions will be automatically fetched and provided to you. You don't need to do anything special - just use the transcription content if available.`;
 
 export const COMPOSER_OUTPUT_INSTRUCTIONS = `Return the new note content or canvas JSON in <writeFile> tags.
 


### PR DESCRIPTION
Fixes Brevilabs/obsidian-copilot-private#389

## Why

Copilot tells models to use hyphen bullets with no leading spaces. That conflicts with custom instructions requesting nested lists.

## What

> **Before:** A request for nested lists competes with Copilot's built-in prohibition on indentation.
>
> **After:** Regular chat and Agent Chat no longer impose list indentation or bullet-marker restrictions.

## Non goal

Changing table, equation, image, or wikilink guidance, or custom instruction loading and precedence.

## Screenshot

Not applicable: this changes instructions sent to models, with no UI layout change.

## Risk

**Medium**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ❌ | Formatting responses depend on nondeterministic model output and require a chat check |
| A defect would fail CI or be obvious on first use | ✅ | Unwanted list formatting appears directly in the response |
| A revert fully restores prior state, including persisted data | ✅ | Only prompt text and related test expectations change |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | No changes to those surfaces |
| No public API, plugin API, message, or on-disk contract changes | ✅ | No interfaces or stored formats change |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | No runtime logic changes |
| No hot-path behavior lacks deterministic coverage | ✅ | No execution paths or branches change |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | The next generated list shows the formatting behavior |

Review: inspect the removed list rules in `src/constants.ts` (`DEFAULT_SYSTEM_PROMPT`) and `src/agentMode/backends/shared/agentSystemPrompt.ts` (`COPILOT_PROMPT_BASE`), then follow Verification.

## Verification

1. Load the updated plugin and start a new Agent Chat with instructions requesting two-level nested lists and asterisk bullets. Ask for an outline and verify the response follows that structure.
2. Repeat in regular chat with a custom system prompt requesting the same format. Verify Copilot no longer objects to indentation or asterisk bullets because of a built-in rule.

