### PR TITLE
[Chat context] - Step 1: Support Miyo context retrieval

### DIFF
--- a/docs/vault-search-and-indexing.md
+++ b/docs/vault-search-and-indexing.md
@@ -104,6 +104,8 @@ Miyo's Connector can let supported ChatGPT and Claude clients work with files yo
 
 Connector access is separate from Agent Chat search. Review the folders, remote access, and write permissions in Miyo before enabling it. This is the ownership advantage of Miyo: one local-first knowledge layer can serve several AI tools without turning Copilot's private plugin data into the permanent home of your knowledge.
 
+Copilot uses Miyo’s recommendation API for related notes. Older Miyo installations continue to support recommendations from the editor note. Update Miyo to use conversation context for recommendations.
+
 ## Troubleshooting
 
 - **Unavailable:** open Miyo, return to **Settings → Copilot → Miyo**, and retry. Check the remote server address if you configured one.

--- a/src/components/chat-components/ui/RelevantNotesPane.stories.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.stories.tsx
@@ -53,10 +53,6 @@ export default meta;
 
 export const ConnectedScoredResults: StoryObj<RelevantNotesPaneProps> = {};
 
-export const MockChatContext: StoryObj<RelevantNotesPaneProps> = {
-  args: { details: { mock: true } },
-};
-
 export const SkippedChatAttachments: StoryObj<RelevantNotesPaneProps> = {
   args: { details: { skippedAttachments: 2 } },
 };

--- a/src/components/chat-components/ui/RelevantNotesPane.stories.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.stories.tsx
@@ -53,6 +53,30 @@ export default meta;
 
 export const ConnectedScoredResults: StoryObj<RelevantNotesPaneProps> = {};
 
+export const MockChatContext: StoryObj<RelevantNotesPaneProps> = {
+  args: { details: { mock: true } },
+};
+
+export const SkippedChatAttachments: StoryObj<RelevantNotesPaneProps> = {
+  args: { details: { skippedAttachments: 2 } },
+};
+
+export const NoUsableChatContext: StoryObj<RelevantNotesPaneProps> = {
+  args: { status: "no-usable-context", details: { skippedAttachments: 2 }, noteRows: [] },
+};
+
+export const UnsupportedChatService: StoryObj<RelevantNotesPaneProps> = {
+  args: { status: "unsupported-service", noteRows: [] },
+};
+
+export const ChatContextTooLarge: StoryObj<RelevantNotesPaneProps> = {
+  args: { status: "request-too-large", noteRows: [] },
+};
+
+export const ChatRequestFailure: StoryObj<RelevantNotesPaneProps> = {
+  args: { status: "request-error", noteRows: [] },
+};
+
 export const MatchedFilesUnavailable: StoryObj<RelevantNotesPaneProps> = {
   args: { status: "matches", noteRows: [] },
 };

--- a/src/components/chat-components/ui/RelevantNotesPane.test.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.test.tsx
@@ -42,6 +42,13 @@ describe("RelevantNotesPane", () => {
       }
     );
 
