### PR TITLE
Keep reopened Quick Chat conversations in their original notes

### DIFF
--- a/docs/chat-interface.md
+++ b/docs/chat-interface.md
@@ -55,7 +55,7 @@ After a response, the token counter in the top bar shows the context used for th
 
 Use **New Chat** in the top bar or run **New Copilot Quick Chat**. Starting over clears the current messages and resets context to the active note when automatic context is enabled.
 
-Use **Chat History** to search saved conversations, reopen one, rename it, open its Markdown source, or delete it.
+Use **Chat History** to search saved conversations, reopen one, rename it, open its Markdown source, or delete it. Continuing a reopened conversation updates its existing note, including after the note has been renamed or while its source is open.
 
 **Autosave Chat as Markdown** is enabled by default. Copilot saves after each user message and response under `<Copilot folder>/copilot-conversations/`. If autosave is off, use **Save Chat as Note** in the top bar. Change autosave and **Conversation Filename Template** under **Settings → Copilot → Basic → Saving conversations**.
 

--- a/src/core/ChatPersistenceManager.test.ts
+++ b/src/core/ChatPersistenceManager.test.ts
@@ -3,7 +3,7 @@ import { ChatMessage } from "@/types/message";
 import { App, Notice, TFile } from "obsidian";
 import type { MessageRepository } from "./MessageRepository";
 import { ChatPersistenceManager } from "./ChatPersistenceManager";
-import { mockTFile } from "@/__tests__/mockObsidian";
+import { mockTFile, mockTFolder } from "@/__tests__/mockObsidian";
 import { getSettings } from "@/settings/model";
 import { getEffectiveConversationsFolder } from "@/settings/copilotFolder";
 import { ensureFolderExists } from "@/utils";
@@ -23,6 +23,8 @@ jest.mock("obsidian", () => ({
   Notice: jest.fn(),
   TFile: jest.fn(),
   TFolder: jest.fn(),
+  parseYaml: (content: string): unknown =>
+    jest.requireActual<typeof import("yaml")>("yaml").parse(content),
 }));
 jest.mock("@/logger");
 jest.mock("@/settings/model", () => ({
@@ -1001,7 +1003,108 @@ Nature's quiet song`);
     });
   });
 
