### PR TITLE
Refresh release detection when creating an agent tab

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -83,7 +83,7 @@ An empty Agent Chat suggests example requests in the composer. If your operating
 
 Agent Chat groups consecutive tool calls and reasoning into a compact activity row. The row reports the total tool commands, distinct files read or edited, and recorded reasoning time. Open it to inspect every step.
 
-When a newer Copilot release is available, the global Agent Chat home shows an update banner along the bottom of the pane. The banner stays above the home tabs when space is tight. Select **See what’s new** to read the release notes, or dismiss the banner for that release. Project homes and active conversations do not show it.
+Copilot checks for the latest release whenever you create a new Agent Chat tab with **+**, so you can discover updates without reloading the plugin. When a newer Copilot release is available, the global Agent Chat home shows an update banner along the bottom of the pane. The banner stays above the home tabs when space is tight. Select **See what’s new** to read the release notes, or dismiss the banner for that release. Project homes and active conversations do not show it.
 
 ## Models, effort, and permissions
 

--- a/src/agentMode/ui/AgentTabStrip.test.ts
+++ b/src/agentMode/ui/AgentTabStrip.test.ts
@@ -1,101 +1,153 @@
-import { computeVisibleCount, partitionSessions } from "./AgentTabStrip";
+import {
+  AgentTabStrip,
+  computeVisibleCount,
+  partitionSessions,
+} from "@/agentMode/ui/AgentTabStrip";
+import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { refreshLatestVersion } from "@/hooks/useLatestVersion";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
 