+    it("describes skipped sources without assuming an indexing failure (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)", () => {
+      render(<RelevantNotesPane {...BASE_PROPS} details={{ skippedAttachments: 1 }} />);
+      expect(
+        screen.getByText("Skipped attachments: 1. They aren't available for this request.")
+      ).toBeTruthy();
+    });
+
     it.each(["matches", "no-usable-context"] as const)(
       "shows mock and skipped-source notices with %s (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)",
       (status) => {

--- a/src/components/chat-components/ui/RelevantNotesPane.test.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.test.tsx
@@ -50,26 +50,17 @@ describe("RelevantNotesPane", () => {
     });
 
     it.each(["matches", "no-usable-context"] as const)(
-      "shows mock and skipped-source notices with %s (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)",
+      "shows skipped-source notices with %s (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)",
       (status) => {
         render(
-          <RelevantNotesPane
-            {...BASE_PROPS}
-            status={status}
-            details={{ mock: true, skippedAttachments: 2 }}
-          />
+          <RelevantNotesPane {...BASE_PROPS} status={status} details={{ skippedAttachments: 2 }} />
         );
-        expect(
-          screen.getByText("Mock preview: these are example notes, not relevance results.")
-        ).toBeTruthy();
         expect(screen.getByText(/Skipped attachments: 2/)).toBeTruthy();
       }
     );
 
-    it("omits notices for real results without skipped sources (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)", () => {
-      render(
-        <RelevantNotesPane {...BASE_PROPS} details={{ mock: false, skippedAttachments: 0 }} />
-      );
+    it("omits notices without skipped sources (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)", () => {
+      render(<RelevantNotesPane {...BASE_PROPS} details={{ skippedAttachments: 0 }} />);
       expect(screen.queryByRole("status")).toBeNull();
     });
 

--- a/src/components/chat-components/ui/RelevantNotesPane.test.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.test.tsx
@@ -24,6 +24,48 @@ describe("RelevantNotesPane", () => {
       jest.clearAllMocks();
     });
 
+    it.each([
+      ["no-usable-context", "No usable chat context"],
+      ["unsupported-service", "Update Miyo for chat context"],
+      ["request-too-large", "Chat context is too large"],
+      ["request-error", "Miyo couldn't use this chat context"],
+    ] as const)(
+      "explains %s without showing stale rows (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)",
+      (status, title) => {
+        render(<RelevantNotesPane {...BASE_PROPS} status={status} />);
+        expect(screen.getByText(title)).toBeTruthy();
+        expect(screen.queryByText("Related note")).toBeNull();
+        if (status === "unsupported-service" || status === "request-error") {
+          fireEvent.click(screen.getByRole("button", { name: "Open Miyo settings" }));
+          expect(BASE_ACTIONS.onOpenMiyoSettings).toHaveBeenCalledTimes(1);
+        }
+      }
+    );
+
+    it.each(["matches", "no-usable-context"] as const)(
+      "shows mock and skipped-source notices with %s (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)",
+      (status) => {
+        render(
+          <RelevantNotesPane
+            {...BASE_PROPS}
+            status={status}
+            details={{ mock: true, skippedAttachments: 2 }}
+          />
+        );
+        expect(
+          screen.getByText("Mock preview: these are example notes, not relevance results.")
+        ).toBeTruthy();
+        expect(screen.getByText(/Skipped attachments: 2/)).toBeTruthy();
+      }
+    );
+
+    it("omits notices for real results without skipped sources (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)", () => {
+      render(
+        <RelevantNotesPane {...BASE_PROPS} details={{ mock: false, skippedAttachments: 0 }} />
+      );
+      expect(screen.queryByRole("status")).toBeNull();
+    });
+
     it("shows neutral loading feedback while the Miyo request is pending (https://github.com/Brevilabs/obsidian-copilot-private/issues/280)", () => {
       render(<RelevantNotesPane {...BASE_PROPS} status="loading" noteRows={[]} />);
 

--- a/src/components/chat-components/ui/RelevantNotesPane.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.tsx
@@ -312,21 +312,12 @@ export function RelevantNotesPane({
       break;
   }
 
-  // Mock suggestions and skipped sources remain visible even for an empty result.
+  // Skipped sources remain visible even for an empty result.
   // https://github.com/Brevilabs/obsidian-copilot-private/issues/383
-  const notices = (
-    <>
-      {details?.mock && (
-        <p role="status" className="tw-m-0 tw-p-2 tw-text-xs tw-text-muted">
-          Mock preview: these are example notes, not relevance results.
-        </p>
-      )}
-      {!!details?.skippedAttachments && (
-        <p role="status" className="tw-m-0 tw-p-2 tw-text-xs tw-text-muted">
-          Skipped attachments: {details.skippedAttachments}. They aren't available for this request.
-        </p>
-      )}
-    </>
+  const notices = !!details?.skippedAttachments && (
+    <p role="status" className="tw-m-0 tw-p-2 tw-text-xs tw-text-muted">
+      Skipped attachments: {details.skippedAttachments}. They aren't available for this request.
+    </p>
   );
 
   return (

--- a/src/components/chat-components/ui/RelevantNotesPane.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.tsx
@@ -36,6 +36,10 @@ interface GuidancePanelProps {
     | "indexing"
     | "index-error"
     | "excluded"
+    | "no-usable-context"
+    | "unsupported-service"
+    | "request-too-large"
+    | "request-error"
     | "not-indexed";
   title: string;
   description: string;
@@ -96,6 +100,53 @@ export function RelevantNotesPane({
   // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
   let guidancePanel: React.ReactNode = null;
   switch (status) {
+    // An unusable chat or incompatible service must explain the failure instead
+    // of silently showing results for an unrelated editor note.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/383
+    case "no-usable-context":
+      guidancePanel = (
+        <GuidancePanel
+          id="no-usable-context"
+          title="No usable chat context"
+          description="The attachments aren't available in Miyo. Write a message or add an indexed note to find related notes."
+        />
+      );
+      break;
+    case "unsupported-service":
+      guidancePanel = (
+        <GuidancePanel
+          id="unsupported-service"
+          title="Update Miyo for chat context"
+          description="This Miyo service doesn't support chat-context retrieval. Connect a compatible Miyo version and try again."
+        >
+          <Button variant="default" size="sm" onClick={actions.onOpenMiyoSettings}>
+            Open Miyo settings
+          </Button>
+        </GuidancePanel>
+      );
+      break;
+    case "request-too-large":
+      guidancePanel = (
+        <GuidancePanel
+          id="request-too-large"
+          title="Chat context is too large"
+          description="Miyo couldn't accept this request. Remove some attached context or try a shorter conversation."
+        />
+      );
+      break;
+    case "request-error":
+      guidancePanel = (
+        <GuidancePanel
+          id="request-error"
+          title="Miyo couldn't use this chat context"
+          description="Check that this vault is registered in Miyo, then try again."
+        >
+          <Button variant="default" size="sm" onClick={actions.onOpenMiyoSettings}>
+            Open Miyo settings
+          </Button>
+        </GuidancePanel>
+      );
+      break;
     case "disabled":
       guidancePanel = (
         <GuidancePanel
@@ -261,16 +312,39 @@ export function RelevantNotesPane({
       break;
   }
 
-  if (status !== "matches" || noteRows.length === 0) {
-    return (
-      <div
-        data-relevant-notes-empty-state
-        className="tw-flex tw-h-full tw-items-center tw-justify-center tw-px-4"
-      >
-        {guidancePanel ?? <span className="tw-text-sm tw-text-muted">No relevant notes found</span>}
-      </div>
-    );
-  }
+  // Mock suggestions and skipped sources remain visible even for an empty result.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/383
+  const notices = (
+    <>
+      {details?.mock && (
+        <p role="status" className="tw-m-0 tw-p-2 tw-text-xs tw-text-muted">
+          Mock preview: these are example notes, not relevance results.
+        </p>
+      )}
+      {!!details?.skippedAttachments && (
+        <p role="status" className="tw-m-0 tw-p-2 tw-text-xs tw-text-muted">
+          Skipped attachments: {details.skippedAttachments}. They aren't indexed or supported by
+          Miyo.
+        </p>
+      )}
+    </>
+  );
 
-  return <div className="tw-flex tw-flex-col tw-gap-0.5">{noteRows}</div>;
+  return (
+    <div className="tw-flex tw-h-full tw-flex-col tw-gap-0.5">
+      {notices}
+      {status !== "matches" || noteRows.length === 0 ? (
+        <div
+          data-relevant-notes-empty-state
+          className="tw-flex tw-flex-1 tw-items-center tw-justify-center tw-px-4"
+        >
+          {guidancePanel ?? (
+            <span className="tw-text-sm tw-text-muted">No relevant notes found</span>
+          )}
+        </div>
+      ) : (
+        noteRows
+      )}
+    </div>
+  );
 }

--- a/src/components/chat-components/ui/RelevantNotesPane.tsx
+++ b/src/components/chat-components/ui/RelevantNotesPane.tsx
@@ -323,8 +323,7 @@ export function RelevantNotesPane({
       )}
       {!!details?.skippedAttachments && (
         <p role="status" className="tw-m-0 tw-p-2 tw-text-xs tw-text-muted">
-          Skipped attachments: {details.skippedAttachments}. They aren't indexed or supported by
-          Miyo.
+          Skipped attachments: {details.skippedAttachments}. They aren't available for this request.
         </p>
       )}
     </>

--- a/src/miyo/MiyoClient.test.ts
+++ b/src/miyo/MiyoClient.test.ts
@@ -265,6 +265,20 @@ describe("MiyoClient", () => {
         );
       }
     );
+    it.each([{}, { status: "error" }])(
+      "does not classify unhealthy or malformed health as compatibility: %j (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)",
+      async (health) => {
+        mockedRequestUrl
+          .mockResolvedValueOnce({ status: 404, json: {} } as RequestUrlResponse)
+          .mockResolvedValueOnce({ status: 200, json: health } as RequestUrlResponse);
+        await expect(
+          new MiyoClient().recommend("http://localhost:8742", {
+            folder_name: "Vault",
+            draft: "topic",
+          })
+        ).rejects.toMatchObject({ status: 404 });
+      }
+    );
   });
 
   describe("searchRelated()", () => {

--- a/src/miyo/MiyoClient.test.ts
+++ b/src/miyo/MiyoClient.test.ts
@@ -184,7 +184,7 @@ describe("MiyoClient", () => {
     );
   });
 
-  describe("searchRelatedContext()", () => {
+  describe("recommend()", () => {
     it("sends the agreed contract without logging conversation text even with debug enabled (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)", async () => {
       mockedGetSettings.mockReturnValue({ plusLicenseKey: "key", debug: true } as CopilotSettings);
       const response = {
@@ -203,12 +203,10 @@ describe("MiyoClient", () => {
         excerpts: ["private excerpt"],
         file_paths: ["Vault/file.md"],
       };
-      expect(await new MiyoClient().searchRelatedContext("http://localhost:8742", request)).toEqual(
-        response
-      );
+      expect(await new MiyoClient().recommend("http://localhost:8742", request)).toEqual(response);
       expect(mockedRequestUrl).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: "http://localhost:8742/v0/search/related/context",
+          url: "http://localhost:8742/v0/recommend",
           body: JSON.stringify(request),
         })
       );
@@ -221,7 +219,7 @@ describe("MiyoClient", () => {
         json: "private echoed draft",
       } as RequestUrlResponse);
       await expect(
-        new MiyoClient().searchRelatedContext("http://localhost:8742", {
+        new MiyoClient().recommend("http://localhost:8742", {
           folder_name: "Vault",
           draft: "private echoed draft",
         })
@@ -236,12 +234,136 @@ describe("MiyoClient", () => {
         json: { code: "empty_context", detail: "private draft" },
       } as RequestUrlResponse);
       await expect(
-        new MiyoClient().searchRelatedContext("http://localhost:8742", { folder_name: "Vault" })
+        new MiyoClient().recommend("http://localhost:8742", { folder_name: "Vault" })
       ).rejects.toMatchObject({
         status: 400,
         errorCode: "empty_context",
         message: expect.not.stringContaining("private draft") as unknown,
       });
+    });
+    it.each([true, false])(
+      "confirms a gateway 404 against Miyo health before classifying support: %s (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)",
+      async (healthy) => {
+        mockedRequestUrl
+          .mockResolvedValueOnce({ status: 404, json: {} } as RequestUrlResponse)
+          .mockResolvedValueOnce({
+            status: healthy ? 200 : 503,
+            json: healthy ? { status: "ok" } : {},
+          } as RequestUrlResponse);
+        await expect(
+          new MiyoClient().recommend("http://localhost:8742", {
+            folder_name: "Vault",
+            draft: "topic",
+          })
+        ).rejects.toMatchObject(
+          healthy ? { status: 501, errorCode: "not_implemented" } : { status: 404 }
+        );
+        expect(mockedRequestUrl).toHaveBeenCalledTimes(2);
+        expect(mockedRequestUrl).toHaveBeenNthCalledWith(
+          2,
+          expect.objectContaining({ url: "http://127.0.0.1:8742/v0/health" })
+        );
+      }
+    );
+  });
+
+  describe("searchRelated()", () => {
+    const baseUrl = "http://localhost:8742";
+    const response = {
+      status: "ok",
+      results: [{ path: "Vault/answer.md", score: 0.8 }],
+      count: 1,
+      skipped_files: [],
+      context_truncated: false,
+      execution_time_ms: 1,
+    };
+    it("uses one file reference and preserves server results (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)", async () => {
+      mockedRequestUrl.mockResolvedValue({ status: 200, json: response } as RequestUrlResponse);
+      expect(
+        await new MiyoClient().searchRelated(baseUrl, "Vault/seed.md", {
+          folderName: "Vault",
+          limit: 20,
+        })
+      ).toEqual(response);
+      expect(mockedRequestUrl).toHaveBeenCalledTimes(1);
+      expect(mockedRequestUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: `${baseUrl}/v0/recommend`,
+          body: JSON.stringify({ folder_name: "Vault", file_paths: ["Vault/seed.md"], limit: 20 }),
+        })
+      );
+    });
+    it("falls back on an old service's structured 501 (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)", async () => {
+      mockedRequestUrl
+        .mockResolvedValueOnce({
+          status: 501,
+          json: { error: "not_implemented" },
+        } as RequestUrlResponse)
+        .mockResolvedValueOnce({
+          status: 200,
+          json: { results: response.results },
+        } as RequestUrlResponse);
+      expect(
+        await new MiyoClient().searchRelated(baseUrl, "Vault/seed.md", {
+          folderName: "Vault",
+          limit: 20,
+        })
+      ).toEqual({ results: response.results });
+      expect(mockedRequestUrl).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          url: `${baseUrl}/v0/search/related`,
+          body: JSON.stringify({ file_path: "Vault/seed.md", folder_name: "Vault", limit: 20 }),
+        })
+      );
+    });
+    it("preserves folderless legacy calls (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)", async () => {
+      mockedRequestUrl.mockResolvedValue({
+        status: 200,
+        json: { results: [] },
+      } as RequestUrlResponse);
+      await new MiyoClient().searchRelated(baseUrl, "Vault/seed.md");
+      expect(mockedRequestUrl).toHaveBeenCalledWith(
+        expect.objectContaining({ url: `${baseUrl}/v0/search/related` })
+      );
+    });
+    it("keeps source classification without legacy retrieval for skipped context (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)", async () => {
+      mockedRequestUrl.mockResolvedValue({
+        status: 200,
+        json: { ...response, status: "no_usable_context", results: [] },
+      } as RequestUrlResponse);
+      await expect(
+        new MiyoClient().searchRelated(baseUrl, "Vault/seed.md", { folderName: "Vault" })
+      ).rejects.toMatchObject({ status: 404 });
+      expect(mockedRequestUrl).toHaveBeenCalledTimes(1);
+    });
+    it.each([400, 401, 403, 413, 500, 501, 503])(
+      "does not fall back on HTTP %s without unsupported-route proof (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)",
+      async (status) => {
+        mockedRequestUrl.mockResolvedValue({
+          status,
+          json: { code: "failure" },
+        } as RequestUrlResponse);
+        await expect(
+          new MiyoClient().searchRelated(baseUrl, "Vault/seed.md", { folderName: "Vault" })
+        ).rejects.toMatchObject({ status });
+        expect(mockedRequestUrl).toHaveBeenCalledTimes(1);
+      }
+    );
+    it("does not fall back on empty results or a transport failure (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)", async () => {
+      mockedRequestUrl.mockResolvedValueOnce({
+        status: 200,
+        json: { ...response, results: [], count: 0 },
+      } as RequestUrlResponse);
+      expect(
+        (await new MiyoClient().searchRelated(baseUrl, "Vault/seed.md", { folderName: "Vault" }))
+          .results
+      ).toEqual([]);
+      mockedRequestUrl.mockRejectedValueOnce(new Error("offline"));
+      await expect(
+        new MiyoClient().searchRelated(baseUrl, "Vault/seed.md", { folderName: "Vault" })
+      ).rejects.toThrow("offline");
+      expect(mockedRequestUrl).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/miyo/MiyoClient.test.ts
+++ b/src/miyo/MiyoClient.test.ts
@@ -1,4 +1,4 @@
-import { logInfo } from "@/logger";
+import { logInfo, logError } from "@/logger";
 import { MiyoClient, MiyoRequestError } from "@/miyo/MiyoClient";
 import { MiyoServiceDiscovery } from "@/miyo/MiyoServiceDiscovery";
 import { getSettings } from "@/settings/model";
@@ -182,6 +182,67 @@ describe("MiyoClient", () => {
         method: "GET",
       })
     );
+  });
+
+  describe("searchRelatedContext()", () => {
+    it("sends the agreed contract without logging conversation text even with debug enabled (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)", async () => {
+      mockedGetSettings.mockReturnValue({ plusLicenseKey: "key", debug: true } as CopilotSettings);
+      const response = {
+        status: "ok",
+        results: [],
+        count: 0,
+        skipped_files: [],
+        context_truncated: true,
+        execution_time_ms: 420,
+      };
+      mockedRequestUrl.mockResolvedValue({ status: 200, json: response } as RequestUrlResponse);
+      const request = {
+        folder_name: "Vault",
+        messages: [{ role: "user" as const, content: "private conversation" }],
+        draft: "private draft",
+        excerpts: ["private excerpt"],
+        file_paths: ["Vault/file.md"],
+      };
+      expect(await new MiyoClient().searchRelatedContext("http://localhost:8742", request)).toEqual(
+        response
+      );
+      expect(mockedRequestUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "http://localhost:8742/v0/search/related/context",
+          body: JSON.stringify(request),
+        })
+      );
+      expect(JSON.stringify(mockedLogInfo.mock.calls)).not.toContain("private");
+    });
+    it("redacts malformed response parse errors (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)", async () => {
+      mockedGetSettings.mockReturnValue({ plusLicenseKey: "key", debug: true } as CopilotSettings);
+      mockedRequestUrl.mockResolvedValue({
+        status: 400,
+        json: "private echoed draft",
+      } as RequestUrlResponse);
+      await expect(
+        new MiyoClient().searchRelatedContext("http://localhost:8742", {
+          folder_name: "Vault",
+          draft: "private echoed draft",
+        })
+      ).rejects.toBeInstanceOf(MiyoRequestError);
+      expect(JSON.stringify((logError as jest.Mock).mock.calls)).not.toContain(
+        "private echoed draft"
+      );
+    });
+    it("retains error codes without retaining a server echo (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)", async () => {
+      mockedRequestUrl.mockResolvedValue({
+        status: 400,
+        json: { code: "empty_context", detail: "private draft" },
+      } as RequestUrlResponse);
+      await expect(
+        new MiyoClient().searchRelatedContext("http://localhost:8742", { folder_name: "Vault" })
+      ).rejects.toMatchObject({
+        status: 400,
+        errorCode: "empty_context",
+        message: expect.not.stringContaining("private draft") as unknown,
+      });
+    });
   });
 
   describe("fileStatus()", () => {

--- a/src/miyo/MiyoClient.ts
+++ b/src/miyo/MiyoClient.ts
@@ -156,6 +156,25 @@ export interface MiyoSearchResponse {
 /**
  * Minimal result item for related-note queries.
  */
+export interface RelatedContextRequest {
+  folder_name: string;
+  messages?: Array<{ role: "user" | "assistant"; content: string }>;
+  draft?: string;
+  excerpts?: string[];
+  file_paths?: string[];
+  limit?: number;
+  filters?: MiyoSearchFilter[];
+}
+
+export interface RelatedContextResponse {
+  status: "ok" | "no_usable_context";
+  results: Array<{ path: string; score: number }>;
+  count: number;
+  skipped_files: Array<{ path: string; reason: "not_indexed" | "unsupported" | "outside_scope" }>;
+  context_truncated: boolean;
+  execution_time_ms: number;
+}
+
 export interface MiyoRelatedSearchResult {
   path: string;
   score: number;
@@ -587,6 +606,21 @@ export class MiyoClient {
     });
   }
 
+  /** Search transient chat context without indexing its contents.
+   * @param baseUrl - Resolved Miyo endpoint.
+   * @param request - Vault-scoped visible text and indexed file references.
+   */
+  public async searchRelatedContext(
+    baseUrl: string,
+    request: RelatedContextRequest
+  ): Promise<RelatedContextResponse> {
+    return this.requestJson<RelatedContextResponse>(baseUrl, "/v0/search/related/context", {
+      method: "POST",
+      body: request,
+      sensitive: true,
+    });
+  }
+
   /**
    * Classify one file when related search cannot find indexed chunks for it.
    *
@@ -652,6 +686,7 @@ export class MiyoClient {
     options: {
       method: "GET" | "POST";
       body?: unknown;
+      sensitive?: boolean;
       query?: Record<string, string | number | boolean | undefined>;
     }
   ): Promise<T> {
@@ -671,7 +706,9 @@ export class MiyoClient {
       url: url.toString(),
       hasBody: Boolean(body),
       hasAuthorizationHeader: Boolean(headers.Authorization),
-      ...(getSettings().debug && options.method === "POST" ? { postBody: options.body } : {}),
+      ...(getSettings().debug && options.method === "POST" && !options.sensitive
+        ? { postBody: options.body }
+        : {}),
     });
 
     const response = await requestUrl({
@@ -684,19 +721,28 @@ export class MiyoClient {
     });
 
     if (response.status >= 400) {
-      const errorPayload = this.parseResponseJson<{ detail?: string; error?: string }>(
-        response.json,
-        response.text
-      );
-      const errorText = errorPayload?.detail || response.text || errorPayload?.error || "";
+      const errorPayload = this.parseResponseJson<{
+        detail?: string;
+        error?: string;
+        code?: string;
+      }>(response.json, response.text, options.sensitive);
+      // Never retain server echoes of private conversation content.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/383
+      const errorText = options.sensitive
+        ? "Chat-context retrieval failed"
+        : errorPayload?.detail || response.text || errorPayload?.error || "";
       logWarn(`Miyo request failed (${response.status}): ${errorText}`);
       // Relevant Notes must distinguish an unindexed source from a service
       // outage without parsing human-readable error messages.
       // https://github.com/Brevilabs/obsidian-copilot-private/issues/280
-      throw new MiyoRequestError(response.status, errorText, errorPayload?.error);
+      throw new MiyoRequestError(
+        response.status,
+        errorText,
+        errorPayload?.code ?? errorPayload?.error
+      );
     }
 
-    const parsed = this.parseResponseJson<T>(response.json, response.text);
+    const parsed = this.parseResponseJson<T>(response.json, response.text, options.sensitive);
     if (getSettings().debug) {
       logInfo(`Miyo request ${options.method} ${url.toString()} succeeded`);
     }
@@ -710,12 +756,16 @@ export class MiyoClient {
    * @param text - Raw response text.
    * @returns Parsed JSON value or empty object.
    */
-  private parseResponseJson<T>(json: unknown, text?: string): T {
+  private parseResponseJson<T>(json: unknown, text?: string, sensitive = false): T {
     if (typeof json === "string") {
       try {
         return JSON.parse(json) as T;
       } catch (error) {
-        logError(`Failed to parse Miyo JSON response: ${err2String(error)}`);
+        logError(
+          sensitive
+            ? "Invalid Miyo chat response"
+            : `Failed to parse Miyo JSON response: ${err2String(error)}`
+        );
         return {} as T;
       }
     }
@@ -726,7 +776,11 @@ export class MiyoClient {
       try {
         return JSON.parse(text) as T;
       } catch (error) {
-        logError(`Failed to parse Miyo text response: ${err2String(error)}`);
+        logError(
+          sensitive
+            ? "Invalid Miyo chat response"
+            : `Failed to parse Miyo text response: ${err2String(error)}`
+        );
         return {} as T;
       }
     }

--- a/src/miyo/MiyoClient.ts
+++ b/src/miyo/MiyoClient.ts
@@ -652,7 +652,7 @@ export class MiyoClient {
       if (
         error instanceof MiyoRequestError &&
         error.status === 404 &&
-        typeof (await this.fetchHealth(baseUrl))?.status === "string"
+        (await this.fetchHealth(baseUrl))?.status === "ok"
       ) {
         throw new MiyoRequestError(501, "Recommendations are unsupported", "not_implemented");
       }

--- a/src/miyo/MiyoClient.ts
+++ b/src/miyo/MiyoClient.ts
@@ -581,7 +581,7 @@ export class MiyoClient {
    * Execute related-notes search for a source note path.
    *
    * @param baseUrl - Miyo base URL.
-   * @param filePath - Absolute source note path to find related notes for.
+   * @param filePath - Source in Miyo public `FolderName/path/to/file` format.
    * @param options - Optional folder name, result limit, and filters.
    * @returns Search response in the same shape as /v0/search.
    */
@@ -594,6 +594,31 @@ export class MiyoClient {
       filters?: MiyoSearchFilter[];
     }
   ): Promise<MiyoRelatedSearchResponse> {
+    // Old Miyo installations must keep serving note recommendations during client upgrades.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/383
+    if (options?.folderName) {
+      try {
+        const response = await this.recommend(baseUrl, {
+          folder_name: options.folderName,
+          file_paths: [filePath],
+          limit: options.limit ?? 10,
+          filters: options.filters,
+        });
+        // Preserve the existing file-status lookup for a skipped single source.
+        // https://github.com/Brevilabs/obsidian-copilot-private/issues/383
+        if (response.status === "no_usable_context") {
+          throw new MiyoRequestError(404, "No indexed context for source file");
+        }
+        return response;
+      } catch (error) {
+        if (
+          !(error instanceof MiyoRequestError) ||
+          error.status !== 501 ||
+          error.errorCode !== "not_implemented"
+        )
+          throw error;
+      }
+    }
     const payload = {
       file_path: filePath,
       ...(options?.folderName ? { folder_name: options.folderName } : {}),
@@ -606,19 +631,33 @@ export class MiyoClient {
     });
   }
 
-  /** Search transient chat context without indexing its contents.
+  /** Recommend notes from indexed file references and optional text without indexing it.
    * @param baseUrl - Resolved Miyo endpoint.
    * @param request - Vault-scoped visible text and indexed file references.
    */
-  public async searchRelatedContext(
+  public async recommend(
     baseUrl: string,
     request: RelatedContextRequest
   ): Promise<RelatedContextResponse> {
-    return this.requestJson<RelatedContextResponse>(baseUrl, "/v0/search/related/context", {
-      method: "POST",
-      body: request,
-      sensitive: true,
-    });
+    try {
+      return await this.requestJson<RelatedContextResponse>(baseUrl, "/v0/recommend", {
+        method: "POST",
+        body: request,
+        sensitive: true,
+      });
+    } catch (error) {
+      // Gateways may translate an old Miyo's missing route into 404. Confirm Miyo
+      // is reachable before offering compatibility fallback instead of connection recovery.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/383
+      if (
+        error instanceof MiyoRequestError &&
+        error.status === 404 &&
+        typeof (await this.fetchHealth(baseUrl))?.status === "string"
+      ) {
+        throw new MiyoRequestError(501, "Recommendations are unsupported", "not_implemented");
+      }
+      throw error;
+    }
   }
 
   /**

--- a/src/search/chatRelevantNotesContext.ts
+++ b/src/search/chatRelevantNotesContext.ts
@@ -1,0 +1,8 @@
+import type { RelatedContextRequest } from "@/miyo/MiyoClient";
+
+export interface ChatRelevantNotesContext {
+  id: string;
+  request: RelatedContextRequest;
+  skippedAttachments: number;
+  addFile: (path: string) => void;
+}

--- a/src/search/findChatRelevantNotes.test.ts
+++ b/src/search/findChatRelevantNotes.test.ts
@@ -4,7 +4,6 @@ import { App, TFile } from "obsidian";
 jest.mock("@/settings/model", () => ({ getSettings: () => ({ plusLicenseKey: "key" }) }));
 jest.mock("@/miyo/miyoUtils", () => ({
   getMiyoCustomUrl: () => "url",
-  getMiyoFilePath: (_app: unknown, path: string) => `Vault/${path}`,
   getVaultRelativeMiyoPath: (_app: unknown, path: string) => path.replace(/^Vault\//, ""),
 }));
 jest.mock("@/miyo/MiyoClient", () => {
@@ -22,14 +21,6 @@ describe("findChatRelevantNotes", () => {
             basename: path.replace(".md", ""),
             extension: "md",
           }),
-        getMarkdownFiles: () => [
-          Object.assign(new (TFile as unknown as new (path: string) => TFile)("file.md"), {
-            path: "b.md",
-          }),
-          Object.assign(new (TFile as unknown as new (path: string) => TFile)("file.md"), {
-            path: "a.md",
-          }),
-        ],
       },
     } as unknown as App;
     beforeEach(() => {
@@ -54,6 +45,11 @@ describe("findChatRelevantNotes", () => {
         request: { folder_name: "Vault", draft: "topic", file_paths: ["Vault/a.md"] },
         skippedAttachments: 1,
         addFile: jest.fn(),
+      });
+      expect(search).toHaveBeenCalledWith("url", {
+        folder_name: "Vault",
+        draft: "topic",
+        file_paths: ["Vault/a.md"],
       });
       expect(result.notes.map((entry) => entry.note.path)).toEqual(["b.md"]);
       expect(result.notes[0].metadata.score).toBe(0.6);
@@ -101,21 +97,6 @@ describe("findChatRelevantNotes", () => {
         request: { folder_name: "Vault", file_paths: ["Vault/a.md"] },
       });
       expect(filtered.notes).toBe(blank.notes);
-    });
-    it("uses an explicitly labeled fixture without a service request (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)", async () => {
-      const result = await findChatRelevantNotes(
-        app,
-        {
-          id: "a",
-          request: { folder_name: "Vault", draft: "topic" },
-          skippedAttachments: 0,
-          addFile: jest.fn(),
-        },
-        true
-      );
-      expect(result.details?.mock).toBe(true);
-      expect(result.notes.map((entry) => entry.note.path)).toEqual(["a.md", "b.md"]);
-      expect(search).not.toHaveBeenCalled();
     });
     it("identifies only a structured unsupported route for host fallback (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)", async () => {
       for (const errorCode of ["not_implemented", undefined]) {

--- a/src/search/findChatRelevantNotes.test.ts
+++ b/src/search/findChatRelevantNotes.test.ts
@@ -36,7 +36,7 @@ describe("findChatRelevantNotes", () => {
       search.mockReset();
       (MiyoClient as unknown as jest.Mock).mockImplementation(() => ({
         resolveBaseUrl: async () => "url",
-        searchRelatedContext: search,
+        recommend: search,
         fetchHealth: async () => ({ status: "ok" }),
       }));
     });
@@ -84,8 +84,20 @@ describe("findChatRelevantNotes", () => {
       expect(result.notes.map((entry) => entry.note.path)).toEqual(["a.md", "b.md"]);
       expect(search).not.toHaveBeenCalled();
     });
+    it("identifies only a structured unsupported route for host fallback (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)", async () => {
+      for (const errorCode of ["not_implemented", undefined]) {
+        search.mockRejectedValue(new MiyoRequestError(501, "", errorCode));
+        const result = await findChatRelevantNotes(app, {
+          id: "a",
+          request: { folder_name: "Vault", draft: "topic" },
+          skippedAttachments: 0,
+          addFile: jest.fn(),
+        });
+        expect(result.status).toBe(errorCode ? "unsupported-service" : "unavailable");
+      }
+    });
     it.each([
-      [404, "unsupported-service"],
+      [404, "unavailable"],
       [400, "request-error"],
       [413, "request-too-large"],
       [503, "unavailable"],

--- a/src/search/findChatRelevantNotes.test.ts
+++ b/src/search/findChatRelevantNotes.test.ts
@@ -69,6 +69,39 @@ describe("findChatRelevantNotes", () => {
       expect(result.status).toBe("no-usable-context");
       expect(search).not.toHaveBeenCalled();
     });
+    it("keeps blank-only text local and reuses the empty result slice (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)", async () => {
+      const context = {
+        id: "a",
+        request: {
+          folder_name: "Vault",
+          messages: [{ role: "user" as const, content: "  " }],
+          excerpts: [""],
+          file_paths: [" "],
+        },
+        skippedAttachments: 0,
+        addFile: jest.fn(),
+      };
+      const blank = await findChatRelevantNotes(app, context);
+      expect(blank.status).toBe("no-usable-context");
+      expect(search).not.toHaveBeenCalled();
+      search.mockResolvedValue({ status: "ok", results: [], skipped_files: [] });
+      const empty = await findChatRelevantNotes(app, {
+        ...context,
+        request: { folder_name: "Vault", draft: "topic" },
+      });
+      expect(empty.status).toBe("no-matches");
+      expect(empty.notes).toBe(blank.notes);
+      search.mockResolvedValue({
+        status: "ok",
+        results: [{ path: "Vault/a.md", score: 0.8 }],
+        skipped_files: [],
+      });
+      const filtered = await findChatRelevantNotes(app, {
+        ...context,
+        request: { folder_name: "Vault", file_paths: ["Vault/a.md"] },
+      });
+      expect(filtered.notes).toBe(blank.notes);
+    });
     it("uses an explicitly labeled fixture without a service request (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)", async () => {
       const result = await findChatRelevantNotes(
         app,

--- a/src/search/findChatRelevantNotes.test.ts
+++ b/src/search/findChatRelevantNotes.test.ts
@@ -1,0 +1,109 @@
+import { findChatRelevantNotes } from "@/search/findChatRelevantNotes";
+import { MiyoClient, MiyoRequestError } from "@/miyo/MiyoClient";
+import { App, TFile } from "obsidian";
+jest.mock("@/settings/model", () => ({ getSettings: () => ({ plusLicenseKey: "key" }) }));
+jest.mock("@/miyo/miyoUtils", () => ({
+  getMiyoCustomUrl: () => "url",
+  getMiyoFilePath: (_app: unknown, path: string) => `Vault/${path}`,
+  getVaultRelativeMiyoPath: (_app: unknown, path: string) => path.replace(/^Vault\//, ""),
+}));
+jest.mock("@/miyo/MiyoClient", () => {
+  const actual = jest.requireActual<typeof import("@/miyo/MiyoClient")>("@/miyo/MiyoClient");
+  return { ...actual, MiyoClient: jest.fn() };
+});
+describe("findChatRelevantNotes", () => {
+  describe("findChatRelevantNotes()", () => {
+    const search = jest.fn();
+    const app = {
+      vault: {
+        getAbstractFileByPath: (path: string) =>
+          Object.assign(new (TFile as unknown as new (path: string) => TFile)("file.md"), {
+            path,
+            basename: path.replace(".md", ""),
+            extension: "md",
+          }),
+        getMarkdownFiles: () => [
+          Object.assign(new (TFile as unknown as new (path: string) => TFile)("file.md"), {
+            path: "b.md",
+          }),
+          Object.assign(new (TFile as unknown as new (path: string) => TFile)("file.md"), {
+            path: "a.md",
+          }),
+        ],
+      },
+    } as unknown as App;
+    beforeEach(() => {
+      search.mockReset();
+      (MiyoClient as unknown as jest.Mock).mockImplementation(() => ({
+        resolveBaseUrl: async () => "url",
+        searchRelatedContext: search,
+        fetchHealth: async () => ({ status: "ok" }),
+      }));
+    });
+    it("preserves order/scores, full-file exclusions and skipped count (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)", async () => {
+      search.mockResolvedValue({
+        status: "ok",
+        results: [
+          { path: "Vault/b.md", score: 0.6 },
+          { path: "Vault/a.md", score: 0.9 },
+        ],
+        skipped_files: [{ path: "Vault/missing.pdf", reason: "not_indexed" }],
+      });
+      const result = await findChatRelevantNotes(app, {
+        id: "a",
+        request: { folder_name: "Vault", draft: "topic", file_paths: ["Vault/a.md"] },
+        skippedAttachments: 1,
+        addFile: jest.fn(),
+      });
+      expect(result.notes.map((entry) => entry.note.path)).toEqual(["b.md"]);
+      expect(result.notes[0].metadata.score).toBe(0.6);
+      expect(result.details?.skippedAttachments).toBe(2);
+    });
+    it("keeps unsupported-only context unavailable without a request (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)", async () => {
+      const result = await findChatRelevantNotes(app, {
+        id: "a",
+        request: { folder_name: "Vault" },
+        skippedAttachments: 1,
+        addFile: jest.fn(),
+      });
+      expect(result.status).toBe("no-usable-context");
+      expect(search).not.toHaveBeenCalled();
+    });
+    it("uses an explicitly labeled fixture without a service request (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)", async () => {
+      const result = await findChatRelevantNotes(
+        app,
+        {
+          id: "a",
+          request: { folder_name: "Vault", draft: "topic" },
+          skippedAttachments: 0,
+          addFile: jest.fn(),
+        },
+        true
+      );
+      expect(result.details?.mock).toBe(true);
+      expect(result.notes.map((entry) => entry.note.path)).toEqual(["a.md", "b.md"]);
+      expect(search).not.toHaveBeenCalled();
+    });
+    it.each([
+      [404, "unsupported-service"],
+      [400, "request-error"],
+      [413, "request-too-large"],
+      [503, "unavailable"],
+    ])(
+      "classifies HTTP %s as %s (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)",
+      async (code, status) => {
+        search.mockRejectedValue(new MiyoRequestError(code, ""));
+        expect(
+          (
+            await findChatRelevantNotes(app, {
+              id: "a",
+              request: { folder_name: "Vault", draft: "topic" },
+              skippedAttachments: 0,
+              addFile: jest.fn(),
+            })
+          ).status
+        ).toBe(status);
+      }
+    );
+  });
+});

--- a/src/search/findChatRelevantNotes.ts
+++ b/src/search/findChatRelevantNotes.ts
@@ -1,5 +1,5 @@
-import { MiyoClient, MiyoRequestError, type RelatedContextResponse } from "@/miyo/MiyoClient";
-import { getMiyoCustomUrl, getMiyoFilePath, getVaultRelativeMiyoPath } from "@/miyo/miyoUtils";
+import { MiyoClient, MiyoRequestError } from "@/miyo/MiyoClient";
+import { getMiyoCustomUrl, getVaultRelativeMiyoPath } from "@/miyo/miyoUtils";
 import type { ChatRelevantNotesContext } from "@/search/chatRelevantNotesContext";
 import type { RelevantNotesResult } from "@/search/findRelevantNotes";
 import { getSettings } from "@/settings/model";
@@ -7,18 +7,16 @@ import { withTimeout } from "@/utils";
 import { App, TFile } from "obsidian";
 
 const EMPTY_NOTES = Object.freeze([]);
-/** Retrieve one chat snapshot; the opt-in fixture exercises the UI without claiming relevance.
+/** Retrieve relevant notes from Miyo for one chat snapshot.
  * @param app - Vault used to resolve result paths.
  * @param context - Isolated composition and visible conversation snapshot.
- * @param mock - Explicit development-only fixture mode.
  */
 export async function findChatRelevantNotes(
   app: App,
-  context: ChatRelevantNotesContext,
-  mock = false
+  context: ChatRelevantNotesContext
 ): Promise<RelevantNotesResult> {
   const { request } = context;
-  const details = { skippedAttachments: context.skippedAttachments, mock };
+  const details = { skippedAttachments: context.skippedAttachments };
   if (
     !request.draft?.trim() &&
     !request.messages?.some((message) => message.content.trim()) &&
@@ -31,36 +29,16 @@ export async function findChatRelevantNotes(
   }
   const client = new MiyoClient({ plusLicenseKey: getSettings().plusLicenseKey });
   try {
-    let response: RelatedContextResponse;
-    if (mock) {
-      // Fixture order is alphabetical, independent of the conversation; it is not a ranking.
-      // https://github.com/Brevilabs/obsidian-copilot-private/issues/383
-      const results = app.vault
-        .getMarkdownFiles()
-        .filter((file) => !request.file_paths?.includes(getMiyoFilePath(app, file.path)))
-        .sort((a, b) => a.path.localeCompare(b.path))
-        .slice(0, request.limit ?? 20)
-        .map((file) => ({ path: getMiyoFilePath(app, file.path), score: 0.73 }));
-      response = {
-        status: "ok",
-        results,
-        count: results.length,
-        skipped_files: [],
-        context_truncated: false,
-        execution_time_ms: 0,
-      };
-    } else {
-      const baseUrl = await withTimeout(
-        () => client.resolveBaseUrl(getMiyoCustomUrl(getSettings())),
-        8000,
-        "Miyo endpoint resolution"
-      );
-      response = await withTimeout(
-        () => client.recommend(baseUrl, request),
-        8000,
-        "Miyo chat related search"
-      );
-    }
+    const baseUrl = await withTimeout(
+      () => client.resolveBaseUrl(getMiyoCustomUrl(getSettings())),
+      8000,
+      "Miyo endpoint resolution"
+    );
+    const response = await withTimeout(
+      () => client.recommend(baseUrl, request),
+      8000,
+      "Miyo chat related search"
+    );
     details.skippedAttachments += response.skipped_files.length;
     const notes = response.results.flatMap(({ path, score }) => {
       const relativePath = getVaultRelativeMiyoPath(app, path);

--- a/src/search/findChatRelevantNotes.ts
+++ b/src/search/findChatRelevantNotes.ts
@@ -1,0 +1,115 @@
+import { MiyoClient, MiyoRequestError, type RelatedContextResponse } from "@/miyo/MiyoClient";
+import { getMiyoCustomUrl, getMiyoFilePath, getVaultRelativeMiyoPath } from "@/miyo/miyoUtils";
+import type { ChatRelevantNotesContext } from "@/search/chatRelevantNotesContext";
+import type { RelevantNotesResult } from "@/search/findRelevantNotes";
+import { getSettings } from "@/settings/model";
+import { withTimeout } from "@/utils";
+import { App, TFile } from "obsidian";
+
+const EMPTY_NOTES = Object.freeze([]);
+/** Retrieve one chat snapshot; the opt-in fixture exercises the UI without claiming relevance.
+ * @param app - Vault used to resolve result paths.
+ * @param context - Isolated composition and visible conversation snapshot.
+ * @param mock - Explicit development-only fixture mode.
+ */
+export async function findChatRelevantNotes(
+  app: App,
+  context: ChatRelevantNotesContext,
+  mock = false
+): Promise<RelevantNotesResult> {
+  const { request } = context;
+  const details = { skippedAttachments: context.skippedAttachments, mock };
+  if (
+    !request.draft?.trim() &&
+    !request.messages?.length &&
+    !request.excerpts?.length &&
+    !request.file_paths?.length
+  ) {
+    // Unsupported-only attachments must stay in chat rather than use an unrelated note.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/383
+    return { notes: EMPTY_NOTES, status: "no-usable-context", details };
+  }
+  const client = new MiyoClient({ plusLicenseKey: getSettings().plusLicenseKey });
+  let baseUrl: string | undefined;
+  try {
+    let response: RelatedContextResponse;
+    if (mock) {
+      // Fixture order is alphabetical, independent of the conversation; it is not a ranking.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/383
+      const results = app.vault
+        .getMarkdownFiles()
+        .filter((file) => !request.file_paths?.includes(getMiyoFilePath(app, file.path)))
+        .sort((a, b) => a.path.localeCompare(b.path))
+        .slice(0, request.limit ?? 20)
+        .map((file) => ({ path: getMiyoFilePath(app, file.path), score: 0.73 }));
+      response = {
+        status: "ok",
+        results,
+        count: results.length,
+        skipped_files: [],
+        context_truncated: false,
+        execution_time_ms: 0,
+      };
+    } else {
+      baseUrl = await withTimeout(
+        () => client.resolveBaseUrl(getMiyoCustomUrl(getSettings())),
+        8000,
+        "Miyo endpoint resolution"
+      );
+      response = await withTimeout(
+        () => client.searchRelatedContext(baseUrl!, request),
+        8000,
+        "Miyo chat related search"
+      );
+    }
+    details.skippedAttachments += response.skipped_files.length;
+    const notes = response.results.flatMap(({ path, score }) => {
+      const relativePath = getVaultRelativeMiyoPath(app, path);
+      const file = app.vault.getAbstractFileByPath(relativePath);
+      if (
+        !(file instanceof TFile) ||
+        file.extension !== "md" ||
+        !Number.isFinite(score) ||
+        request.file_paths?.includes(path)
+      )
+        return [];
+      return [
+        {
+          note: { path: relativePath, title: file.basename },
+          metadata: { score, hasOutgoingLinks: false, hasBacklinks: false },
+        },
+      ];
+    });
+    return {
+      notes,
+      status:
+        response.status === "no_usable_context"
+          ? "no-usable-context"
+          : notes.length
+            ? "matches"
+            : "no-matches",
+      details,
+    };
+  } catch (error) {
+    // Confirm the endpoint itself before interpreting an older service's missing route.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/383
+    if (error instanceof MiyoRequestError && error.status === 404 && baseUrl) {
+      try {
+        if (!(await client.fetchHealth(baseUrl))) throw new Error("Miyo unavailable");
+        return { notes: EMPTY_NOTES, status: "unsupported-service", details };
+      } catch {
+        /* Connection guidance below. */
+      }
+    }
+    return {
+      notes: EMPTY_NOTES,
+      status:
+        error instanceof MiyoRequestError && error.status === 400
+          ? "request-error"
+          : error instanceof MiyoRequestError && error.status === 413
+            ? "request-too-large"
+            : "unavailable",
+      details,
+    };
+  }
+}

--- a/src/search/findChatRelevantNotes.ts
+++ b/src/search/findChatRelevantNotes.ts
@@ -21,16 +21,15 @@ export async function findChatRelevantNotes(
   const details = { skippedAttachments: context.skippedAttachments, mock };
   if (
     !request.draft?.trim() &&
-    !request.messages?.length &&
-    !request.excerpts?.length &&
-    !request.file_paths?.length
+    !request.messages?.some((message) => message.content.trim()) &&
+    !request.excerpts?.some((excerpt) => excerpt.trim()) &&
+    !request.file_paths?.some((path) => path.trim())
   ) {
     // Unsupported-only attachments must stay in chat rather than use an unrelated note.
     // https://github.com/Brevilabs/obsidian-copilot-private/issues/383
     return { notes: EMPTY_NOTES, status: "no-usable-context", details };
   }
   const client = new MiyoClient({ plusLicenseKey: getSettings().plusLicenseKey });
-  let baseUrl: string | undefined;
   try {
     let response: RelatedContextResponse;
     if (mock) {
@@ -51,13 +50,13 @@ export async function findChatRelevantNotes(
         execution_time_ms: 0,
       };
     } else {
-      baseUrl = await withTimeout(
+      const baseUrl = await withTimeout(
         () => client.resolveBaseUrl(getMiyoCustomUrl(getSettings())),
         8000,
         "Miyo endpoint resolution"
       );
       response = await withTimeout(
-        () => client.recommend(baseUrl!, request),
+        () => client.recommend(baseUrl, request),
         8000,
         "Miyo chat related search"
       );
@@ -81,7 +80,7 @@ export async function findChatRelevantNotes(
       ];
     });
     return {
-      notes,
+      notes: notes.length ? notes : EMPTY_NOTES,
       status:
         response.status === "no_usable_context"
           ? "no-usable-context"

--- a/src/search/findChatRelevantNotes.ts
+++ b/src/search/findChatRelevantNotes.ts
@@ -57,7 +57,7 @@ export async function findChatRelevantNotes(
         "Miyo endpoint resolution"
       );
       response = await withTimeout(
-        () => client.searchRelatedContext(baseUrl!, request),
+        () => client.recommend(baseUrl!, request),
         8000,
         "Miyo chat related search"
       );
@@ -91,15 +91,14 @@ export async function findChatRelevantNotes(
       details,
     };
   } catch (error) {
-    // Confirm the endpoint itself before interpreting an older service's missing route.
+    // An old service cannot search chat context; hosts can retain editor-note retrieval.
     // https://github.com/Brevilabs/obsidian-copilot-private/issues/383
-    if (error instanceof MiyoRequestError && error.status === 404 && baseUrl) {
-      try {
-        if (!(await client.fetchHealth(baseUrl))) throw new Error("Miyo unavailable");
-        return { notes: EMPTY_NOTES, status: "unsupported-service", details };
-      } catch {
-        /* Connection guidance below. */
-      }
+    if (
+      error instanceof MiyoRequestError &&
+      error.status === 501 &&
+      error.errorCode === "not_implemented"
+    ) {
+      return { notes: EMPTY_NOTES, status: "unsupported-service", details };
     }
     return {
       notes: EMPTY_NOTES,

--- a/src/search/findRelevantNotes.test.ts
+++ b/src/search/findRelevantNotes.test.ts
@@ -723,6 +723,32 @@ describe("findRelevantNotes", () => {
       ).toBe(false);
     });
 
+    it.each([
+      { field: "mock", before: { mock: false }, after: { mock: true } },
+      {
+        field: "skippedAttachments",
+        before: { skippedAttachments: 1 },
+        after: { skippedAttachments: 2 },
+      },
+    ])(
+      "updates the $field notice without changing rows (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)",
+      ({ before, after }) => {
+        const notes = [note("a.md", 0.7)];
+        expect(
+          isSameRelevantNotesResult(
+            { notes, status: "matches", details: before },
+            { notes, status: "matches", details: after }
+          )
+        ).toBe(false);
+        expect(
+          isSameRelevantNotesResult(
+            { notes, status: "matches", details: after },
+            { notes, status: "matches", details: { ...after } }
+          )
+        ).toBe(true);
+      }
+    );
+
     it("separates a result that gained a note from the one before it (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", () => {
       expect(
         isSameRelevantNotesResult(

--- a/src/search/findRelevantNotes.test.ts
+++ b/src/search/findRelevantNotes.test.ts
@@ -723,31 +723,23 @@ describe("findRelevantNotes", () => {
       ).toBe(false);
     });
 
-    it.each([
-      { field: "mock", before: { mock: false }, after: { mock: true } },
-      {
-        field: "skippedAttachments",
-        before: { skippedAttachments: 1 },
-        after: { skippedAttachments: 2 },
-      },
-    ])(
-      "updates the $field notice without changing rows (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)",
-      ({ before, after }) => {
-        const notes = [note("a.md", 0.7)];
-        expect(
-          isSameRelevantNotesResult(
-            { notes, status: "matches", details: before },
-            { notes, status: "matches", details: after }
-          )
-        ).toBe(false);
-        expect(
-          isSameRelevantNotesResult(
-            { notes, status: "matches", details: after },
-            { notes, status: "matches", details: { ...after } }
-          )
-        ).toBe(true);
-      }
-    );
+    it("updates the skipped-attachment notice without changing rows (https://github.com/Brevilabs/obsidian-copilot-private/issues/383)", () => {
+      const before = { skippedAttachments: 1 };
+      const after = { skippedAttachments: 2 };
+      const notes = [note("a.md", 0.7)];
+      expect(
+        isSameRelevantNotesResult(
+          { notes, status: "matches", details: before },
+          { notes, status: "matches", details: after }
+        )
+      ).toBe(false);
+      expect(
+        isSameRelevantNotesResult(
+          { notes, status: "matches", details: after },
+          { notes, status: "matches", details: { ...after } }
+        )
+      ).toBe(true);
+    });
 
     it("separates a result that gained a note from the one before it (https://github.com/Brevilabs/obsidian-copilot-private/issues/362)", () => {
       expect(

--- a/src/search/findRelevantNotes.ts
+++ b/src/search/findRelevantNotes.ts
@@ -224,7 +224,6 @@ export type RelevantNotesSearchStatus =
 
 export interface RelevantNotesStatusDetails {
   skippedAttachments?: number;
-  mock?: boolean;
   errorMessage?: string;
   exclusionReason?: MiyoFileStatusReason;
   exclusionRule?: string;
@@ -300,11 +299,7 @@ export function isSameRelevantNotesResult(a: RelevantNotesResult, b: RelevantNot
   if (a.status !== b.status) return false;
   // Notice changes must render even when the recommendation rows stay the same.
   // https://github.com/Brevilabs/obsidian-copilot-private/issues/383
-  if (
-    a.details?.skippedAttachments !== b.details?.skippedAttachments ||
-    a.details?.mock !== b.details?.mock
-  )
-    return false;
+  if (a.details?.skippedAttachments !== b.details?.skippedAttachments) return false;
   if (a.details?.errorMessage !== b.details?.errorMessage) return false;
   if (a.details?.exclusionReason !== b.details?.exclusionReason) return false;
   if (a.details?.exclusionRule !== b.details?.exclusionRule) return false;

--- a/src/search/findRelevantNotes.ts
+++ b/src/search/findRelevantNotes.ts
@@ -298,6 +298,8 @@ const EMPTY_RELEVANT_NOTES: readonly RelevantNoteEntry[] = Object.freeze([]);
 export function isSameRelevantNotesResult(a: RelevantNotesResult, b: RelevantNotesResult): boolean {
   if (a === b) return true;
   if (a.status !== b.status) return false;
+  // Notice changes must render even when the recommendation rows stay the same.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/383
   if (
     a.details?.skippedAttachments !== b.details?.skippedAttachments ||
     a.details?.mock !== b.details?.mock

--- a/src/search/findRelevantNotes.ts
+++ b/src/search/findRelevantNotes.ts
@@ -208,6 +208,10 @@ async function searchRelatedNotesWithMiyo(
 }
 
 export type RelevantNotesSearchStatus =
+  | "no-usable-context"
+  | "unsupported-service"
+  | "request-too-large"
+  | "request-error"
   | "disabled"
   | "matches"
   | "no-matches"
@@ -219,6 +223,8 @@ export type RelevantNotesSearchStatus =
   | "unavailable";
 
 export interface RelevantNotesStatusDetails {
+  skippedAttachments?: number;
+  mock?: boolean;
   errorMessage?: string;
   exclusionReason?: MiyoFileStatusReason;
   exclusionRule?: string;
@@ -292,6 +298,11 @@ const EMPTY_RELEVANT_NOTES: readonly RelevantNoteEntry[] = Object.freeze([]);
 export function isSameRelevantNotesResult(a: RelevantNotesResult, b: RelevantNotesResult): boolean {
   if (a === b) return true;
   if (a.status !== b.status) return false;
+  if (
+    a.details?.skippedAttachments !== b.details?.skippedAttachments ||
+    a.details?.mock !== b.details?.mock
+  )
+    return false;
   if (a.details?.errorMessage !== b.details?.errorMessage) return false;
   if (a.details?.exclusionReason !== b.details?.exclusionReason) return false;
   if (a.details?.exclusionRule !== b.details?.exclusionRule) return false;


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#383

## Why

Copilot needs one recommendation API for an editor note or a conversation. Moving to Miyo’s richer API must keep single-note recommendations working for users who have not updated Miyo.

## What

Use `POST /v0/recommend` for vault-scoped recommendations. An editor note supplies one file reference; chat can supply visible conversation text, a draft, excerpts and indexed files together. Preserve Miyo’s result order, skipped-source details and explicit empty/error states. Conversation payloads and server echoes stay out of debug logs.

If the new route is unsupported, single-note requests use `/v0/search/related`. A structured `501 not_implemented` establishes incompatibility; a gateway 404 also requires `status: "ok"` from Miyo health. Authentication failures, retrieval failures and valid empty results do not trigger legacy retrieval. Skipped single-note context retains the existing file-status guidance.

Chat retrieval uses Miyo for usable context and reports unsupported service for the focus integration to handle. Remove the development mock mode, fabricated scores and example-results banner; fixtures remain in tests and component stories.

## Non goal

No chat focus selection, automatic refresh or chat-to-editor fallback is connected here. No summarization, reranking, attachment indexing, telemetry, settings migration, or retrieval-quality claim.

## Screenshot

The cleanup removes the banner "Mock preview: these are example notes, not relevance results." Skipped-attachment notices remain. No fresh screenshot is available: another workspace replaced the shared test vault gallery build during verification. Chat response states have adjacent gallery stories; chat source selection is not connected in this PR.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Adapter and pane tests cover results, skipped files, service errors and privacy |
| A defect would fail CI or be obvious on first use | ✅ | Regression tests cover the known source and request failures |
| A revert fully restores prior state, including persisted data | ✅ | No schema migration or irreversible write |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Visible chat text enters a new request; request/response debug bodies are redacted |
| No public API, plugin API, message, or on-disk contract changes | ❌ | Adds the agreed Miyo chat-context request/response contract |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Unsupported-route handling can probe health and retry the legacy route |
| No hot-path behavior lacks deterministic coverage | ✅ | Transport, adapter and pane states have deterministic coverage |
| No new dependency | ✅ | Dependency manifests unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Response states are confined to Relevant Notes |

Review: inspect `recommend`, `searchRelated`, `requestJson` and `parseResponseJson` in `src/miyo/MiyoClient.ts`, plus `findChatRelevantNotes` in `src/search/findChatRelevantNotes.ts`; check error mappings and privacy in Verification.

## Verification

1. Open an indexed Markdown note with Miyo connected. On a build containing Brevilabs/miyo#621, confirm the request uses `/v0/recommend` with one `file_paths` entry. With an older Miyo, confirm the same note still returns recommendations through `/v0/search/related`.
2. Exercise an unindexed source, a valid empty result, authentication failure and retrieval failure. Preserve source guidance and error states; only an unsupported route permits legacy retrieval. A 404 without recognizable Miyo health must remain a connection failure.
3. Run the adjacent Miyo client, chat adapter, note retrieval and pane tests. In the component gallery, inspect scored results, skipped attachments, unusable context and request errors. Confirm there is no example-results banner and private conversation text does not appear in debug logs. Blank-only context must stay local, and skipped-source wording must also cover out-of-scope files.

## Note

The matching Miyo endpoint is implemented in Brevilabs/miyo#621. `/v0/search/related` is deprecated but remains operational. Live cross-version acceptance and shipped-version evidence remain pending.