-  describe("loadChat", () => {
+  describe("loadChat()", () => {
+    it("keeps appended turns in the topic-renamed note after reload for https://github.com/logancyang/obsidian-copilot/issues/2886", async () => {
+      const display = "2024/09/23 22:18:00";
+      const epoch = new Date(display).getTime() + 865;
+      const firstMessage: ChatMessage = {
+        message: "testing1",
+        sender: USER_SENDER,
+        timestamp: { epoch, display, fileName: "20240923_221800" },
+        isVisible: true,
+      };
+      const file = mockTFile({ path: "test-folder/Generated_topic@20240923_221800.md" });
+      let savedContent = "";
+      mockApp.vault.create.mockImplementation(async (_path: string, content: string) => {
+        savedContent = content;
+        return file;
+      });
+      mockApp.vault.read.mockImplementation(async () => savedContent);
+      mockApp.vault.modify.mockImplementation(async (_file: TFile, content: string) => {
+        savedContent = content;
+      });
+      mockMessageRepo.getDisplayMessages.mockReturnValue([firstMessage]);
+      await persistenceManager.saveChat("gpt-4");
+      expect(mockApp.vault.create).toHaveBeenCalledTimes(1);
+
+      // Topic generation changes the filename independently of the first message.
+      mockApp.vault.getMarkdownFiles.mockReturnValue([file]);
+      const folder = mockTFolder({ path: "test-folder" });
+      mockApp.vault.getAbstractFileByPath.mockImplementation((path: string) =>
+        path === file.path ? file : path === folder.path ? folder : null
+      );
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: { epoch, topic: "Generated topic" },
+      });
+      const loaded = await persistenceManager.loadChat(file);
+      const appended = {
+        ...firstMessage,
+        message: "testing3",
+        timestamp: { ...firstMessage.timestamp!, epoch: epoch + 3000 },
+      };
+      mockMessageRepo.getDisplayMessages.mockReturnValue([...loaded, appended]);
+      await persistenceManager.saveChat("gpt-4");
+
+      expect(mockApp.vault.create).toHaveBeenCalledTimes(1);
+      expect(mockApp.vault.modify).toHaveBeenCalledWith(
+        file,
+        expect.stringContaining("**user**: testing3")
+      );
+      expect(loaded[0].timestamp).toMatchObject({ epoch, display });
+      expect(savedContent).toContain(`epoch: ${epoch}`);
+      expect((await persistenceManager.loadChat(file)).map((message) => message.message)).toEqual([
+        "testing1",
+        "testing3",
+      ]);
+    });
+
+    it.each(["1788916607865", '"1788916607865"'])(
+      "restores numeric or quoted identity %s only on the first message for https://github.com/logancyang/obsidian-copilot/issues/2886",
+      async (epoch) => {
+        mockApp.vault.read.mockResolvedValue(
+          `---\nepoch: ${epoch}\n---\n\n**user**: testing1\n[Timestamp: 2026/09/08 18:16:47]\n\n**ai**: OK\n[Timestamp: 2026/09/08 18:16:48]`
+        );
+        const messages = await persistenceManager.loadChat(mockTFile({ path: "chat.md" }));
+        expect(messages[0].timestamp).toMatchObject({
+          epoch: 1788916607865,
+          display: "2026/09/08 18:16:47",
+        });
+        expect(messages[1].timestamp?.epoch).toBe(new Date("2026/09/08 18:16:48").getTime());
+      }
+    );
+
+    it.each([
+      "",
+      "---\ntopic: Legacy\n---\n",
+      "---\nepoch: nope\n---\n",
+      "---\nepoch: .inf\n---\n",
+      "---\nepoch: true\n---\n",
+      "---\nepoch: 0\n---\n",
+      "---\nepoch: -1\n---\n",
+      "---\nepoch: [broken\n---\n",
+    ])(
+      "loads legacy message timestamps when identity is absent or invalid (%s) for https://github.com/logancyang/obsidian-copilot/issues/2886",
+      async (frontmatter) => {
+        const display = "2024/09/23 22:18:00";
+        mockApp.vault.read.mockResolvedValue(
+          `${frontmatter}\n**user**: Hello\n[Timestamp: ${display}]`
+        );
+        const messages = await persistenceManager.loadChat(mockTFile({ path: "legacy.md" }));
+        expect(messages[0].timestamp).toMatchObject({
+          epoch: new Date(display).getTime(),
+          display,
+        });
+      }
+    );
+
+    it("restores identity even without a display timestamp for https://github.com/logancyang/obsidian-copilot/issues/2886", async () => {
+      mockApp.vault.read.mockResolvedValue("---\nepoch: 1788916607865\n---\n**user**: Hello");
+      const messages = await persistenceManager.loadChat(mockTFile({ path: "chat.md" }));
+      expect(messages[0].timestamp).toMatchObject({
+        epoch: 1788916607865,
+        display: "Unknown time",
+      });
+    });
     it("should load and parse chat from file", async () => {
       const fileContent = `---
 epoch: 1695513480000

--- a/src/core/ChatPersistenceManager.ts
+++ b/src/core/ChatPersistenceManager.ts
@@ -22,7 +22,7 @@ import {
   readFrontmatterViaAdapter,
 } from "@/utils/vaultAdapterUtils";
 import { joinPosix } from "@/utils/pathUtils";
-import { App, Notice, TFile } from "obsidian";
+import { App, Notice, parseYaml, TFile } from "obsidian";
 import { MessageRepository } from "./MessageRepository";
 
 const SAFE_FILENAME_BYTE_LIMIT = 100;
@@ -333,9 +333,25 @@ export class ChatPersistenceManager {
     // Extract the YAML frontmatter
     const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
     let chatContent = content;
+    let conversationEpoch: number | undefined;
 
     if (frontmatterMatch) {
       chatContent = content.slice(frontmatterMatch[0].length).trim();
+      // Display timestamps omit milliseconds, but saving locates renamed notes by exact epoch.
+      // Preserve that identity across history reloads: https://github.com/logancyang/obsidian-copilot/issues/2886
+      try {
+        const epochValue = (parseYaml(frontmatterMatch[1]) as { epoch?: unknown } | null)?.epoch;
+        const epoch =
+          typeof epochValue === "number" || typeof epochValue === "string"
+            ? Number(epochValue)
+            : NaN;
+        if (Number.isFinite(epoch) && epoch > 0) {
+          conversationEpoch = epoch;
+        }
+      } catch {
+        // Keep legacy chats readable when edited YAML is invalid; use message timestamps instead.
+        // https://github.com/logancyang/obsidian-copilot/issues/2886
+      }
     }
 
     // Parse messages from the content
@@ -401,6 +417,11 @@ export class ChatPersistenceManager {
         if (!isNaN(date.getTime())) {
           epoch = date.getTime();
         }
+      }
+
+      // The first message carries the saved conversation identity: https://github.com/logancyang/obsidian-copilot/issues/2886
+      if (messages.length === 0 && conversationEpoch !== undefined) {
+        epoch = conversationEpoch;
       }
 
       messages.push({


### PR DESCRIPTION
Relates to #2886

## Why

In Quick Chat, reopen a saved conversation after its note receives a generated title, then send another message with the source note open. The original note stops updating and the new turn disappears when reopening that history entry. Reloading drops milliseconds from the conversation identity, so the next save creates a different note.

## What

> **Before:** Reopen the renamed chat, send `testing3`, and switch away and back: the original chat ends at `testing2`.
>
> **After:** The same sequence updates the original note and retains `testing3` and its response.

Existing saved chats retain their original identity. Chats without a valid saved identity keep their existing timestamp fallback.

## Non goal

Recovering turns already split across duplicate notes or changing how Markdown editors save.

## Screenshot

No visual change. The observable result is the original note's saved content and the messages restored from history.

## Risk

**High**, because selecting the destination for a conversation save affects vault files.

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Save/load continuation and invalid-identity tests cover the change |
| A defect would fail CI or be obvious on first use | ✅ | The regression asserts that continuation updates the original note |
| A revert fully restores prior state, including persisted data | ❌ | Reverting does not undo conversation writes made while installed |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Loading reads the saved YAML identity, with malformed-input fallback |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Existing epoch field and Markdown format remain unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Only synchronous history parsing changes |
| No hot-path behavior lacks deterministic coverage | ✅ | Numeric, quoted, absent, invalid, and missing-display cases are covered |
| No new dependency | ✅ | Uses Obsidian's existing YAML parser |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Quick Chat history continuation is visible after switching chats |

Review: inspect `parseChatContent` in `src/core/ChatPersistenceManager.ts` and the `loadChat()` tests in `src/core/ChatPersistenceManager.test.ts`. Run both verification cases below. A rollback leaves saved notes readable but restores the old continuation bug.

## Verification

1. Enable Quick Chat autosave. Send `testing` and `testing2`, wait for responses and a generated note title, then start another conversation. Reopen the first chat from Chat History, open its source note, and send `testing3`. Confirm that the original note updates, no duplicate appears, and all three turns survive switching away and back.
2. Repeat with an existing saved chat and the source note closed. Also load a copied legacy chat with no epoch or malformed YAML; its messages should remain readable through the timestamp fallback.