-describe("computeVisibleCount", () => {
-  it("returns 0 for empty input", () => {
-    expect(computeVisibleCount(500, 0)).toBe(0);
-  });
+jest.mock("@/hooks/useLatestVersion", () => ({ refreshLatestVersion: jest.fn() }));
 
-  it("shows all tabs when they fit alongside the + button", () => {
-    // 3 fixed tabs + 2 gaps + plus button = 128+4+128+4+128+32 = 424
-    expect(computeVisibleCount(424, 3)).toBe(3);
-  });
+describe("AgentTabStrip", () => {
+  describe("computeVisibleCount", () => {
+    it("returns 0 for empty input", () => {
+      expect(computeVisibleCount(500, 0)).toBe(0);
+    });
 
-  it("reserves overflow button space when not all tabs fit", () => {
-    // With overflow, tab budget is 460 - plus(32) - overflow(32) = 396,
-    // which fits 3 fixed tabs and 2 inter-tab gaps.
-    expect(computeVisibleCount(460, 5)).toBe(3);
-  });
+    it("shows all tabs when they fit alongside the + button", () => {
+      // 3 fixed tabs + 2 gaps + plus button = 128+4+128+4+128+32 = 424
+      expect(computeVisibleCount(424, 3)).toBe(3);
+    });
 
-  it("guarantees at least one visible tab even when nothing fits", () => {
-    expect(computeVisibleCount(40, 3)).toBe(1);
-  });
+    it("reserves overflow button space when not all tabs fit", () => {
+      // With overflow, tab budget is 460 - plus(32) - overflow(32) = 396,
+      // which fits 3 fixed tabs and 2 inter-tab gaps.
+      expect(computeVisibleCount(460, 5)).toBe(3);
+    });
 
-  it("treats the + button as always reserved", () => {
-    // One fixed tab + plus button = 128 + 32.
-    expect(computeVisibleCount(160, 1)).toBe(1);
-    expect(computeVisibleCount(159, 1)).toBe(1);
-  });
+    it("guarantees at least one visible tab even when nothing fits", () => {
+      expect(computeVisibleCount(40, 3)).toBe(1);
+    });
 
-  it("accounts for inter-tab gaps", () => {
-    // 2 fixed tabs + 1 gap + plus button = 128+4+128+32 = 292.
-    expect(computeVisibleCount(292, 2)).toBe(2);
-    expect(computeVisibleCount(291, 2)).toBe(1);
-  });
-});
+    it("treats the + button as always reserved", () => {
+      // One fixed tab + plus button = 128 + 32.
+      expect(computeVisibleCount(160, 1)).toBe(1);
+      expect(computeVisibleCount(159, 1)).toBe(1);
+    });
 
-describe("partitionSessions", () => {
-  const s = (id: string) => ({ internalId: id });
-
-  it("returns empty arrays for empty input", () => {
-    expect(partitionSessions({ sessions: [], visibleCount: 0, activeId: null })).toEqual({
-      visibleSessions: [],
-      overflowSessions: [],
+    it("accounts for inter-tab gaps", () => {
+      // 2 fixed tabs + 1 gap + plus button = 128+4+128+32 = 292.
+      expect(computeVisibleCount(292, 2)).toBe(2);
+      expect(computeVisibleCount(291, 2)).toBe(1);
     });
   });
 
-  it("splits front-to-back when active is already visible", () => {
-    const sessions = [s("a"), s("b"), s("c"), s("d")];
-    const { visibleSessions, overflowSessions } = partitionSessions({
-      sessions,
-      visibleCount: 2,
-      activeId: "a",
+  describe("partitionSessions", () => {
+    const s = (id: string) => ({ internalId: id });
+
+    it("returns empty arrays for empty input", () => {
+      expect(partitionSessions({ sessions: [], visibleCount: 0, activeId: null })).toEqual({
+        visibleSessions: [],
+        overflowSessions: [],
+      });
     });
-    expect(visibleSessions.map((x) => x.internalId)).toEqual(["a", "b"]);
-    expect(overflowSessions.map((x) => x.internalId)).toEqual(["c", "d"]);
+
+    it("splits front-to-back when active is already visible", () => {
+      const sessions = [s("a"), s("b"), s("c"), s("d")];
+      const { visibleSessions, overflowSessions } = partitionSessions({
+        sessions,
+        visibleCount: 2,
+        activeId: "a",
+      });
+      expect(visibleSessions.map((x) => x.internalId)).toEqual(["a", "b"]);
+      expect(overflowSessions.map((x) => x.internalId)).toEqual(["c", "d"]);
+    });
+
+    it("pins the active tab into the last visible slot when it would overflow", () => {
+      const sessions = [s("a"), s("b"), s("c"), s("d")];
+      const { visibleSessions, overflowSessions } = partitionSessions({
+        sessions,
+        visibleCount: 2,
+        activeId: "d",
+      });
+      // 'd' takes the last visible slot; 'b' is displaced to the front of overflow.
+      expect(visibleSessions.map((x) => x.internalId)).toEqual(["a", "d"]);
+      expect(overflowSessions.map((x) => x.internalId)).toEqual(["b", "c"]);
+    });
+
+    it("does not swap when activeId is null", () => {
+      const sessions = [s("a"), s("b"), s("c")];
+      const { visibleSessions, overflowSessions } = partitionSessions({
+        sessions,
+        visibleCount: 1,
+        activeId: null,
+      });
+      expect(visibleSessions.map((x) => x.internalId)).toEqual(["a"]);
+      expect(overflowSessions.map((x) => x.internalId)).toEqual(["b", "c"]);
+    });
+
+    it("does not swap when active is already visible", () => {
+      const sessions = [s("a"), s("b"), s("c")];
+      const { visibleSessions, overflowSessions } = partitionSessions({
+        sessions,
+        visibleCount: 2,
+        activeId: "b",
+      });
+      expect(visibleSessions.map((x) => x.internalId)).toEqual(["a", "b"]);
+      expect(overflowSessions.map((x) => x.internalId)).toEqual(["c"]);
+    });
+
+    it("handles visibleCount === 1 with overflow active", () => {
+      const sessions = [s("a"), s("b"), s("c")];
+      const { visibleSessions, overflowSessions } = partitionSessions({
+        sessions,
+        visibleCount: 1,
+        activeId: "c",
+      });
+      expect(visibleSessions.map((x) => x.internalId)).toEqual(["c"]);
+      expect(overflowSessions.map((x) => x.internalId)).toEqual(["a", "b"]);
+    });
   });
 
-  it("pins the active tab into the last visible slot when it would overflow", () => {
-    const sessions = [s("a"), s("b"), s("c"), s("d")];
-    const { visibleSessions, overflowSessions } = partitionSessions({
-      sessions,
-      visibleCount: 2,
-      activeId: "d",
+  describe("AgentTabStrip()", () => {
+    it("refreshes releases after the new-session button creates a tab for https://github.com/Brevilabs/obsidian-copilot-private/issues/317", async () => {
+      const session = {
+        internalId: "existing",
+        backendId: "test",
+        subscribe: () => () => {},
+        getLabel: () => "Existing chat",
+        getStatus: () => "idle",
+        getNeedsAttention: () => false,
+      };
+      let finishCreation!: () => void;
+      const manager = {
+        subscribe: () => () => {},
+        getSessionsForScope: () => [session],
+        getActiveProjectId: () => null,
+        getActiveSession: () => session,
+        getIsStarting: () => false,
+        createSession: jest.fn(
+          () =>
+            new Promise<void>((resolve) => {
+              finishCreation = resolve;
+            })
+        ),
+      };
+      render(
+        React.createElement(
+          TooltipProvider,
+          null,
+          React.createElement(AgentTabStrip, { manager: manager as unknown as AgentSessionManager })
+        )
+      );
+      fireEvent.click(screen.getByRole("button", { name: "New agent session" }));
+      expect(manager.createSession).toHaveBeenCalledTimes(1);
+      expect(refreshLatestVersion).not.toHaveBeenCalled();
+      finishCreation();
+      await waitFor(() => expect(refreshLatestVersion).toHaveBeenCalledTimes(1));
     });
-    // 'd' takes the last visible slot; 'b' is displaced to the front of overflow.
-    expect(visibleSessions.map((x) => x.internalId)).toEqual(["a", "d"]);
-    expect(overflowSessions.map((x) => x.internalId)).toEqual(["b", "c"]);
-  });
-
-  it("does not swap when activeId is null", () => {
-    const sessions = [s("a"), s("b"), s("c")];
-    const { visibleSessions, overflowSessions } = partitionSessions({
-      sessions,
-      visibleCount: 1,
-      activeId: null,
-    });
-    expect(visibleSessions.map((x) => x.internalId)).toEqual(["a"]);
-    expect(overflowSessions.map((x) => x.internalId)).toEqual(["b", "c"]);
-  });
-
-  it("does not swap when active is already visible", () => {
-    const sessions = [s("a"), s("b"), s("c")];
-    const { visibleSessions, overflowSessions } = partitionSessions({
-      sessions,
-      visibleCount: 2,
-      activeId: "b",
-    });
-    expect(visibleSessions.map((x) => x.internalId)).toEqual(["a", "b"]);
-    expect(overflowSessions.map((x) => x.internalId)).toEqual(["c"]);
-  });
-
-  it("handles visibleCount === 1 with overflow active", () => {
-    const sessions = [s("a"), s("b"), s("c")];
-    const { visibleSessions, overflowSessions } = partitionSessions({
-      sessions,
-      visibleCount: 1,
-      activeId: "c",
-    });
-    expect(visibleSessions.map((x) => x.internalId)).toEqual(["c"]);
-    expect(overflowSessions.map((x) => x.internalId)).toEqual(["a", "b"]);
   });
 });

--- a/src/agentMode/ui/AgentTabStrip.tsx
+++ b/src/agentMode/ui/AgentTabStrip.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { refreshLatestVersion } from "@/hooks/useLatestVersion";
 import { cn } from "@/lib/utils";
 import { logError } from "@/logger";
 import type { AgentSession, AgentSessionStatus } from "@/agentMode/session/AgentSession";
@@ -181,7 +182,10 @@ export const AgentTabStrip: React.FC<Props> = ({ manager }) => {
 
   const handleNew = React.useCallback(() => {
     if (manager.getIsStarting()) return;
-    manager.createSession().catch((e) => logError("[AgentMode] createSession failed", e));
+    manager
+      .createSession()
+      .then(() => refreshLatestVersion())
+      .catch((e) => logError("[AgentMode] createSession failed", e));
   }, [manager]);
 
   const handleClose = React.useCallback(

--- a/src/hooks/useLatestVersion.test.tsx
+++ b/src/hooks/useLatestVersion.test.tsx
@@ -1,6 +1,6 @@
-import { useLatestVersion } from "@/hooks/useLatestVersion";
+import { refreshLatestVersion, useLatestVersion } from "@/hooks/useLatestVersion";
 import { checkLatestVersion } from "@/utils";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import * as React from "react";
 
 jest.mock("@/utils", () => ({
@@ -21,6 +21,10 @@ function LatestVersionProbe(): React.ReactElement {
 }
 
 describe("useLatestVersion", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    refreshLatestVersion();
+  });
   describe("useLatestVersion()", () => {
     it(`shares one release payload and request across remounted consumers for ${ISSUE_URL}`, async () => {
       jest.mocked(checkLatestVersion).mockResolvedValue({
@@ -50,6 +54,62 @@ describe("useLatestVersion", () => {
         })
       );
       expect(checkLatestVersion).toHaveBeenCalledTimes(1);
+    });
+  });
+  describe("refreshLatestVersion()", () => {
+    it(`updates mounted consumers after a new-tab refresh for ${ISSUE_URL}`, async () => {
+      jest
+        .mocked(checkLatestVersion)
+        .mockResolvedValue({ error: null, release: RELEASE, version: RELEASE.version });
+      const mounted = render(
+        <>
+          <LatestVersionProbe />
+          <LatestVersionProbe />
+        </>
+      );
+      await waitFor(() =>
+        expect(screen.getAllByRole("status")[0].textContent).toContain(RELEASE.version)
+      );
+      expect(checkLatestVersion).toHaveBeenCalledTimes(1);
+
+      const nextRelease = { ...RELEASE, version: "4.0.5", body: "New release notes" };
+      jest
+        .mocked(checkLatestVersion)
+        .mockResolvedValue({ error: null, release: nextRelease, version: nextRelease.version });
+      act(() => refreshLatestVersion());
+
+      await waitFor(() => {
+        for (const output of screen.getAllByRole("status")) {
+          expect(JSON.parse(output.textContent ?? "{}").latestRelease).toEqual(nextRelease);
+        }
+      });
+      expect(checkLatestVersion).toHaveBeenCalledTimes(2);
+      mounted.rerender(
+        <>
+          <LatestVersionProbe />
+          <LatestVersionProbe />
+        </>
+      );
+      expect(checkLatestVersion).toHaveBeenCalledTimes(2);
+    });
+    it(`ignores a stale response after a new-tab refresh for ${ISSUE_URL}`, async () => {
+      let resolveOld!: (value: Awaited<ReturnType<typeof checkLatestVersion>>) => void;
+      jest.mocked(checkLatestVersion).mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveOld = resolve;
+        })
+      );
+      render(<LatestVersionProbe />);
+      const nextRelease = { ...RELEASE, version: "4.0.5" };
+      jest
+        .mocked(checkLatestVersion)
+        .mockResolvedValue({ error: null, release: nextRelease, version: nextRelease.version });
+      act(() => refreshLatestVersion());
+      await waitFor(() => expect(screen.getByRole("status").textContent).toContain("4.0.5"));
+      await act(async () => {
+        resolveOld({ error: null, release: RELEASE, version: RELEASE.version });
+      });
+      expect(screen.getByRole("status").textContent).toContain("4.0.5");
     });
   });
 });

--- a/src/hooks/useLatestVersion.ts
+++ b/src/hooks/useLatestVersion.ts
@@ -1,6 +1,6 @@
 import { logError } from "@/logger";
 import { checkLatestVersion, isNewerVersion, type LatestRelease } from "@/utils";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
 
 interface UseLatestVersionResult {
   latestVersion: string | null;
@@ -11,25 +11,52 @@ interface UseLatestVersionResult {
 let latestReleaseRequest: Promise<LatestRelease | null> | null = null;
 
 function requestLatestRelease(): Promise<LatestRelease | null> {
-  // Every mounted release surface shares the same request for the lifetime of
-  // the loaded plugin bundle, including settings opened after Agent Home.
+  // Release surfaces share one request until a new agent tab invalidates it.
   // https://github.com/Brevilabs/obsidian-copilot-private/issues/317
   latestReleaseRequest ??= checkLatestVersion().then((result) => result.release);
   return latestReleaseRequest;
 }
 
+let releaseRevision = 0;
+const releaseListeners = new Set<() => void>();
+
+function subscribeToReleaseRefresh(listener: () => void): () => void {
+  releaseListeners.add(listener);
+  return () => {
+    releaseListeners.delete(listener);
+  };
+}
+
+function getReleaseRevision(): number {
+  return releaseRevision;
+}
+
+/** Invalidates the shared release check and refreshes mounted release surfaces. */
+export function refreshLatestVersion(): void {
+  latestReleaseRequest = null;
+  releaseRevision += 1;
+  releaseListeners.forEach((listener) => listener());
+}
+
 export function useLatestVersion(currentVersion: string): UseLatestVersionResult {
+  const revision = useSyncExternalStore(subscribeToReleaseRefresh, getReleaseRevision);
   const [latestRelease, setLatestRelease] = useState<LatestRelease | null>(null);
 
   useEffect(() => {
+    let active = true;
     const checkVersion = async () => {
       const release = await requestLatestRelease();
-      if (release) {
+      // A previous tab's slower check must not replace a newer release result.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/317
+      if (active && release) {
         setLatestRelease(release);
       }
     };
     void checkVersion().catch((err) => logError("checkVersion failed", err));
-  }, []);
+    return () => {
+      active = false;
+    };
+  }, [revision]);
 
   const latestVersion = latestRelease?.version ?? null;
   const hasUpdate = latestVersion !== null && isNewerVersion(latestVersion, currentVersion);


### PR DESCRIPTION
## Why

An Agent Chat pane left open keeps its first release check until Copilot reloads, so later releases never appear in its update banner.

## What

| Trigger | Before | After |
| --- | --- | --- |
| Create a tab with + | Reuse the old release result | Check again and update mounted release notices |
| Dismissed version is still latest | Stay dismissed | Stay dismissed |
| An older request finishes late | Only one check existed | Keep the newer check's result |

## Non goal

No banner redesign, periodic polling, or changes to dismissal rules.

## Screenshot

Not applicable: release-check timing changes; banner appearance is unchanged.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Button integration, shared refresh, and delayed-response tests |
| A defect would fail CI or be obvious on first use | ✅ | Regression tests assert a new request and updated mounted consumers |
| A revert fully restores prior state, including persisted data | ✅ | No persisted-data change |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Existing release endpoint and payload |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Internal release-hook notification only |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Release notification only; session creation lifecycle unchanged |
| No hot-path behavior lacks deterministic coverage | ✅ | New-tab refresh and stale-response handling covered |
| No new dependency | ✅ | Dependency manifests unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Banner refresh observable on the next new tab |

Review: skim Why and What, run Verification, and confirm CI is green.

## Verification

1. Open Agent Chat on a Copilot version older than the latest release, with that release not dismissed; keep the pane open
2. Click **+** and confirm another latest-release request occurs and the empty global home shows **See what’s new**
3. Dismiss the banner and create another tab; confirm the same release stays dismissed
