### PR TITLE
Keep note previews inert until explicitly rendered

### DIFF
--- a/docs/vault-search-and-indexing.md
+++ b/docs/vault-search-and-indexing.md
@@ -61,7 +61,7 @@ The scope is a retrieval preference, not a security boundary. Keep Miyo's regist
 
 ### Relevant Notes
 
-Hover over a relevant note to read its Markdown preview, with formatted headings, lists, code, and links. The preview hides note properties and scrolls for longer notes.
+Hover over a relevant note to read a text preview without loading external media. Select **Show formatted preview** to render headings, lists, code, and links; this may load external media. Each time you reopen the preview, it starts as text. The preview hides note properties, scrolls, and shortens very long notes. Select **Open note** to read the full content.
 
 In Agent Chat, select the **Relevant Notes** tab, then **Open in separate pane** at the bottom to keep the notes alongside your conversation. This button stays available below the results, including while notes are loading or the list is empty. Closing the separate pane brings the Relevant Notes tab back to chat.
 

--- a/src/components/Markdown.test.tsx
+++ b/src/components/Markdown.test.tsx
@@ -64,6 +64,33 @@ describe("Markdown", () => {
       expect(await screen.findByText("Release notes remain readable")).not.toBeNull();
     });
 
+    it("preserves fallback line breaks and clears fallback styling after recovery (https://github.com/Brevilabs/obsidian-copilot-private/issues/391)", async () => {
+      jest.mocked(renderMarkdown).mockRejectedValueOnce(new Error("postprocessor failed"));
+      const app = new App();
+      const view = render(
+        <AppContext.Provider value={app}>
+          <Markdown sourcePath="Note.md" text={"First line\nSecond line"} />
+        </AppContext.Provider>
+      );
+      await waitFor(() =>
+        expect(view.container.firstElementChild?.textContent).toBe("First line\nSecond line")
+      );
+      expect(view.container.firstElementChild?.classList.contains("tw-whitespace-pre-wrap")).toBe(
+        true
+      );
+      jest.mocked(renderMarkdown).mockResolvedValueOnce(undefined);
+      view.rerender(
+        <AppContext.Provider value={app}>
+          <Markdown sourcePath="Note.md" text="Recovered" />
+        </AppContext.Provider>
+      );
+      await waitFor(() =>
+        expect(view.container.firstElementChild?.classList.contains("tw-whitespace-pre-wrap")).toBe(
+          false
+        )
+      );
+    });
+
     it(`does not let an obsolete failed render replace newer content for ${ISSUE_URL}`, async () => {
       let rejectFirstRender: ((error: Error) => void) | undefined;
       jest

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -33,6 +33,7 @@ export function Markdown({
     let cancelled = false;
     component.load();
     target.classList.add("markdown-rendered");
+    target.classList.remove("tw-whitespace-pre-wrap");
     target.replaceChildren();
     void renderMarkdown(app, text, target, sourcePath, component)
       .then(() => {
@@ -46,6 +47,9 @@ export function Markdown({
         // https://github.com/Brevilabs/obsidian-copilot-private/issues/317
         if (cancelled) return;
         logWarn("[Markdown] render failed", error);
+        // Failed previews must preserve the note's line breaks.
+        // https://github.com/Brevilabs/obsidian-copilot-private/issues/391
+        target.classList.add("tw-whitespace-pre-wrap");
         target.textContent = text;
       });
 

--- a/src/components/chat-components/ui/RelevantNoteRow.stories.tsx
+++ b/src/components/chat-components/ui/RelevantNoteRow.stories.tsx
@@ -36,7 +36,9 @@ const nextAction = "Review the evidence";
 Longer notes stay inside the preview. Scroll to continue reading without losing the note actions.
 `;
 
-function MarkdownHoverPreview(props: RelevantNoteRowProps): React.ReactElement {
+function MarkdownHoverPreview(
+  props: RelevantNoteRowProps & { content?: string }
+): React.ReactElement {
   const app = useApp();
   const previewApp = useMemo<App>(() => {
     const file: unknown = Object.create(TFile.prototype);
@@ -54,10 +56,12 @@ function MarkdownHoverPreview(props: RelevantNoteRowProps): React.ReactElement {
         getAbstractFileByPath: (path: string) =>
           path === file.path ? file : app.vault.getAbstractFileByPath(path),
         cachedRead: (requested: TFile) =>
-          requested === file ? Promise.resolve(PREVIEW_MARKDOWN) : app.vault.cachedRead(requested),
+          requested === file
+            ? Promise.resolve(props.content ?? PREVIEW_MARKDOWN)
+            : app.vault.cachedRead(requested),
       }),
     });
-  }, [app, props.note.note.path, props.note.note.title]);
+  }, [app, props.content, props.note.note.path, props.note.note.title]);
 
   return (
     <AppContext.Provider value={previewApp}>
@@ -167,4 +171,22 @@ export const ReducedMotion: StoryObj<RelevantNoteRowProps> = {
 
 export const LiveReranking: StoryObj<RelevantNoteRowProps> = {
   render: LiveRerank,
+};
+
+export const LongPreview: StoryObj<RelevantNoteRowProps> = {
+  render: (props) => (
+    <MarkdownHoverPreview {...baseArgs} {...props} content={PREVIEW_MARKDOWN.repeat(100)} />
+  ),
+};
+
+export const MediaPreview: StoryObj<RelevantNoteRowProps> = {
+  render: (props) => (
+    <MarkdownHoverPreview
+      {...baseArgs}
+      {...props}
+      content={
+        "# Imported note\n\n![Remote image](https://example.invalid/image.png)\n\n![[Embedded note]]"
+      }
+    />
+  ),
 };

--- a/src/components/chat-components/ui/RelevantNoteRow.test.tsx
+++ b/src/components/chat-components/ui/RelevantNoteRow.test.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @eslint-react/hooks-extra/no-unnecessary-use-prefix -- Mock exports must preserve production hook names. */
 import { RelevantNoteRow } from "@/components/chat-components/ui/RelevantNoteRow";
 import type { RelevantNoteEntry } from "@/search/findRelevantNotes";
+import { PREVIEW_RENDER_LIMIT } from "@/utils/truncateForPreview";
 import { renderMarkdown } from "@/utils/renderMarkdown";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { TFile } from "obsidian";
@@ -49,6 +50,11 @@ function renderRow(props: Partial<React.ComponentProps<typeof RelevantNoteRow>> 
 
 describe("RelevantNoteRow", () => {
   describe("RelevantNoteRow()", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(null);
+    });
+
     it("renders the hover preview as Markdown with links relative to the previewed note", async () => {
       const file: unknown = Object.create(TFile.prototype);
       if (!(file instanceof TFile)) throw new Error("Expected a TFile fixture");
@@ -68,6 +74,8 @@ describe("RelevantNoteRow", () => {
       renderRow();
       fireEvent.mouseEnter(screen.getByText("Design principles"));
 
+      fireEvent.click(await screen.findByRole("button", { name: "Show formatted preview" }));
+
       const heading = await screen.findByRole("heading", { name: "Readable preview" });
       expect(heading.closest(".markdown-rendered")).not.toBeNull();
       expect(renderMarkdown).toHaveBeenCalledWith(
@@ -77,6 +85,64 @@ describe("RelevantNoteRow", () => {
         file.path,
         expect.anything()
       );
+    });
+
+    it("requires a fresh explicit action to render media on each hover (https://github.com/Brevilabs/obsidian-copilot-private/issues/391)", async () => {
+      const file: unknown = Object.assign(Object.create(TFile.prototype), {
+        path: "Design principles.md",
+      });
+      if (!(file instanceof TFile)) throw new Error("Expected a TFile fixture");
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(file);
+      const content =
+        '![pixel](https://tracker.example/id)\n<img src="https://tracker.example/html">\n![[Embedded note]]';
+      mockApp.vault.cachedRead.mockResolvedValue(content);
+      jest.mocked(renderMarkdown).mockResolvedValue(undefined);
+      renderRow();
+      const title = screen.getByText("Design principles");
+      fireEvent.mouseEnter(title);
+      const button = await screen.findByRole("button", { name: "Show formatted preview" });
+      expect(renderMarkdown).not.toHaveBeenCalled();
+      expect(document.querySelector("img, iframe, video, audio")).toBeNull();
+      fireEvent.click(button);
+      expect(renderMarkdown).toHaveBeenCalledTimes(1);
+      expect(renderMarkdown).toHaveBeenCalledWith(
+        mockApp,
+        content,
+        expect.any(HTMLElement),
+        file.path,
+        expect.anything()
+      );
+      fireEvent.mouseLeave(title);
+      fireEvent.mouseEnter(title);
+      expect(await screen.findByRole("button", { name: "Show formatted preview" })).toBeTruthy();
+      expect(renderMarkdown).toHaveBeenCalledTimes(1);
+    });
+
+    it("caps large previews and keeps the full note action available (https://github.com/Brevilabs/obsidian-copilot-private/issues/391)", async () => {
+      const file: unknown = Object.assign(Object.create(TFile.prototype), {
+        path: "Design principles.md",
+      });
+      if (!(file instanceof TFile)) throw new Error("Expected a TFile fixture");
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(file);
+      mockApp.vault.cachedRead.mockResolvedValue("x".repeat(PREVIEW_RENDER_LIMIT + 100));
+      jest.mocked(renderMarkdown).mockResolvedValue(undefined);
+      const onNavigateToNote = jest.fn();
+      renderRow({ onNavigateToNote });
+      fireEvent.mouseEnter(screen.getByText("Design principles"));
+      expect(
+        await screen.findByText("Preview shortened. Open note to read the full content.")
+      ).toBeTruthy();
+      expect(screen.getByText("x".repeat(PREVIEW_RENDER_LIMIT))).toBeTruthy();
+      fireEvent.click(screen.getByRole("button", { name: "Show formatted preview" }));
+      expect(renderMarkdown).toHaveBeenCalledWith(
+        mockApp,
+        "x".repeat(PREVIEW_RENDER_LIMIT),
+        expect.any(HTMLElement),
+        file.path,
+        expect.anything()
+      );
+      fireEvent.click(screen.getByText("Open note"));
+      expect(onNavigateToNote).toHaveBeenCalledTimes(1);
     });
 
     it("names the note and states how strongly it matches", () => {

--- a/src/components/chat-components/ui/RelevantNoteRow.tsx
+++ b/src/components/chat-components/ui/RelevantNoteRow.tsx
@@ -4,6 +4,7 @@ import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover"
 import { useApp } from "@/context";
 import { useNoteDrag } from "@/hooks/useNoteDrag";
 import { cn } from "@/lib/utils";
+import { truncateForPreview } from "@/utils/truncateForPreview";
 import { type RelevantNoteEntry } from "@/search/findRelevantNotes";
 import { ArrowRight, FileInput, FileOutput, FileText, PlusCircle } from "lucide-react";
 import { TFile } from "obsidian";
@@ -84,6 +85,8 @@ function RelevantNoteHoverCard({
   const app = useApp();
   const [open, setOpen] = useState(false);
   const [fileContent, setFileContent] = useState<string | null>(null);
+  const [formatted, setFormatted] = useState(false);
+  const preview = truncateForPreview(fileContent ?? "");
   const similarity = note.metadata.score;
 
   const loadContent = useCallback(async () => {
@@ -111,10 +114,20 @@ function RelevantNoteHoverCard({
     }
   }, [open, loadContent]);
 
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    // Consent to render media lasts only while this preview stays open.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/391
+    if (!nextOpen) setFormatted(false);
+  };
+
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverAnchor asChild>
-        <div onMouseEnter={() => setOpen(true)} onMouseLeave={() => setOpen(false)}>
+        <div
+          onMouseEnter={() => handleOpenChange(true)}
+          onMouseLeave={() => handleOpenChange(false)}
+        >
           {children}
         </div>
       </PopoverAnchor>
@@ -122,8 +135,8 @@ function RelevantNoteHoverCard({
         side="left"
         align="start"
         sideOffset={0}
-        onMouseEnter={() => setOpen(true)}
-        onMouseLeave={() => setOpen(false)}
+        onMouseEnter={() => handleOpenChange(true)}
+        onMouseLeave={() => handleOpenChange(false)}
         onOpenAutoFocus={(e) => e.preventDefault()}
         className="tw-flex tw-w-fit tw-min-w-72 tw-max-w-96 tw-flex-col tw-gap-3 tw-overflow-hidden tw-p-3"
       >
@@ -136,11 +149,37 @@ function RelevantNoteHoverCard({
         </div>
 
         {fileContent && (
-          <Markdown
-            text={fileContent}
-            sourcePath={note.note.path}
-            className="tw-m-0 tw-max-h-64 tw-overflow-y-auto tw-text-xs tw-leading-normal tw-text-muted"
-          />
+          <>
+            {/* Hover must not load media from untrusted notes, including nested embeds.
+                Rendering requires an explicit action each time the card opens.
+                https://github.com/Brevilabs/obsidian-copilot-private/issues/391 */}
+            {formatted ? (
+              <Markdown
+                text={preview.text}
+                sourcePath={note.note.path}
+                className="tw-m-0 tw-max-h-64 tw-overflow-y-auto tw-text-xs tw-leading-normal tw-text-muted"
+              />
+            ) : (
+              <>
+                <div className="tw-max-h-64 tw-overflow-y-auto tw-whitespace-pre-wrap tw-break-words tw-text-xs tw-leading-normal tw-text-muted">
+                  {preview.text}
+                </div>
+                <div className="tw-flex tw-flex-col tw-gap-1">
+                  <Button variant="secondary" size="sm" onClick={() => setFormatted(true)}>
+                    Show formatted preview
+                  </Button>
+                  <span className="tw-text-xs tw-text-faint">May load external media.</span>
+                </div>
+              </>
+            )}
+            {/* Large notes must not freeze the UI just to show a preview.
+                https://github.com/Brevilabs/obsidian-copilot-private/issues/391 */}
+            {preview.truncated && (
+              <span className="tw-text-xs tw-text-faint">
+                Preview shortened. Open note to read the full content.
+              </span>
+            )}
+          </>
         )}
 
         <div className="tw-flex tw-items-center tw-gap-2">


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#391

## Why

Hovering a Relevant Notes result can load tracking images and freeze Obsidian on large notes. Renderer failures also collapse line breaks. These findings arrived on merged PR #3149.

## What

Hover shows a text preview. **Show formatted preview** explicitly enables Markdown and media for that opening of the card. Previews stop at 30,000 characters with a notice directing readers to **Open note**. Failed Markdown renders preserve line breaks.

## Non goal

Ranking, live refresh, note loading, and Add to Chat behavior.

## Screenshot

Same deterministic gallery note in Obsidian, since live relevance results depend on vault indexing.

| Before | After |
| --- | --- |
| ![Automatic Markdown preview](https://github.com/user-attachments/assets/25a903f0-6de6-4182-a05c-7c0935a52764) | ![Text preview with explicit formatting action](https://github.com/user-attachments/assets/57ad7595-867f-4b1f-b562-26253e3745d2) |

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Tests cover consent, reopening, truncation, fallback, and recovery |
| A defect would fail CI or be obvious on first use | ✅ | Renderer invocation and input size are asserted |
| A revert fully restores prior state, including persisted data | ✅ | No persisted changes |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Note rendering now requires a click before it can load external media |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Existing component contracts remain intact |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Local hover state only; renderer lifecycle unchanged |
| No hot-path behavior lacks deterministic coverage | ✅ | Cap, renderer handoff, and failure paths have regression tests |
| No new dependency | ✅ | Dependency manifests unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Preview layout is visible on hover |

Review: inspect `RelevantNoteHoverCard` in `src/components/chat-components/ui/RelevantNoteRow.tsx` and the failure handler in `Markdown` in `src/components/Markdown.tsx`, then exercise the media and failure cases below.

## Verification

1. Hover a note with Markdown images, raw HTML media, or an embedded note. Expect readable source text and no media loading. Click **Show formatted preview** to enable rendering; close and reopen to require the action again.
2. Preview a note longer than 30,000 characters. Expect a shortened preview notice, scrolling, and visible **Open note** and **Add to Chat** actions. Open the note to read it in full.
3. Preview a short note containing headings, code, and relative links. Click to format it and confirm links resolve relative to that note.
4. Force a Markdown postprocessor to throw on a multiline note. After clicking to format, expect readable text with preserved line breaks.
