### PR TITLE
Move qs, hono, and fast-uri past their September advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10992,9 +10992,9 @@
       "license": "Unlicense"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -11701,9 +11701,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.2.tgz",
-      "integrity": "sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==",
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -15365,9 +15365,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#239

## Why

The Obsidian community review dashboard now shows a **Dependency has a potential vulnerability advisory** warning for `qs`, `hono`, and `fast-uri`. The versions are the ones 4.0.6 shipped; the advisories were published on September 2 and 8, after that release, so the same dependency tree now trips them. All three are transitive dependencies of the MCP SDK's server transport and of Express, so none sit on a path where the plugin parses untrusted requests, but the warning would appear on the 4.0.7 review.

## What

The lockfile moves three transitive packages to versions outside their advisory ranges. Nothing in `package.json` changes and no direct dependency moves.

| Package | Before | After | Advisory |
| --- | --- | --- | --- |
| qs | 6.15.3 | 6.16.0 | GHSA-x5fp-wj9c-mxmx |
| hono | 4.13.2 | 4.13.7 | GHSA-gqvv-2mrq-wpjv, GHSA-g6gw-c38x-mqfc, GHSA-crvj-82cr-hjcx |
| fast-uri | 3.1.5 | 3.1.7 | GHSA-5jgf-p345-68v8, GHSA-f65p-4m7j-42xc |

`npm audit --omit=dev` reports zero vulnerabilities on this lockfile.

## Non goal

- Upgrading Express, the MCP SDK, or ajv themselves; each already accepts the patched versions through its existing caret range.
- Changing the `review:obsidian` audit level, which stays at critical.

## Screenshot

Not applicable: a lockfile change with no user-visible surface.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Patch and minor releases of three transitive parsers; the full Jest suite runs against the updated tree |
| A defect would fail CI or be obvious on first use | ✅ | Build and the full test suite run in CI |
| A revert fully restores prior state, including persisted data | ✅ | Lockfile only |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | The plugin does not call these packages directly |
| No public API, plugin API, message, or on-disk contract changes | ✅ | No source change |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | No source change |
| No hot-path behavior lacks deterministic coverage | ✅ | Unchanged plugin code, existing coverage applies |
| No new dependency | ✅ | Three existing transitive packages move within their declared ranges |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | None |

Review: confirm the lockfile diff touches only the three packages in the table, then run Verification step 2.

## Verification

1. Run `npm ci` and `npm run build`.
2. Run `npm audit --omit=dev` and expect `found 0 vulnerabilities`.
3. Open Agent Chat and run one MCP-backed tool call, which exercises the MCP SDK transport these packages sit under.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KyYBvfhdskCPJ4txKN92g7
