### PR TITLE
Verify BYOK provider status on every tab visit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Copilot for Obsidian is an AI-powered assistant plugin that integrates various L
 
 ## Commands
 
-- **NEVER RUN `npm run dev`** — the user handles all builds manually.
+- **NEVER RUN `npm run dev`**.
 - `npm run build` — production build (TypeScript check + minified output).
 - `npm run lint` / `npm run lint:fix` — ESLint check / autofix.
 - `npm run format` / `npm run format:check` — Prettier write / check.

--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -52,6 +52,14 @@ with that provider.
 5. Select or enter at least one model, optionally click **Test**, then click
    **Save**.
 
+Each time you open **BYOK**, Copilot checks your configured providers again. A small
+“Verifying providers…” indicator appears while checks run, and each provider updates
+as its check finishes. **Verified** means the provider passed its connection or key
+check. **No key** or **Invalid key** means you should configure that provider again.
+**Check failed** can also mean a connection or rate-limit problem; hover over the
+badge for details and reopen the tab to retry. Saving provider changes also refreshes
+these checks. A successful check does not guarantee access to every model.
+
 The provider list and model catalog are loaded in the app, so this guide does
 not keep a fixed provider or model count. If the endpoint cannot list its
 models, you can enter a model ID yourself.

--- a/src/modelManagement/providers/ProviderRegistry.test.ts
+++ b/src/modelManagement/providers/ProviderRegistry.test.ts
@@ -6,7 +6,7 @@
  * `resetSettings` / `setSettings`).
  */
 
-import { resetSettings, getSettings } from "@/settings/model";
+import { resetSettings, getSettings, setSettings } from "@/settings/model";
 import { KeychainService } from "@/services/keychainService";
 
 import type { ProviderAdapter } from "./adapters/ProviderAdapter";
@@ -68,6 +68,7 @@ describe("ProviderRegistry", () => {
 
     beforeEach(() => {
       resetSettings();
+      setSettings({ providers: {} });
       KeychainService.resetInstance();
       const fake = makeFakeApp();
       app = fake.app;
@@ -79,169 +80,218 @@ describe("ProviderRegistry", () => {
       registry = new ProviderRegistry(app, adapters);
     });
 
-    it("add() mints id, stamps addedAt, persists the row", async () => {
-      const before = Date.now();
-      const id = await registry.add({
-        providerType: "anthropic",
-        displayName: "Anthropic (prod)",
-        origin: { kind: "byok" },
-      });
-      expect(typeof id).toBe("string");
-      expect(id.length).toBeGreaterThan(0);
+    describe("add()", () => {
+      it("add() mints id, stamps addedAt, persists the row", async () => {
+        const before = Date.now();
+        const id = await registry.add({
+          providerType: "anthropic",
+          displayName: "Anthropic (prod)",
+          origin: { kind: "byok" },
+        });
+        expect(typeof id).toBe("string");
+        expect(id.length).toBeGreaterThan(0);
 
-      const row = registry.get(id);
-      expect(row).toBeDefined();
-      expect(row?.displayName).toBe("Anthropic (prod)");
-      expect(row?.providerType).toBe("anthropic");
-      expect(row?.origin).toEqual({ kind: "byok" });
-      expect(row?.addedAt).toBeGreaterThanOrEqual(before);
-      expect(row?.apiKeyKeychainId).toBeNull();
+        const row = registry.get(id);
+        expect(row).toBeDefined();
+        expect(row?.displayName).toBe("Anthropic (prod)");
+        expect(row?.providerType).toBe("anthropic");
+        expect(row?.origin).toEqual({ kind: "byok" });
+        expect(row?.addedAt).toBeGreaterThanOrEqual(before);
+        expect(row?.apiKeyKeychainId).toBeNull();
+      });
     });
 
-    it("list() / listByOrigin / listByProviderType return stable references when settings unchanged", async () => {
-      await registry.add({
-        providerType: "anthropic",
-        displayName: "A",
-        origin: { kind: "byok" },
+    describe("get()", () => {
+      it("returns the persisted row and undefined for an unknown provider", async () => {
+        const id = await registry.add({
+          providerType: "anthropic",
+          displayName: "A",
+          origin: { kind: "byok" },
+        });
+        expect(registry.get(id)).toBe(getSettings().providers[id]);
+        expect(registry.get("unknown")).toBeUndefined();
       });
-      await registry.add({
-        providerType: "anthropic",
-        displayName: "B",
-        origin: { kind: "agent", agentType: "claude" },
-      });
-      const list1 = registry.list();
-      const list2 = registry.list();
-      expect(list1).toBe(list2);
-
-      const byok1 = registry.listByOrigin("byok");
-      const byok2 = registry.listByOrigin("byok");
-      expect(byok1).toBe(byok2);
-      expect(byok1.length).toBe(1);
-
-      const ant1 = registry.listByProviderType("anthropic");
-      const ant2 = registry.listByProviderType("anthropic");
-      expect(ant1).toBe(ant2);
-      expect(ant1.length).toBe(2);
     });
 
-    it("empty filtered views reuse a shared frozen empty array", () => {
-      const empty1 = registry.listByOrigin("byok");
-      const empty2 = registry.listByOrigin("copilot-plus");
-      expect(empty1).toBe(empty2);
-      expect(empty1.length).toBe(0);
-    });
-
-    it("update() merges patch and refuses to mutate providerId / addedAt / providerType / origin", async () => {
-      const id = await registry.add({
-        providerType: "anthropic",
-        displayName: "Original",
-        origin: { kind: "byok" },
-      });
-      const originalAddedAt = registry.get(id)!.addedAt;
-
-      // Bypass the typed Omit to verify the runtime guard strips immutable
-      // fields even when callers shove them in via an untyped object.
-      // providerType is the adapter-dispatch key and origin determines
-      // which settings tab owns the row — both must stay pinned to the
-      // values supplied at creation.
-      await registry.update(id, {
-        displayName: "Renamed",
-        baseUrl: "https://example.test",
-        ...({
-          providerId: "hacked",
-          addedAt: 1,
-          providerType: "openai",
+    describe("listByOrigin()", () => {
+      it("returns stable references while settings are unchanged", async () => {
+        await registry.add({
+          providerType: "anthropic",
+          displayName: "A",
+          origin: { kind: "byok" },
+        });
+        await registry.add({
+          providerType: "anthropic",
+          displayName: "B",
           origin: { kind: "agent", agentType: "claude" },
-        } as Record<string, unknown>),
+        });
+        const rows = registry.listByOrigin("byok");
+        expect(registry.listByOrigin("byok")).toBe(rows);
+        expect(rows).toHaveLength(1);
       });
-      const row = registry.get(id)!;
-      expect(row.displayName).toBe("Renamed");
-      expect(row.baseUrl).toBe("https://example.test");
-      expect(row.providerId).toBe(id);
-      expect(row.addedAt).toBe(originalAddedAt);
-      expect(row.providerType).toBe("anthropic");
-      expect(row.origin).toEqual({ kind: "byok" });
+      it("empty filtered views reuse a shared frozen empty array", () => {
+        const empty1 = registry.listByOrigin("byok");
+        const empty2 = registry.listByOrigin("copilot-plus");
+        expect(empty1).toBe(empty2);
+        expect(empty1.length).toBe(0);
+      });
     });
 
-    it("update() throws for unknown providerId", async () => {
-      await expect(registry.update("nope", { displayName: "x" })).rejects.toThrow(/unknown/);
+    describe("update()", () => {
+      it("update() merges patch and refuses to mutate providerId / addedAt / providerType / origin", async () => {
+        const id = await registry.add({
+          providerType: "anthropic",
+          displayName: "Original",
+          origin: { kind: "byok" },
+        });
+        const originalAddedAt = registry.get(id)!.addedAt;
+
+        // Bypass the typed Omit to verify the runtime guard strips immutable
+        // fields even when callers shove them in via an untyped object.
+        // providerType is the adapter-dispatch key and origin determines
+        // which settings tab owns the row — both must stay pinned to the
+        // values supplied at creation.
+        await registry.update(id, {
+          displayName: "Renamed",
+          baseUrl: "https://example.test",
+          ...({
+            providerId: "hacked",
+            addedAt: 1,
+            providerType: "openai",
+            origin: { kind: "agent", agentType: "claude" },
+          } as Record<string, unknown>),
+        });
+        const row = registry.get(id)!;
+        expect(row.displayName).toBe("Renamed");
+        expect(row.baseUrl).toBe("https://example.test");
+        expect(row.providerId).toBe(id);
+        expect(row.addedAt).toBe(originalAddedAt);
+        expect(row.providerType).toBe("anthropic");
+        expect(row.origin).toEqual({ kind: "byok" });
+      });
+      it("update() throws for unknown providerId", async () => {
+        await expect(registry.update("nope", { displayName: "x" })).rejects.toThrow(/unknown/);
+      });
+      it("update() ignores attempts to overwrite apiKeyKeychainId", async () => {
+        const id = await registry.add({
+          providerType: "anthropic",
+          displayName: "A",
+          origin: { kind: "byok" },
+        });
+        await registry.setApiKey(id, "sk-real");
+        const realKeychainId = registry.get(id)!.apiKeyKeychainId;
+        expect(realKeychainId).not.toBeNull();
+
+        // Bypass the typed Omit to verify the runtime strip refuses to move
+        // the keychain pointer (which would orphan the secret or repoint the
+        // row at a keychain entry this registry never wrote).
+        await registry.update(id, {
+          ...({ apiKeyKeychainId: "copilot-v0-provider-attacker" } as Record<string, unknown>),
+        });
+        expect(registry.get(id)!.apiKeyKeychainId).toBe(realKeychainId);
+        // The real secret is still readable.
+        expect(await registry.getApiKey(id)).toBe("sk-real");
+      });
     });
 
-    it("setApiKey mints apiKeyKeychainId on first call and reuses it on rotation", async () => {
-      const id = await registry.add({
-        providerType: "anthropic",
-        displayName: "A",
-        origin: { kind: "byok" },
+    describe("setApiKey()", () => {
+      it("setApiKey mints apiKeyKeychainId on first call and reuses it on rotation", async () => {
+        const id = await registry.add({
+          providerType: "anthropic",
+          displayName: "A",
+          origin: { kind: "byok" },
+        });
+        expect(registry.get(id)!.apiKeyKeychainId).toBeNull();
+
+        await registry.setApiKey(id, "sk-first");
+        const firstKeychainId = registry.get(id)!.apiKeyKeychainId;
+        const vaultId = KeychainService.getInstance(app).getVaultId();
+        // Vault-namespaced so `KeychainService.clearAllVaultSecrets()` (which
+        // filters by `copilot-v{vaultId}-`) sweeps these entries.
+        expect(firstKeychainId).toBe(`copilot-v${vaultId}-provider-${id}`);
+        expect(await registry.getApiKey(id)).toBe("sk-first");
+
+        await registry.setApiKey(id, "sk-rotated");
+        expect(registry.get(id)!.apiKeyKeychainId).toBe(firstKeychainId);
+        expect(await registry.getApiKey(id)).toBe("sk-rotated");
       });
-      expect(registry.get(id)!.apiKeyKeychainId).toBeNull();
-
-      await registry.setApiKey(id, "sk-first");
-      const firstKeychainId = registry.get(id)!.apiKeyKeychainId;
-      const vaultId = KeychainService.getInstance(app).getVaultId();
-      // Vault-namespaced so `KeychainService.clearAllVaultSecrets()` (which
-      // filters by `copilot-v{vaultId}-`) sweeps these entries.
-      expect(firstKeychainId).toBe(`copilot-v${vaultId}-provider-${id}`);
-      expect(await registry.getApiKey(id)).toBe("sk-first");
-
-      await registry.setApiKey(id, "sk-rotated");
-      expect(registry.get(id)!.apiKeyKeychainId).toBe(firstKeychainId);
-      expect(await registry.getApiKey(id)).toBe("sk-rotated");
     });
 
-    it("update() ignores attempts to overwrite apiKeyKeychainId", async () => {
-      const id = await registry.add({
-        providerType: "anthropic",
-        displayName: "A",
-        origin: { kind: "byok" },
+    describe("getApiKey()", () => {
+      it("getApiKey returns null when the provider has no apiKeyKeychainId", async () => {
+        const id = await registry.add({
+          providerType: "anthropic",
+          displayName: "Ollama-like",
+          origin: { kind: "byok" },
+        });
+        expect(await registry.getApiKey(id)).toBeNull();
       });
-      await registry.setApiKey(id, "sk-real");
-      const realKeychainId = registry.get(id)!.apiKeyKeychainId;
-      expect(realKeychainId).not.toBeNull();
-
-      // Bypass the typed Omit to verify the runtime strip refuses to move
-      // the keychain pointer (which would orphan the secret or repoint the
-      // row at a keychain entry this registry never wrote).
-      await registry.update(id, {
-        ...({ apiKeyKeychainId: "copilot-v0-provider-attacker" } as Record<string, unknown>),
-      });
-      expect(registry.get(id)!.apiKeyKeychainId).toBe(realKeychainId);
-      // The real secret is still readable.
-      expect(await registry.getApiKey(id)).toBe("sk-real");
     });
 
-    it("getApiKey returns null when the provider has no apiKeyKeychainId", async () => {
-      const id = await registry.add({
-        providerType: "anthropic",
-        displayName: "Ollama-like",
-        origin: { kind: "byok" },
+    describe("clearApiKey()", () => {
+      it("clearApiKey drops the keychain entry and clears the pointer", async () => {
+        const id = await registry.add({
+          providerType: "anthropic",
+          displayName: "A",
+          origin: { kind: "byok" },
+        });
+        await registry.setApiKey(id, "sk-x");
+        await registry.clearApiKey(id);
+        expect(registry.get(id)!.apiKeyKeychainId).toBeNull();
+        expect(await registry.getApiKey(id)).toBeNull();
       });
-      expect(await registry.getApiKey(id)).toBeNull();
     });
 
-    it("clearApiKey drops the keychain entry and clears the pointer", async () => {
-      const id = await registry.add({
-        providerType: "anthropic",
-        displayName: "A",
-        origin: { kind: "byok" },
+    describe("remove()", () => {
+      it("remove() drops the row and the keychain entry", async () => {
+        const id = await registry.add({
+          providerType: "anthropic",
+          displayName: "A",
+          origin: { kind: "byok" },
+        });
+        await registry.setApiKey(id, "sk-x");
+        const keychainId = registry.get(id)!.apiKeyKeychainId!;
+        await registry.remove(id);
+        expect(registry.get(id)).toBeUndefined();
+        // Verify keychain side cleaned up by reading raw storage.
+        expect(KeychainService.getInstance(app).getSecretById(keychainId)).toBeNull();
       });
-      await registry.setApiKey(id, "sk-x");
-      await registry.clearApiKey(id);
-      expect(registry.get(id)!.apiKeyKeychainId).toBeNull();
-      expect(await registry.getApiKey(id)).toBeNull();
     });
 
-    it("remove() drops the row and the keychain entry", async () => {
-      const id = await registry.add({
-        providerType: "anthropic",
-        displayName: "A",
-        origin: { kind: "byok" },
+    describe("list()", () => {
+      it("returns stable references while settings are unchanged", async () => {
+        await registry.add({
+          providerType: "anthropic",
+          displayName: "A",
+          origin: { kind: "byok" },
+        });
+        await registry.add({
+          providerType: "anthropic",
+          displayName: "B",
+          origin: { kind: "agent", agentType: "claude" },
+        });
+        const rows = registry.list();
+        expect(registry.list()).toBe(rows);
+        expect(rows).toHaveLength(2);
       });
-      await registry.setApiKey(id, "sk-x");
-      const keychainId = registry.get(id)!.apiKeyKeychainId!;
-      await registry.remove(id);
-      expect(registry.get(id)).toBeUndefined();
-      // Verify keychain side cleaned up by reading raw storage.
-      expect(KeychainService.getInstance(app).getSecretById(keychainId)).toBeNull();
+    });
+
+    describe("listByProviderType()", () => {
+      it("returns stable references while settings are unchanged", async () => {
+        await registry.add({
+          providerType: "anthropic",
+          displayName: "A",
+          origin: { kind: "byok" },
+        });
+        await registry.add({
+          providerType: "anthropic",
+          displayName: "B",
+          origin: { kind: "agent", agentType: "claude" },
+        });
+        const rows = registry.listByProviderType("anthropic");
+        expect(registry.listByProviderType("anthropic")).toBe(rows);
+        expect(rows).toHaveLength(2);
+      });
     });
 
     describe("verify()", () => {
@@ -293,17 +343,6 @@ describe("ProviderRegistry", () => {
         KeychainService.getInstance(app).deleteSecretById(registry.get(id)!.apiKeyKeychainId!);
         expect(await registry.verify(id)).toMatchObject({ ok: false, code: "missing_api_key" });
       });
-    });
-
-    it("settings reflect mutations atomically", async () => {
-      const id = await registry.add({
-        providerType: "anthropic",
-        displayName: "A",
-        origin: { kind: "byok" },
-      });
-      expect(getSettings().providers[id]).toBeDefined();
-      await registry.remove(id);
-      expect(getSettings().providers[id]).toBeUndefined();
     });
 
     describe("subscribe()", () => {

--- a/src/modelManagement/providers/ProviderRegistry.test.ts
+++ b/src/modelManagement/providers/ProviderRegistry.test.ts
@@ -61,314 +61,351 @@ const anthropicStub: ProviderAdapter = {
 };
 
 describe("ProviderRegistry", () => {
-  let app: App;
-  let adapters: ProviderAdapterRegistry;
-  let registry: ProviderRegistry;
+  describe("ProviderRegistry", () => {
+    let app: App;
+    let adapters: ProviderAdapterRegistry;
+    let registry: ProviderRegistry;
 
-  beforeEach(() => {
-    resetSettings();
-    KeychainService.resetInstance();
-    const fake = makeFakeApp();
-    app = fake.app;
-    // Eager init so subsequent KeychainService.getInstance() calls inside
-    // the registry hit the same singleton.
-    KeychainService.getInstance(app);
-    adapters = new ProviderAdapterRegistry();
-    adapters.register(anthropicStub);
-    registry = new ProviderRegistry(app, adapters);
-  });
-
-  it("add() mints id, stamps addedAt, persists the row", async () => {
-    const before = Date.now();
-    const id = await registry.add({
-      providerType: "anthropic",
-      displayName: "Anthropic (prod)",
-      origin: { kind: "byok" },
+    beforeEach(() => {
+      resetSettings();
+      KeychainService.resetInstance();
+      const fake = makeFakeApp();
+      app = fake.app;
+      // Eager init so subsequent KeychainService.getInstance() calls inside
+      // the registry hit the same singleton.
+      KeychainService.getInstance(app);
+      adapters = new ProviderAdapterRegistry();
+      adapters.register(anthropicStub);
+      registry = new ProviderRegistry(app, adapters);
     });
-    expect(typeof id).toBe("string");
-    expect(id.length).toBeGreaterThan(0);
 
-    const row = registry.get(id);
-    expect(row).toBeDefined();
-    expect(row?.displayName).toBe("Anthropic (prod)");
-    expect(row?.providerType).toBe("anthropic");
-    expect(row?.origin).toEqual({ kind: "byok" });
-    expect(row?.addedAt).toBeGreaterThanOrEqual(before);
-    expect(row?.apiKeyKeychainId).toBeNull();
-  });
-
-  it("list() / listByOrigin / listByProviderType return stable references when settings unchanged", async () => {
-    await registry.add({
-      providerType: "anthropic",
-      displayName: "A",
-      origin: { kind: "byok" },
-    });
-    await registry.add({
-      providerType: "anthropic",
-      displayName: "B",
-      origin: { kind: "agent", agentType: "claude" },
-    });
-    const list1 = registry.list();
-    const list2 = registry.list();
-    expect(list1).toBe(list2);
-
-    const byok1 = registry.listByOrigin("byok");
-    const byok2 = registry.listByOrigin("byok");
-    expect(byok1).toBe(byok2);
-    expect(byok1.length).toBe(1);
-
-    const ant1 = registry.listByProviderType("anthropic");
-    const ant2 = registry.listByProviderType("anthropic");
-    expect(ant1).toBe(ant2);
-    expect(ant1.length).toBe(2);
-  });
-
-  it("empty filtered views reuse a shared frozen empty array", () => {
-    const empty1 = registry.listByOrigin("byok");
-    const empty2 = registry.listByOrigin("copilot-plus");
-    expect(empty1).toBe(empty2);
-    expect(empty1.length).toBe(0);
-  });
-
-  it("update() merges patch and refuses to mutate providerId / addedAt / providerType / origin", async () => {
-    const id = await registry.add({
-      providerType: "anthropic",
-      displayName: "Original",
-      origin: { kind: "byok" },
-    });
-    const originalAddedAt = registry.get(id)!.addedAt;
-
-    // Bypass the typed Omit to verify the runtime guard strips immutable
-    // fields even when callers shove them in via an untyped object.
-    // providerType is the adapter-dispatch key and origin determines
-    // which settings tab owns the row — both must stay pinned to the
-    // values supplied at creation.
-    await registry.update(id, {
-      displayName: "Renamed",
-      baseUrl: "https://example.test",
-      ...({
-        providerId: "hacked",
-        addedAt: 1,
-        providerType: "openai",
-        origin: { kind: "agent", agentType: "claude" },
-      } as Record<string, unknown>),
-    });
-    const row = registry.get(id)!;
-    expect(row.displayName).toBe("Renamed");
-    expect(row.baseUrl).toBe("https://example.test");
-    expect(row.providerId).toBe(id);
-    expect(row.addedAt).toBe(originalAddedAt);
-    expect(row.providerType).toBe("anthropic");
-    expect(row.origin).toEqual({ kind: "byok" });
-  });
-
-  it("update() throws for unknown providerId", async () => {
-    await expect(registry.update("nope", { displayName: "x" })).rejects.toThrow(/unknown/);
-  });
-
-  it("setApiKey mints apiKeyKeychainId on first call and reuses it on rotation", async () => {
-    const id = await registry.add({
-      providerType: "anthropic",
-      displayName: "A",
-      origin: { kind: "byok" },
-    });
-    expect(registry.get(id)!.apiKeyKeychainId).toBeNull();
-
-    await registry.setApiKey(id, "sk-first");
-    const firstKeychainId = registry.get(id)!.apiKeyKeychainId;
-    const vaultId = KeychainService.getInstance(app).getVaultId();
-    // Vault-namespaced so `KeychainService.clearAllVaultSecrets()` (which
-    // filters by `copilot-v{vaultId}-`) sweeps these entries.
-    expect(firstKeychainId).toBe(`copilot-v${vaultId}-provider-${id}`);
-    expect(await registry.getApiKey(id)).toBe("sk-first");
-
-    await registry.setApiKey(id, "sk-rotated");
-    expect(registry.get(id)!.apiKeyKeychainId).toBe(firstKeychainId);
-    expect(await registry.getApiKey(id)).toBe("sk-rotated");
-  });
-
-  it("update() ignores attempts to overwrite apiKeyKeychainId", async () => {
-    const id = await registry.add({
-      providerType: "anthropic",
-      displayName: "A",
-      origin: { kind: "byok" },
-    });
-    await registry.setApiKey(id, "sk-real");
-    const realKeychainId = registry.get(id)!.apiKeyKeychainId;
-    expect(realKeychainId).not.toBeNull();
-
-    // Bypass the typed Omit to verify the runtime strip refuses to move
-    // the keychain pointer (which would orphan the secret or repoint the
-    // row at a keychain entry this registry never wrote).
-    await registry.update(id, {
-      ...({ apiKeyKeychainId: "copilot-v0-provider-attacker" } as Record<string, unknown>),
-    });
-    expect(registry.get(id)!.apiKeyKeychainId).toBe(realKeychainId);
-    // The real secret is still readable.
-    expect(await registry.getApiKey(id)).toBe("sk-real");
-  });
-
-  it("getApiKey returns null when the provider has no apiKeyKeychainId", async () => {
-    const id = await registry.add({
-      providerType: "anthropic",
-      displayName: "Ollama-like",
-      origin: { kind: "byok" },
-    });
-    expect(await registry.getApiKey(id)).toBeNull();
-  });
-
-  it("clearApiKey drops the keychain entry and clears the pointer", async () => {
-    const id = await registry.add({
-      providerType: "anthropic",
-      displayName: "A",
-      origin: { kind: "byok" },
-    });
-    await registry.setApiKey(id, "sk-x");
-    await registry.clearApiKey(id);
-    expect(registry.get(id)!.apiKeyKeychainId).toBeNull();
-    expect(await registry.getApiKey(id)).toBeNull();
-  });
-
-  it("remove() drops the row and the keychain entry", async () => {
-    const id = await registry.add({
-      providerType: "anthropic",
-      displayName: "A",
-      origin: { kind: "byok" },
-    });
-    await registry.setApiKey(id, "sk-x");
-    const keychainId = registry.get(id)!.apiKeyKeychainId!;
-    await registry.remove(id);
-    expect(registry.get(id)).toBeUndefined();
-    // Verify keychain side cleaned up by reading raw storage.
-    expect(KeychainService.getInstance(app).getSecretById(keychainId)).toBeNull();
-  });
-
-  it("verify() dispatches to the adapter for the row's providerType", async () => {
-    const id = await registry.add({
-      providerType: "anthropic",
-      displayName: "A",
-      origin: { kind: "byok" },
-    });
-    await registry.setApiKey(id, "sk-x");
-    const result = await registry.verify(id);
-    expect(result.ok).toBe(true);
-    expect(result.message).toBe("stub-ok");
-  });
-
-  it("verify() throws for unknown providerId", async () => {
-    await expect(registry.verify("nope")).rejects.toThrow(/unknown/);
-  });
-
-  it("settings reflect mutations atomically", async () => {
-    const id = await registry.add({
-      providerType: "anthropic",
-      displayName: "A",
-      origin: { kind: "byok" },
-    });
-    expect(getSettings().providers[id]).toBeDefined();
-    await registry.remove(id);
-    expect(getSettings().providers[id]).toBeUndefined();
-  });
-
-  describe("subscribe()", () => {
-    it("fires on add/update/remove and on every setApiKey (including key rotation)", async () => {
-      const listener = jest.fn();
-      const unsubscribe = registry.subscribe(listener);
-
+    it("add() mints id, stamps addedAt, persists the row", async () => {
+      const before = Date.now();
       const id = await registry.add({
+        providerType: "anthropic",
+        displayName: "Anthropic (prod)",
+        origin: { kind: "byok" },
+      });
+      expect(typeof id).toBe("string");
+      expect(id.length).toBeGreaterThan(0);
+
+      const row = registry.get(id);
+      expect(row).toBeDefined();
+      expect(row?.displayName).toBe("Anthropic (prod)");
+      expect(row?.providerType).toBe("anthropic");
+      expect(row?.origin).toEqual({ kind: "byok" });
+      expect(row?.addedAt).toBeGreaterThanOrEqual(before);
+      expect(row?.apiKeyKeychainId).toBeNull();
+    });
+
+    it("list() / listByOrigin / listByProviderType return stable references when settings unchanged", async () => {
+      await registry.add({
         providerType: "anthropic",
         displayName: "A",
         origin: { kind: "byok" },
       });
-      expect(listener).toHaveBeenCalledTimes(1);
-
-      await registry.update(id, { displayName: "A-renamed" });
-      expect(listener).toHaveBeenCalledTimes(2);
-
-      // First setApiKey: fresh keychainId, settings row also updates.
-      await registry.setApiKey(id, "sk-first");
-      expect(listener).toHaveBeenCalledTimes(3);
-
-      // Rotating the key reuses `apiKeyKeychainId` → settings row is
-      // unchanged. The emitter must still fire so subprocess backends
-      // (opencode) restart and pick up the new key. This is the case that
-      // caused the LM Studio silent-failure diagnostic.
-      await registry.setApiKey(id, "sk-rotated");
-      expect(listener).toHaveBeenCalledTimes(4);
-
-      await registry.clearApiKey(id);
-      expect(listener).toHaveBeenCalledTimes(5);
-
-      await registry.remove(id);
-      expect(listener).toHaveBeenCalledTimes(6);
-
-      unsubscribe();
       await registry.add({
         providerType: "anthropic",
         displayName: "B",
-        origin: { kind: "byok" },
+        origin: { kind: "agent", agentType: "claude" },
       });
-      expect(listener).toHaveBeenCalledTimes(6);
+      const list1 = registry.list();
+      const list2 = registry.list();
+      expect(list1).toBe(list2);
+
+      const byok1 = registry.listByOrigin("byok");
+      const byok2 = registry.listByOrigin("byok");
+      expect(byok1).toBe(byok2);
+      expect(byok1.length).toBe(1);
+
+      const ant1 = registry.listByProviderType("anthropic");
+      const ant2 = registry.listByProviderType("anthropic");
+      expect(ant1).toBe(ant2);
+      expect(ant1.length).toBe(2);
     });
 
-    it("does not notify Agent consumers for a Quick Chat-only CORS update (https://github.com/logancyang/obsidian-copilot-preview/issues/313)", async () => {
+    it("empty filtered views reuse a shared frozen empty array", () => {
+      const empty1 = registry.listByOrigin("byok");
+      const empty2 = registry.listByOrigin("copilot-plus");
+      expect(empty1).toBe(empty2);
+      expect(empty1.length).toBe(0);
+    });
+
+    it("update() merges patch and refuses to mutate providerId / addedAt / providerType / origin", async () => {
       const id = await registry.add({
-        providerType: "openai-compatible",
-        displayName: "Work endpoint",
+        providerType: "anthropic",
+        displayName: "Original",
         origin: { kind: "byok" },
       });
-      const listener = jest.fn();
-      registry.subscribe(listener);
+      const originalAddedAt = registry.get(id)!.addedAt;
 
-      await registry.update(id, { enableCors: true });
-
-      expect(registry.get(id)?.enableCors).toBe(true);
-      expect(listener).not.toHaveBeenCalled();
+      // Bypass the typed Omit to verify the runtime guard strips immutable
+      // fields even when callers shove them in via an untyped object.
+      // providerType is the adapter-dispatch key and origin determines
+      // which settings tab owns the row — both must stay pinned to the
+      // values supplied at creation.
+      await registry.update(id, {
+        displayName: "Renamed",
+        baseUrl: "https://example.test",
+        ...({
+          providerId: "hacked",
+          addedAt: 1,
+          providerType: "openai",
+          origin: { kind: "agent", agentType: "claude" },
+        } as Record<string, unknown>),
+      });
+      const row = registry.get(id)!;
+      expect(row.displayName).toBe("Renamed");
+      expect(row.baseUrl).toBe("https://example.test");
+      expect(row.providerId).toBe(id);
+      expect(row.addedAt).toBe(originalAddedAt);
+      expect(row.providerType).toBe("anthropic");
+      expect(row.origin).toEqual({ kind: "byok" });
     });
 
-    // Regression: keychain writes must complete before #emit() fires.
-    // Otherwise subscribers reading apiKey inside their listener (e.g. the
-    // opencode-restart wiring re-reading provider creds) would observe the
-    // prior value and the freshly-set key would be lost until the next emit.
-    it("setApiKey listener observes the new key synchronously, not stale state", async () => {
+    it("update() throws for unknown providerId", async () => {
+      await expect(registry.update("nope", { displayName: "x" })).rejects.toThrow(/unknown/);
+    });
+
+    it("setApiKey mints apiKeyKeychainId on first call and reuses it on rotation", async () => {
       const id = await registry.add({
         providerType: "anthropic",
         displayName: "A",
         origin: { kind: "byok" },
       });
-      await registry.setApiKey(id, "sk-old");
+      expect(registry.get(id)!.apiKeyKeychainId).toBeNull();
 
-      const seenInListener: Array<string | null> = [];
-      registry.subscribe(() => {
-        // Read the keychain synchronously inside the listener — mirrors what
-        // the opencode-restart wiring does (it queues a respawn that reads
-        // the just-emitted credentials). If setApiKey emitted before the
-        // keychain write was durable, this snapshot would still be "sk-old".
-        const row = getSettings().providers[id];
-        const keychainId = row?.apiKeyKeychainId ?? null;
-        seenInListener.push(
-          keychainId ? KeychainService.getInstance(app).getSecretById(keychainId) : null
-        );
-      });
+      await registry.setApiKey(id, "sk-first");
+      const firstKeychainId = registry.get(id)!.apiKeyKeychainId;
+      const vaultId = KeychainService.getInstance(app).getVaultId();
+      // Vault-namespaced so `KeychainService.clearAllVaultSecrets()` (which
+      // filters by `copilot-v{vaultId}-`) sweeps these entries.
+      expect(firstKeychainId).toBe(`copilot-v${vaultId}-provider-${id}`);
+      expect(await registry.getApiKey(id)).toBe("sk-first");
 
-      await registry.setApiKey(id, "sk-new");
-      expect(seenInListener).toEqual(["sk-new"]);
+      await registry.setApiKey(id, "sk-rotated");
+      expect(registry.get(id)!.apiKeyKeychainId).toBe(firstKeychainId);
+      expect(await registry.getApiKey(id)).toBe("sk-rotated");
     });
 
-    it("a throwing listener does not block other listeners", async () => {
-      const bad = jest.fn(() => {
-        throw new Error("boom");
-      });
-      const good = jest.fn();
-      registry.subscribe(bad);
-      registry.subscribe(good);
-      await registry.add({
+    it("update() ignores attempts to overwrite apiKeyKeychainId", async () => {
+      const id = await registry.add({
         providerType: "anthropic",
         displayName: "A",
         origin: { kind: "byok" },
       });
-      expect(bad).toHaveBeenCalledTimes(1);
-      expect(good).toHaveBeenCalledTimes(1);
+      await registry.setApiKey(id, "sk-real");
+      const realKeychainId = registry.get(id)!.apiKeyKeychainId;
+      expect(realKeychainId).not.toBeNull();
+
+      // Bypass the typed Omit to verify the runtime strip refuses to move
+      // the keychain pointer (which would orphan the secret or repoint the
+      // row at a keychain entry this registry never wrote).
+      await registry.update(id, {
+        ...({ apiKeyKeychainId: "copilot-v0-provider-attacker" } as Record<string, unknown>),
+      });
+      expect(registry.get(id)!.apiKeyKeychainId).toBe(realKeychainId);
+      // The real secret is still readable.
+      expect(await registry.getApiKey(id)).toBe("sk-real");
+    });
+
+    it("getApiKey returns null when the provider has no apiKeyKeychainId", async () => {
+      const id = await registry.add({
+        providerType: "anthropic",
+        displayName: "Ollama-like",
+        origin: { kind: "byok" },
+      });
+      expect(await registry.getApiKey(id)).toBeNull();
+    });
+
+    it("clearApiKey drops the keychain entry and clears the pointer", async () => {
+      const id = await registry.add({
+        providerType: "anthropic",
+        displayName: "A",
+        origin: { kind: "byok" },
+      });
+      await registry.setApiKey(id, "sk-x");
+      await registry.clearApiKey(id);
+      expect(registry.get(id)!.apiKeyKeychainId).toBeNull();
+      expect(await registry.getApiKey(id)).toBeNull();
+    });
+
+    it("remove() drops the row and the keychain entry", async () => {
+      const id = await registry.add({
+        providerType: "anthropic",
+        displayName: "A",
+        origin: { kind: "byok" },
+      });
+      await registry.setApiKey(id, "sk-x");
+      const keychainId = registry.get(id)!.apiKeyKeychainId!;
+      await registry.remove(id);
+      expect(registry.get(id)).toBeUndefined();
+      // Verify keychain side cleaned up by reading raw storage.
+      expect(KeychainService.getInstance(app).getSecretById(keychainId)).toBeNull();
+    });
+
+    describe("verify()", () => {
+      it("dispatches to the adapter for the row's providerType", async () => {
+        const id = await registry.add({
+          providerType: "anthropic",
+          displayName: "A",
+          origin: { kind: "byok" },
+        });
+        await registry.setApiKey(id, "sk-x");
+        const result = await registry.verify(id);
+        expect(result.ok).toBe(true);
+        expect(result.message).toBe("stub-ok");
+      });
+
+      it("throws for unknown providerId", async () => {
+        await expect(registry.verify("nope")).rejects.toThrow(/unknown/);
+      });
+
+      it.each([null, "", "   "])(
+        "rejects a missing stored key (%p) without probing a public endpoint (https://github.com/logancyang/obsidian-copilot/issues/3147)",
+        async (secret) => {
+          const id = await registry.add({
+            providerType: "anthropic",
+            displayName: "A",
+            origin: { kind: "byok" },
+            requiresApiKey: true,
+          });
+          await registry.setApiKey(id, "old-key");
+          const pointer = registry.get(id)!.apiKeyKeychainId!;
+          if (secret === null) KeychainService.getInstance(app).deleteSecretById(pointer);
+          else KeychainService.getInstance(app).setSecretById(pointer, secret);
+          const probe = jest.spyOn(adapters, "verifyCredentials");
+          expect(await registry.verify(id)).toMatchObject({ ok: false, code: "missing_api_key" });
+          expect(probe).not.toHaveBeenCalled();
+          expect(registry.get(id)!.apiKeyKeychainId).toBe(pointer);
+        }
+      );
+
+      it("verifies an optional-auth endpoint without a key but rejects its dangling stored credential (https://github.com/logancyang/obsidian-copilot/issues/3147)", async () => {
+        const id = await registry.add({
+          providerType: "anthropic",
+          displayName: "Local",
+          origin: { kind: "byok" },
+          requiresApiKey: false,
+        });
+        expect(await registry.verify(id)).toMatchObject({ ok: true });
+        await registry.setApiKey(id, "old-key");
+        KeychainService.getInstance(app).deleteSecretById(registry.get(id)!.apiKeyKeychainId!);
+        expect(await registry.verify(id)).toMatchObject({ ok: false, code: "missing_api_key" });
+      });
+    });
+
+    it("settings reflect mutations atomically", async () => {
+      const id = await registry.add({
+        providerType: "anthropic",
+        displayName: "A",
+        origin: { kind: "byok" },
+      });
+      expect(getSettings().providers[id]).toBeDefined();
+      await registry.remove(id);
+      expect(getSettings().providers[id]).toBeUndefined();
+    });
+
+    describe("subscribe()", () => {
+      it("fires on add/update/remove and on every setApiKey (including key rotation)", async () => {
+        const listener = jest.fn();
+        const unsubscribe = registry.subscribe(listener);
+
+        const id = await registry.add({
+          providerType: "anthropic",
+          displayName: "A",
+          origin: { kind: "byok" },
+        });
+        expect(listener).toHaveBeenCalledTimes(1);
+
+        await registry.update(id, { displayName: "A-renamed" });
+        expect(listener).toHaveBeenCalledTimes(2);
+
+        // First setApiKey: fresh keychainId, settings row also updates.
+        await registry.setApiKey(id, "sk-first");
+        expect(listener).toHaveBeenCalledTimes(3);
+
+        // Rotating the key reuses `apiKeyKeychainId` → settings row is
+        // unchanged. The emitter must still fire so subprocess backends
+        // (opencode) restart and pick up the new key. This is the case that
+        // caused the LM Studio silent-failure diagnostic.
+        await registry.setApiKey(id, "sk-rotated");
+        expect(listener).toHaveBeenCalledTimes(4);
+
+        await registry.clearApiKey(id);
+        expect(listener).toHaveBeenCalledTimes(5);
+
+        await registry.remove(id);
+        expect(listener).toHaveBeenCalledTimes(6);
+
+        unsubscribe();
+        await registry.add({
+          providerType: "anthropic",
+          displayName: "B",
+          origin: { kind: "byok" },
+        });
+        expect(listener).toHaveBeenCalledTimes(6);
+      });
+
+      it("does not notify Agent consumers for a Quick Chat-only CORS update (https://github.com/logancyang/obsidian-copilot-preview/issues/313)", async () => {
+        const id = await registry.add({
+          providerType: "openai-compatible",
+          displayName: "Work endpoint",
+          origin: { kind: "byok" },
+        });
+        const listener = jest.fn();
+        registry.subscribe(listener);
+
+        await registry.update(id, { enableCors: true });
+
+        expect(registry.get(id)?.enableCors).toBe(true);
+        expect(listener).not.toHaveBeenCalled();
+      });
+
+      // Regression: keychain writes must complete before #emit() fires.
+      // Otherwise subscribers reading apiKey inside their listener (e.g. the
+      // opencode-restart wiring re-reading provider creds) would observe the
+      // prior value and the freshly-set key would be lost until the next emit.
+      it("setApiKey listener observes the new key synchronously, not stale state", async () => {
+        const id = await registry.add({
+          providerType: "anthropic",
+          displayName: "A",
+          origin: { kind: "byok" },
+        });
+        await registry.setApiKey(id, "sk-old");
+
+        const seenInListener: Array<string | null> = [];
+        registry.subscribe(() => {
+          // Read the keychain synchronously inside the listener — mirrors what
+          // the opencode-restart wiring does (it queues a respawn that reads
+          // the just-emitted credentials). If setApiKey emitted before the
+          // keychain write was durable, this snapshot would still be "sk-old".
+          const row = getSettings().providers[id];
+          const keychainId = row?.apiKeyKeychainId ?? null;
+          seenInListener.push(
+            keychainId ? KeychainService.getInstance(app).getSecretById(keychainId) : null
+          );
+        });
+
+        await registry.setApiKey(id, "sk-new");
+        expect(seenInListener).toEqual(["sk-new"]);
+      });
+
+      it("a throwing listener does not block other listeners", async () => {
+        const bad = jest.fn(() => {
+          throw new Error("boom");
+        });
+        const good = jest.fn();
+        registry.subscribe(bad);
+        registry.subscribe(good);
+        await registry.add({
+          providerType: "anthropic",
+          displayName: "A",
+          origin: { kind: "byok" },
+        });
+        expect(bad).toHaveBeenCalledTimes(1);
+        expect(good).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/src/modelManagement/providers/ProviderRegistry.ts
+++ b/src/modelManagement/providers/ProviderRegistry.ts
@@ -22,6 +22,7 @@
 import type { App } from "obsidian";
 import { v4 as uuidv4 } from "uuid";
 
+import { providerNeedsResolvedApiKey } from "@/modelManagement/providers/providerRequiresApiKey";
 import { logError } from "@/logger";
 import { KeychainService } from "@/services/keychainService";
 import { getSettings, setSettings } from "@/settings/model";
@@ -46,6 +47,7 @@ function providerKeychainId(vaultId: string, providerId: string): string {
   return `copilot-v${vaultId}-provider-${providerId}`;
 }
 
+/** Owns persisted provider configuration and secret access; model enrollment and removal cascades belong to the coordinator. */
 export class ProviderRegistry {
   readonly #app: App;
   readonly #adapters: ProviderAdapterRegistry;
@@ -309,6 +311,7 @@ export class ProviderRegistry {
   /**
    * Issues an adapter-defined "ping". Returns the verification
    * result; does NOT persist it.
+   * @param providerId - Configured provider whose current credentials should be checked.
    */
   async verify(providerId: string): Promise<VerificationResult> {
     const provider = this.get(providerId);
@@ -318,6 +321,16 @@ export class ProviderRegistry {
       );
     }
     const apiKey = await this.getApiKey(providerId);
+    // https://github.com/logancyang/obsidian-copilot/issues/3147:
+    // A public models endpoint must not mask a missing stored credential.
+    if (providerNeedsResolvedApiKey(provider) && !apiKey?.trim()) {
+      return {
+        ok: false,
+        code: "missing_api_key",
+        message: "API key is missing. Configure this provider to enter it again.",
+        checkedAt: Date.now(),
+      };
+    }
     return this.#adapters.verifyCredentials(provider.providerType, {
       provider,
       apiKey,

--- a/src/modelManagement/ui/components/ByokGlobalTable.test.tsx
+++ b/src/modelManagement/ui/components/ByokGlobalTable.test.tsx
@@ -27,6 +27,7 @@ const group: ByokTableGroup = {
     requiresApiKey: true,
     apiKeyKeychainId: "key1",
   },
+  verification: { ok: true, checkedAt: 0 },
   models: [
     {
       configuredModelId: "m1",
@@ -56,121 +57,124 @@ const renderWithProvider = (ui: React.ReactElement) =>
   );
 
 describe("ByokGlobalTable", () => {
-  it("shows the empty state when there are no groups", () => {
-    renderWithProvider(
-      <ByokGlobalTable groups={[]} onConfigure={jest.fn()} onRemove={jest.fn()} />
-    );
-    expect(screen.getByTestId("byok-table-empty")).toBeTruthy();
-  });
+  describe("ByokGlobalTable()", () => {
+    it("shows the empty state when there are no groups", () => {
+      renderWithProvider(
+        <ByokGlobalTable groups={[]} onConfigure={jest.fn()} onRemove={jest.fn()} />
+      );
+      expect(screen.getByTestId("byok-table-empty")).toBeTruthy();
+    });
 
-  it("renders the provider name and model rows when expanded", () => {
-    renderWithProvider(
-      <ByokGlobalTable groups={[group]} onConfigure={jest.fn()} onRemove={jest.fn()} />
-    );
-    expect(screen.getByText("Anthropic")).toBeTruthy();
+    it("renders the provider name and model rows when expanded", () => {
+      renderWithProvider(
+        <ByokGlobalTable groups={[group]} onConfigure={jest.fn()} onRemove={jest.fn()} />
+      );
+      expect(screen.getByText("Anthropic")).toBeTruthy();
 
-    // Models are collapsed by default, expand first
-    fireEvent.click(screen.getByText("Anthropic"));
-    expect(screen.getByText("Claude Sonnet 4.5")).toBeTruthy();
-    expect(screen.getByText("Claude Opus 4.5")).toBeTruthy();
-  });
+      // Models are collapsed by default, expand first
+      fireEvent.click(screen.getByText("Anthropic"));
+      expect(screen.getByText("Claude Sonnet 4.5")).toBeTruthy();
+      expect(screen.getByText("Claude Opus 4.5")).toBeTruthy();
+    });
 
-  it("shows model count and status badge", () => {
-    renderWithProvider(
-      <ByokGlobalTable groups={[group]} onConfigure={jest.fn()} onRemove={jest.fn()} />
-    );
-    expect(screen.getByText("2 models")).toBeTruthy();
-    // A configured (key-set) provider gets the green success pill.
-    const badge = screen.getByText("API key set");
-    expect(badge.className).toContain("tw-bg-success");
-    expect(badge.className).toContain("tw-text-success");
-  });
+    it("shows model count and status badge", () => {
+      renderWithProvider(
+        <ByokGlobalTable groups={[group]} onConfigure={jest.fn()} onRemove={jest.fn()} />
+      );
+      expect(screen.getByText("2 models")).toBeTruthy();
+      // The current successful check earns the success pill.
+      const badge = screen.getByText("Verified");
+      expect(badge.className).toContain("tw-bg-success");
+      expect(badge.className).toContain("tw-text-success");
+    });
 
-  it("renders a neutral (non-success) badge when the provider has no key", () => {
-    const noKeyGroup: ByokTableGroup = {
-      provider: { ...group.provider, apiKeyKeychainId: undefined },
-      models: group.models,
-    };
-    renderWithProvider(
-      <ByokGlobalTable groups={[noKeyGroup]} onConfigure={jest.fn()} onRemove={jest.fn()} />
-    );
-    const badge = screen.getByText("No key");
-    expect(badge.className).not.toContain("tw-bg-success");
-  });
+    it("shows a missing-key result even when configuration alone cannot verify it (https://github.com/logancyang/obsidian-copilot/issues/3147)", () => {
+      const noKeyGroup: ByokTableGroup = {
+        provider: { ...group.provider, apiKeyKeychainId: undefined },
+        models: group.models,
+        verification: { ok: false, code: "missing_api_key", checkedAt: 0 },
+      };
+      renderWithProvider(
+        <ByokGlobalTable groups={[noKeyGroup]} onConfigure={jest.fn()} onRemove={jest.fn()} />
+      );
+      const badge = screen.getByText("No key");
+      expect(badge.className).not.toContain("tw-bg-success");
+    });
 
-  it("uses a clearer sub-line than '0 models' when a key-set provider has no models", () => {
-    const emptyGroup: ByokTableGroup = { provider: group.provider, models: [] };
-    renderWithProvider(
-      <ByokGlobalTable groups={[emptyGroup]} onConfigure={jest.fn()} onRemove={jest.fn()} />
-    );
-    expect(screen.getByText("No models added")).toBeTruthy();
-    expect(screen.queryByText("0 models")).toBeNull();
-    // Key is still set, so the green pill stays.
-    expect(screen.getByText("API key set")).toBeTruthy();
-  });
+    it("uses a clearer sub-line than '0 models' when a key-set provider has no models", () => {
+      const emptyGroup: ByokTableGroup = { ...group, models: [] };
+      renderWithProvider(
+        <ByokGlobalTable groups={[emptyGroup]} onConfigure={jest.fn()} onRemove={jest.fn()} />
+      );
+      expect(screen.getByText("No models added")).toBeTruthy();
+      expect(screen.queryByText("0 models")).toBeNull();
+      // Model count does not change the current verification result.
+      expect(screen.getByText("Verified")).toBeTruthy();
+    });
 
-  it("describes a local (keyless) provider with the green 'Running' pill and a self-describing sub-line", () => {
-    const localGroup: ByokTableGroup = {
-      provider: { ...group.provider, displayName: "Ollama", requiresApiKey: false },
-      models: [],
-    };
-    renderWithProvider(
-      <ByokGlobalTable groups={[localGroup]} onConfigure={jest.fn()} onRemove={jest.fn()} />
-    );
-    expect(screen.getByText("Local models on your machine")).toBeTruthy();
-    const badge = screen.getByText("Running");
-    expect(badge.className).toContain("tw-bg-success");
-  });
+    it("waits for verification before claiming a keyless provider is running (https://github.com/logancyang/obsidian-copilot/issues/3147)", () => {
+      const localGroup: ByokTableGroup = {
+        provider: { ...group.provider, displayName: "Ollama", requiresApiKey: false },
+        models: [],
+      };
+      renderWithProvider(
+        <ByokGlobalTable groups={[localGroup]} onConfigure={jest.fn()} onRemove={jest.fn()} />
+      );
+      expect(screen.getByText("Local models on your machine")).toBeTruthy();
+      const badge = screen.getByText("Checking…");
+      expect(badge.className).not.toContain("tw-bg-success");
+    });
 
-  it("collapses and expands when the provider card is clicked", () => {
-    renderWithProvider(
-      <ByokGlobalTable groups={[group]} onConfigure={jest.fn()} onRemove={jest.fn()} />
-    );
+    it("collapses and expands when the provider card is clicked", () => {
+      renderWithProvider(
+        <ByokGlobalTable groups={[group]} onConfigure={jest.fn()} onRemove={jest.fn()} />
+      );
 
-    // Initially collapsed
-    expect(screen.queryByText("Claude Sonnet 4.5")).toBeNull();
+      // Initially collapsed
+      expect(screen.queryByText("Claude Sonnet 4.5")).toBeNull();
 
-    // Click to expand
-    fireEvent.click(screen.getByText("Anthropic"));
-    expect(screen.getByText("Claude Sonnet 4.5")).toBeTruthy();
+      // Click to expand
+      fireEvent.click(screen.getByText("Anthropic"));
+      expect(screen.getByText("Claude Sonnet 4.5")).toBeTruthy();
 
-    // Click to collapse
-    fireEvent.click(screen.getByText("Anthropic"));
-    expect(screen.queryByText("Claude Sonnet 4.5")).toBeNull();
-  });
+      // Click to collapse
+      fireEvent.click(screen.getByText("Anthropic"));
+      expect(screen.queryByText("Claude Sonnet 4.5")).toBeNull();
+    });
 
-  it("exposes the header as a keyboard-operable button that toggles on Enter/Space", () => {
-    renderWithProvider(
-      <ByokGlobalTable groups={[group]} onConfigure={jest.fn()} onRemove={jest.fn()} />
-    );
+    it("exposes the header as a keyboard-operable button that toggles on Enter/Space", () => {
+      renderWithProvider(
+        <ByokGlobalTable groups={[group]} onConfigure={jest.fn()} onRemove={jest.fn()} />
+      );
 
-    // The header's accessible name includes its text ("2 models"); the
-    // overflow-menu trigger (also aria-expanded) is named "More actions…".
-    const header = screen.getByRole("button", { name: /2 models/i });
-    expect(header.getAttribute("tabindex")).toBe("0");
-    expect(header.getAttribute("aria-expanded")).toBe("false");
+      // The header's accessible name includes its text ("2 models"); the
+      // overflow-menu trigger (also aria-expanded) is named "More actions…".
+      const header = screen.getByRole("button", { name: /2 models/i });
+      expect(header.getAttribute("tabindex")).toBe("0");
+      expect(header.getAttribute("aria-expanded")).toBe("false");
 
-    // Enter expands.
-    fireEvent.keyDown(header, { key: "Enter" });
-    expect(screen.getByText("Claude Sonnet 4.5")).toBeTruthy();
-    expect(header.getAttribute("aria-expanded")).toBe("true");
+      // Enter expands.
+      fireEvent.keyDown(header, { key: "Enter" });
+      expect(screen.getByText("Claude Sonnet 4.5")).toBeTruthy();
+      expect(header.getAttribute("aria-expanded")).toBe("true");
 
-    // Space collapses.
-    fireEvent.keyDown(header, { key: " " });
-    expect(screen.queryByText("Claude Sonnet 4.5")).toBeNull();
-    expect(header.getAttribute("aria-expanded")).toBe("false");
-  });
+      // Space collapses.
+      fireEvent.keyDown(header, { key: " " });
+      expect(screen.queryByText("Claude Sonnet 4.5")).toBeNull();
+      expect(header.getAttribute("aria-expanded")).toBe("false");
+    });
 
-  it("keeps the per-model remove button mounted (keyboard reachable) when expanded", () => {
-    renderWithProvider(
-      <ByokGlobalTable groups={[group]} onConfigure={jest.fn()} onRemove={jest.fn()} />
-    );
-    fireEvent.click(screen.getByText("Anthropic"));
+    it("keeps the per-model remove button mounted (keyboard reachable) when expanded", () => {
+      renderWithProvider(
+        <ByokGlobalTable groups={[group]} onConfigure={jest.fn()} onRemove={jest.fn()} />
+      );
+      fireEvent.click(screen.getByText("Anthropic"));
 
-    // Button is in the DOM without any hover — opacity, not conditional render,
-    // gates its visibility, so keyboard users can Tab to it.
-    const removeBtn = screen.getByRole("button", { name: "Remove Claude Sonnet 4.5" });
-    expect(removeBtn).toBeTruthy();
-    expect(removeBtn.getAttribute("tabindex")).toBe("0");
+      // Button is in the DOM without any hover — opacity, not conditional render,
+      // gates its visibility, so keyboard users can Tab to it.
+      const removeBtn = screen.getByRole("button", { name: "Remove Claude Sonnet 4.5" });
+      expect(removeBtn).toBeTruthy();
+      expect(removeBtn.getAttribute("tabindex")).toBe("0");
+    });
   });
 });

--- a/src/modelManagement/ui/components/ByokGlobalTable.tsx
+++ b/src/modelManagement/ui/components/ByokGlobalTable.tsx
@@ -6,7 +6,8 @@
  * chevron, provider name, model count, status badge, and overflow menu. When
  * expanded, model names appear in a vertical list with hover × remove.
  */
-import { Badge } from "@/components/ui/badge";
+import { ProviderVerificationStatus } from "@/modelManagement/ui/components/ProviderVerificationStatus";
+import type { VerificationResult } from "@/modelManagement/types/runtime";
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import {
@@ -32,6 +33,8 @@ import { safeAsyncHandler } from "@/utils/safeAsyncHandler";
 export interface ByokTableGroup {
   provider: Provider;
   models: ConfiguredModel[];
+  /** Latest check from this tab visit; absent while checking. */
+  verification?: VerificationResult;
   /** `true` when Self-Host Mode is on and this is a cloud provider — the card
    *  header shows a cloud-egress warning icon. */
   needsSelfHostWarning?: boolean;
@@ -110,25 +113,6 @@ const ProviderCard: React.FC<ProviderCardProps> = ({
   const api = useModelManagement();
   const app = useApp();
 
-  const getStatusBadge = (): {
-    label: string;
-    variant: "default" | "secondary" | "destructive" | "outline";
-    /** Green tint for the "configured" states (key set / local running);
-     *  matches the repo's canonical success pill. `undefined` keeps the
-     *  neutral variant styling for the "No key" state. */
-    className?: string;
-  } => {
-    const requiresKey = providerRequiresApiKey(provider);
-    const successClassName = "tw-rounded-full tw-bg-success tw-text-success";
-    if (!requiresKey) {
-      return { label: "Running", variant: "default", className: successClassName };
-    }
-    if (provider.apiKeyKeychainId) {
-      return { label: "API key set", variant: "default", className: successClassName };
-    }
-    return { label: "No key", variant: "secondary", className: "tw-rounded-full" };
-  };
-
   const handleRemoveModel = async (configuredModelId: string, modelName: string): Promise<void> => {
     const modal = new ConfirmModal(
       app,
@@ -147,8 +131,6 @@ const ProviderCard: React.FC<ProviderCardProps> = ({
     );
     modal.open();
   };
-
-  const statusBadge = getStatusBadge();
 
   // Sub-line under the provider name. Local providers describe themselves
   // (their models aren't a curated count); key-based providers show the
@@ -212,12 +194,7 @@ const ProviderCard: React.FC<ProviderCardProps> = ({
               <span className="tw-text-xs tw-text-muted">{getSubLine()}</span>
             </div>
             <div className="tw-flex-1" />
-            <Badge
-              variant={statusBadge.variant}
-              className={cn("tw-shrink-0", statusBadge.className)}
-            >
-              {statusBadge.label}
-            </Badge>
+            <ProviderVerificationStatus result={group.verification} />
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button

--- a/src/modelManagement/ui/components/ProviderVerificationStatus.stories.tsx
+++ b/src/modelManagement/ui/components/ProviderVerificationStatus.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from "@/lib/story";
+import {
+  ProviderVerificationProgress,
+  ProviderVerificationStatus,
+  type ProviderVerificationStatusProps,
+} from "./ProviderVerificationStatus";
+import React from "react";
+import { Button } from "@/components/ui/button";
+
+const meta = {
+  title: "Settings/Provider Verification",
+  component: ProviderVerificationStatus,
+  parameters: { gallery: { host: "settings-tab", layout: "padded" } },
+} satisfies Meta<ProviderVerificationStatusProps>;
+export default meta;
+
+export const Checking: StoryObj<ProviderVerificationStatusProps> = {};
+export const Verified: StoryObj<ProviderVerificationStatusProps> = {
+  args: { result: { ok: true, checkedAt: 0 } },
+};
+export const MissingKey: StoryObj<ProviderVerificationStatusProps> = {
+  args: {
+    result: {
+      ok: false,
+      code: "missing_api_key",
+      message: "API key is missing. Configure this provider to enter it again.",
+      checkedAt: 0,
+    },
+  },
+};
+export const InvalidKey: StoryObj<ProviderVerificationStatusProps> = {
+  args: {
+    result: {
+      ok: false,
+      code: "invalid_api_key",
+      message: "The provider rejected this API key.",
+      checkedAt: 0,
+    },
+  },
+};
+export const Offline: StoryObj<ProviderVerificationStatusProps> = {
+  args: {
+    result: { ok: false, code: "network", message: "Could not reach this provider.", checkedAt: 0 },
+  },
+};
+export const Progress: StoryObj<ProviderVerificationStatusProps> = {
+  render: () => (
+    <div className="tw-relative tw-flex tw-flex-col tw-gap-4 tw-py-4">
+      <ProviderVerificationProgress pending={2} />
+      <div className="tw-flex tw-items-start tw-justify-between tw-gap-4">
+        <div className="tw-text-xl tw-font-bold">Bring Your Own Key</div>
+        <Button className="tw-shrink-0">Add a provider</Button>
+      </div>
+      <div className="tw-text-sm tw-text-muted">
+        Set up your own providers and models to use in Copilot.
+      </div>
+      <div className="tw-flex tw-items-center tw-justify-between tw-rounded-lg tw-border tw-border-solid tw-p-4">
+        OpenAI <ProviderVerificationStatus />
+      </div>
+    </div>
+  ),
+};

--- a/src/modelManagement/ui/components/ProviderVerificationStatus.test.tsx
+++ b/src/modelManagement/ui/components/ProviderVerificationStatus.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import {
+  ProviderVerificationProgress,
+  ProviderVerificationStatus,
+} from "./ProviderVerificationStatus";
+import type { VerificationResult } from "@/modelManagement/types/runtime";
+
+const issue = "https://github.com/logancyang/obsidian-copilot/issues/3147";
+
+describe("ProviderVerificationStatus", () => {
+  describe("ProviderVerificationStatus()", () => {
+    it.each<[VerificationResult | undefined, string]>([
+      [undefined, "Checking…"],
+      [{ ok: true, checkedAt: 0 }, "Verified"],
+      [{ ok: false, code: "missing_api_key", checkedAt: 0 }, "No key"],
+      [{ ok: false, code: "invalid_api_key", checkedAt: 0 }, "Invalid key"],
+      [{ ok: false, code: "network", checkedAt: 0 }, "Check failed"],
+      [{ ok: false, code: "rate_limited", checkedAt: 0 }, "Check failed"],
+    ])(`renders the current result %p as %s (${issue})`, (result, label) => {
+      render(<ProviderVerificationStatus result={result} />);
+      expect(screen.getByText(label)).toBeTruthy();
+    });
+
+    it(`exposes the verification failure detail on the badge (${issue})`, () => {
+      render(
+        <ProviderVerificationStatus
+          result={{ ok: false, message: "Could not reach provider", checkedAt: 0 }}
+        />
+      );
+      expect(screen.getByTitle("Could not reach provider")).toBeTruthy();
+    });
+  });
+
+  describe("ProviderVerificationProgress()", () => {
+    it(`announces pending checks and disappears once they finish (${issue})`, () => {
+      const { rerender } = render(<ProviderVerificationProgress pending={2} />);
+      expect(screen.getByRole("status").textContent).toBe("Verifying providers…");
+      rerender(<ProviderVerificationProgress pending={0} />);
+      expect(screen.queryByRole("status")).toBeNull();
+    });
+  });
+});

--- a/src/modelManagement/ui/components/ProviderVerificationStatus.tsx
+++ b/src/modelManagement/ui/components/ProviderVerificationStatus.tsx
@@ -1,0 +1,53 @@
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import type { VerificationResult } from "@/modelManagement/types/runtime";
+import { Loader2 } from "lucide-react";
+import React from "react";
+
+export interface ProviderVerificationStatusProps {
+  /** Latest result for the current provider configuration; absent while checking. */
+  result?: VerificationResult;
+}
+
+export function ProviderVerificationStatus({ result }: ProviderVerificationStatusProps) {
+  // https://github.com/logancyang/obsidian-copilot/issues/3147:
+  // Only a fresh successful probe earns a success badge. Connection failures
+  // remain inconclusive rather than accusing a valid key of being invalid.
+  const label = !result
+    ? "Checking…"
+    : result.ok
+      ? "Verified"
+      : result.code === "missing_api_key"
+        ? "No key"
+        : result.code === "invalid_api_key"
+          ? "Invalid key"
+          : "Check failed";
+  return (
+    <Badge
+      variant={result && !result.ok ? "destructive" : "secondary"}
+      title={result?.message}
+      className={cn("tw-shrink-0 tw-rounded-full", result?.ok && "tw-bg-success tw-text-success")}
+    >
+      {label}
+    </Badge>
+  );
+}
+
+export interface ProviderVerificationProgressProps {
+  pending: number;
+}
+
+export function ProviderVerificationProgress({ pending }: ProviderVerificationProgressProps) {
+  // https://github.com/logancyang/obsidian-copilot/issues/3147:
+  // Keep progress outside document flow so the provider list does not jump.
+  if (pending === 0) return null;
+  return (
+    <div
+      role="status"
+      className="tw-pointer-events-none tw-absolute tw-right-0 tw-top-0 tw-flex -tw-translate-y-1/2 tw-items-center tw-gap-1.5 tw-rounded-full tw-bg-primary tw-px-2 tw-py-1 tw-text-xs tw-text-muted tw-shadow-sm"
+    >
+      <Loader2 className="tw-size-3 tw-animate-spin" aria-hidden="true" />
+      Verifying providers…
+    </div>
+  );
+}

--- a/src/modelManagement/ui/dialogs/ConfigureProviderDialog.test.tsx
+++ b/src/modelManagement/ui/dialogs/ConfigureProviderDialog.test.tsx
@@ -1,5 +1,5 @@
 import type { VerificationResult } from "@/modelManagement/types/runtime";
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import React from "react";
 
 const mockVerifyCredentials = jest.fn<Promise<VerificationResult>, [string, unknown]>();
@@ -167,596 +167,688 @@ function rowCheckbox(id: string): HTMLElement {
   return within(row).getByRole("checkbox");
 }
 
-describe("ConfigureProviderForm (new mode)", () => {
-  it.each([
-    ["Anthropic", anthropicSource],
-    ["OpenAI", openaiSource],
-    ["Ollama", ollamaSource],
-    ["custom OpenAI-compatible", CUSTOM_OPENAI_DEFINITION],
-  ] as const)(
-    "renders manual Model ID and discovery search together for %s (https://github.com/logancyang/obsidian-copilot/issues/2894)",
-    (_provider, source) => {
-      render(<ConfigureProviderForm state={{ mode: "new", source }} onClose={jest.fn()} />);
-      const modelsSection = screen.getByText("Models").parentElement;
-      expect(modelsSection).not.toBeNull();
-      expect(within(modelsSection!).getByTestId("model-checklist-manual-input")).toBeTruthy();
-      expect(within(modelsSection!).getByPlaceholderText("Search available models…")).toBeTruthy();
-    }
-  );
-
-  it("skips the mount fetch when the source requires an API key and the field is empty", () => {
-    render(
-      <ConfigureProviderForm state={{ mode: "new", source: anthropicSource }} onClose={jest.fn()} />
-    );
-    expect(mockListProviderModels).not.toHaveBeenCalled();
-  });
-
-  it("fires the mount fetch for a key-less template (no auth required)", async () => {
-    mockListProviderModels.mockResolvedValue({ ok: true, modelIds: ["llama3.2"] });
-    render(
-      <ConfigureProviderForm state={{ mode: "new", source: ollamaSource }} onClose={jest.fn()} />
-    );
-    await waitFor(() => expect(mockListProviderModels).toHaveBeenCalledTimes(1));
-    expect(mockListProviderModels).toHaveBeenCalledWith(
-      "openai-compatible",
-      "http://localhost:11434/v1",
-      expect.objectContaining({ apiKey: null })
-    );
-    // Discovered ids appear as unchecked candidates; user opts in.
-    await waitFor(() => expect(screen.getByTestId("model-row-llama3.2")).toBeTruthy());
-    expect(rowCheckbox("llama3.2").getAttribute("aria-checked")).toBe("false");
-  });
-
-  it("waits for Test before discovering models from a typed custom URL (https://github.com/logancyang/obsidian-copilot/issues/2895)", async () => {
-    mockVerifyCredentials.mockResolvedValue({ ok: true, checkedAt: 1 });
-    render(
-      <ConfigureProviderForm
-        state={{ mode: "new", source: CUSTOM_OPENAI_DEFINITION }}
-        onClose={jest.fn()}
-      />
-    );
-    const baseUrlInput = screen.getByText("Base URL").parentElement?.querySelector("input");
-    expect(baseUrlInput).not.toBeNull();
-
-    fireEvent.change(baseUrlInput!, { target: { value: "h" } });
-    fireEvent.change(baseUrlInput!, { target: { value: "https://work.example.com/v1" } });
-    expect(mockListProviderModels).not.toHaveBeenCalled();
-
-    fireEvent.click(screen.getByRole("button", { name: "Test" }));
-    await waitFor(() => expect(mockListProviderModels).toHaveBeenCalledTimes(1));
-    expect(mockListProviderModels).toHaveBeenCalledWith(
-      "openai-compatible",
-      "https://work.example.com/v1",
-      expect.objectContaining({ apiKey: null })
-    );
-  });
-
-  it("uses the source default URL as the input placeholder", () => {
-    render(
-      <ConfigureProviderForm state={{ mode: "new", source: anthropicSource }} onClose={jest.fn()} />
-    );
-    expect(screen.getByPlaceholderText("https://api.anthropic.com")).toBeTruthy();
-  });
-
-  it("falls back to a known default endpoint when the source ships none", async () => {
-    // OpenAI catalog has no defaultBaseUrl; the known-default lookup fills in.
-    render(
-      <ConfigureProviderForm state={{ mode: "new", source: openaiSource }} onClose={jest.fn()} />
-    );
-    expect(screen.getByPlaceholderText("https://api.openai.com/v1")).toBeTruthy();
-  });
-
-  it("Save is gated only on a non-empty selection", async () => {
-    render(
-      <ConfigureProviderForm state={{ mode: "new", source: ollamaSource }} onClose={jest.fn()} />
-    );
-    const save = screen.getByRole("button", { name: "Save" });
-    expect(save.hasAttribute("disabled")).toBe(true);
-    manualAddId("llama3.2");
-    expect(save.hasAttribute("disabled")).toBe(false);
-  });
-
-  it("calls setupProvider with the catalog id + enriched model metadata", async () => {
-    mockGetProvider.mockReturnValue(anthropicCatalogMetadata);
-    mockVerifyCredentials.mockResolvedValue({ ok: true, checkedAt: 1 });
-    const onClose = jest.fn();
-    render(
-      <ConfigureProviderForm state={{ mode: "new", source: anthropicSource }} onClose={onClose} />
-    );
-    // A required-key provider can't save without a key, so supply one.
-    fireEvent.change(screen.getByTestId("api-key"), { target: { value: "sk-ant" } });
-    manualAddId("claude-sonnet");
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-    await waitFor(() => expect(mockSetupProvider).toHaveBeenCalledTimes(1));
-    expect(mockSetupProvider).toHaveBeenCalledWith(
-      expect.objectContaining({
-        catalogProviderId: "anthropic",
-        providerType: "anthropic",
-        displayName: "Anthropic",
-        baseUrl: "https://api.anthropic.com",
-        models: [
-          // The manually-added id matches a catalog entry, so the saved
-          // ModelInfo carries the enriched displayName + limits.
-          expect.objectContaining({
-            id: "claude-sonnet",
-            displayName: "Claude Sonnet 4.5",
-            limits: { context: 200000 },
-          }),
-        ],
-      })
-    );
-    await waitFor(() => expect(onClose).toHaveBeenCalled());
-  });
-
-  it("synthesizes minimal ModelInfo for a manual id with no catalog entry", async () => {
-    const onClose = jest.fn();
-    render(
-      <ConfigureProviderForm state={{ mode: "new", source: ollamaSource }} onClose={onClose} />
-    );
-    manualAddId("nomic-embed-text");
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-    await waitFor(() => expect(mockSetupProvider).toHaveBeenCalled());
-    expect(mockSetupProvider).toHaveBeenCalledWith(
-      expect.objectContaining({
-        // No catalogProviderId for a template-origin save.
-        providerType: "openai-compatible",
-        models: [
-          expect.objectContaining({
-            id: "nomic-embed-text",
-            displayName: "nomic-embed-text",
-            // Embedding heuristic kicks in for the embed-named id.
-            isEmbedding: true,
-          }),
-        ],
-      })
-    );
-  });
-
-  it("saves an explicit Quick Chat CORS choice for a new provider (https://github.com/logancyang/obsidian-copilot-preview/issues/313)", async () => {
-    mockVerifyCredentials.mockResolvedValue({ ok: true, checkedAt: 1 });
-    render(
-      <ConfigureProviderForm
-        state={{ mode: "new", source: CUSTOM_OPENAI_DEFINITION }}
-        onClose={jest.fn()}
-      />
+describe("ConfigureProviderDialog", () => {
+  describe("ConfigureProviderForm()", () => {
+    it.each([
+      ["Anthropic", anthropicSource],
+      ["OpenAI", openaiSource],
+      ["Ollama", ollamaSource],
+      ["custom OpenAI-compatible", CUSTOM_OPENAI_DEFINITION],
+    ] as const)(
+      "renders manual Model ID and discovery search together for %s (https://github.com/logancyang/obsidian-copilot/issues/2894)",
+      (_provider, source) => {
+        render(<ConfigureProviderForm state={{ mode: "new", source }} onClose={jest.fn()} />);
+        const modelsSection = screen.getByText("Models").parentElement;
+        expect(modelsSection).not.toBeNull();
+        expect(within(modelsSection!).getByTestId("model-checklist-manual-input")).toBeTruthy();
+        expect(
+          within(modelsSection!).getByPlaceholderText("Search available models…")
+        ).toBeTruthy();
+      }
     );
 
-    fireEvent.change(screen.getByTestId("api-key"), { target: { value: "work-key" } });
-    const baseUrlInput = screen.getByText("Base URL").parentElement?.querySelector("input");
-    expect(baseUrlInput).not.toBeNull();
-    fireEvent.change(baseUrlInput!, { target: { value: "https://work.example.com/v1" } });
-    manualAddId("work-model");
-    fireEvent.click(screen.getByRole("switch", { name: "Enable CORS" }));
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-
-    await waitFor(() =>
-      expect(mockSetupProvider).toHaveBeenCalledWith(expect.objectContaining({ enableCors: true }))
-    );
-  });
-
-  it("re-fetches the model list after a successful API key test", async () => {
-    mockVerifyCredentials.mockResolvedValue({ ok: true, checkedAt: 1 });
-    mockListProviderModels
-      // mount-skip (requiresApiKey + no key); post-test fetch returns ids
-      .mockResolvedValueOnce({ ok: true, modelIds: ["claude-sonnet"] });
-    render(
-      <ConfigureProviderForm state={{ mode: "new", source: anthropicSource }} onClose={jest.fn()} />
-    );
-
-    fireEvent.change(screen.getByTestId("api-key"), { target: { value: "sk-ant" } });
-    fireEvent.click(screen.getByRole("button", { name: "Test" }));
-    await waitFor(() => expect(mockListProviderModels).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(screen.getByTestId("model-row-claude-sonnet")).toBeTruthy());
-    // Fetched ids are candidates only — user must explicitly tick them.
-    expect(rowCheckbox("claude-sonnet").getAttribute("aria-checked")).toBe("false");
-  });
-
-  it("surfaces a fetch error inline (mount fetch failure)", async () => {
-    mockListProviderModels.mockResolvedValue({ ok: false, message: "connection refused" });
-    render(
-      <ConfigureProviderForm state={{ mode: "new", source: ollamaSource }} onClose={jest.fn()} />
-    );
-    expect(await screen.findByText("connection refused")).toBeTruthy();
-  });
-
-  it("only manually-added ids get an X (remove) button — discovered rows do not", async () => {
-    mockGetProvider.mockReturnValue(anthropicCatalogMetadata);
-    mockListProviderModels.mockResolvedValueOnce({ ok: true, modelIds: ["claude-sonnet"] });
-    render(
-      <ConfigureProviderForm state={{ mode: "new", source: anthropicSource }} onClose={jest.fn()} />
-    );
-    // Trigger a fetch by typing an API key + Test.
-    mockVerifyCredentials.mockResolvedValue({ ok: true, checkedAt: 1 });
-    fireEvent.change(screen.getByTestId("api-key"), { target: { value: "sk-ant" } });
-    fireEvent.click(screen.getByRole("button", { name: "Test" }));
-    await waitFor(() => expect(screen.getByTestId("model-row-claude-sonnet")).toBeTruthy());
-    // Discovered (live-fetched + catalog-known) row → no X.
-    expect(screen.queryByTestId("model-row-remove-claude-sonnet")).toBeNull();
-    // Manually-typed id → X visible.
-    manualAddId("my-private-model");
-    expect(screen.getByTestId("model-row-remove-my-private-model")).toBeTruthy();
-  });
-
-  it("saves a keyless custom endpoint (https://github.com/logancyang/obsidian-copilot/issues/2895)", async () => {
-    const onClose = jest.fn();
-    render(
-      <ConfigureProviderForm
-        state={{ mode: "new", source: CUSTOM_OPENAI_DEFINITION }}
-        onClose={onClose}
-      />
-    );
-    const baseUrlInput = screen.getByText("Base URL").parentElement?.querySelector("input");
-    expect(baseUrlInput).not.toBeNull();
-    fireEvent.change(baseUrlInput!, {
-      target: { value: "http://127.0.0.1:8000/v1" },
+    it("skips the mount fetch when the source requires an API key and the field is empty", () => {
+      render(
+        <ConfigureProviderForm
+          state={{ mode: "new", source: anthropicSource }}
+          onClose={jest.fn()}
+        />
+      );
+      expect(mockListProviderModels).not.toHaveBeenCalled();
     });
-    manualAddId("qwen3.8-27b");
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
-    await waitFor(() => expect(mockSetupProvider).toHaveBeenCalledTimes(1));
-    expect(mockSetupProvider).toHaveBeenCalledWith(
-      expect.objectContaining({
-        apiKey: undefined,
-        requiresApiKey: false,
-        models: [expect.objectContaining({ id: "qwen3.8-27b" })],
-      })
-    );
-    expect(mockVerifyCredentials).not.toHaveBeenCalled();
-    await waitFor(() => expect(onClose).toHaveBeenCalled());
-  });
-
-  it("requires a Base URL before saving a custom endpoint (https://github.com/logancyang/obsidian-copilot/issues/2895)", () => {
-    render(
-      <ConfigureProviderForm
-        state={{ mode: "new", source: CUSTOM_OPENAI_DEFINITION }}
-        onClose={jest.fn()}
-      />
-    );
-    manualAddId("qwen3.8-27b");
-
-    expect(screen.getByRole("button", { name: "Save" }).hasAttribute("disabled")).toBe(true);
-    expect(mockSetupProvider).not.toHaveBeenCalled();
-  });
-});
-
-describe("ConfigureProviderForm (edit mode)", () => {
-  it("seeds the selection from existing configured models", async () => {
-    render(
-      <ConfigureProviderForm state={{ mode: "edit", providerId: "p1" }} onClose={jest.fn()} />
-    );
-    await waitFor(() => expect(screen.getByTestId("model-row-claude-sonnet")).toBeTruthy());
-    expect(rowCheckbox("claude-sonnet").getAttribute("aria-checked")).toBe("true");
-    expect(rowCheckbox("claude-opus").getAttribute("aria-checked")).toBe("true");
-  });
-
-  it("does not auto-check newly fetched ids (no silent subscription)", async () => {
-    // Mount fetch returns claude-haiku as a new id, on top of the two seeded
-    // from existing configured models.
-    mockListProviderModels.mockResolvedValue({ ok: true, modelIds: ["claude-haiku"] });
-    render(
-      <ConfigureProviderForm state={{ mode: "edit", providerId: "p1" }} onClose={jest.fn()} />
-    );
-    await waitFor(() => expect(screen.getByTestId("model-row-claude-haiku")).toBeTruthy());
-    expect(rowCheckbox("claude-haiku").getAttribute("aria-checked")).toBe("false");
-  });
-
-  it("verifies without writing the API key (Test never persists)", async () => {
-    mockVerifyCredentials.mockResolvedValue({ ok: true, checkedAt: 1 });
-    render(
-      <ConfigureProviderForm state={{ mode: "edit", providerId: "p1" }} onClose={jest.fn()} />
-    );
-    // The body mounts once the gate resolves the saved key.
-    fireEvent.click(await screen.findByRole("button", { name: "Test" }));
-    await waitFor(() => expect(mockVerifyCredentials).toHaveBeenCalled());
-    expect(mockGetApiKey).toHaveBeenCalledWith("p1");
-    expect(mockSetApiKey).not.toHaveBeenCalled();
-  });
-
-  it("Test verifies the edited base URL, not the persisted one", async () => {
-    mockVerifyCredentials.mockResolvedValue({ ok: true, checkedAt: 1 });
-    render(
-      <ConfigureProviderForm state={{ mode: "edit", providerId: "p1" }} onClose={jest.fn()} />
-    );
-    const baseUrlInput = await screen.findByPlaceholderText("https://api.anthropic.com");
-    fireEvent.change(baseUrlInput, { target: { value: "https://proxy.example.com" } });
-    fireEvent.click(screen.getByRole("button", { name: "Test" }));
-    await waitFor(() => expect(mockVerifyCredentials).toHaveBeenCalled());
-    const [providerType, ctx] = mockVerifyCredentials.mock.calls[0];
-    expect(providerType).toBe("anthropic");
-    expect((ctx as { provider: { baseUrl?: string } }).provider.baseUrl).toBe(
-      "https://proxy.example.com"
-    );
-  });
-
-  it("removes de-selected models from every backend on save", async () => {
-    mockBulkSet.mockResolvedValue(["cm1"]);
-    const onClose = jest.fn();
-    render(<ConfigureProviderForm state={{ mode: "edit", providerId: "p1" }} onClose={onClose} />);
-    // Wait for seed to apply.
-    await waitFor(() =>
-      expect(rowCheckbox("claude-opus").getAttribute("aria-checked")).toBe("true")
-    );
-    fireEvent.click(rowCheckbox("claude-opus"));
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-    await waitFor(() => expect(mockRemoveRefs).toHaveBeenCalledWith(["cm2"]));
-    expect(mockBulkSet).toHaveBeenCalledWith("p1", [
-      expect.objectContaining({ id: "claude-sonnet" }),
-    ]);
-    await waitFor(() => expect(onClose).toHaveBeenCalled());
-  });
-
-  it("auto-enrolls only newly-added chat models — skips embeddings, never re-enables existing", async () => {
-    mockGetProvider.mockReturnValue(anthropicCatalogMetadata);
-    mockListProviderModels.mockResolvedValue({
-      ok: true,
-      modelIds: ["claude-haiku", "voyage-embed"],
+    it("fires the mount fetch for a key-less template (no auth required)", async () => {
+      mockListProviderModels.mockResolvedValue({ ok: true, modelIds: ["llama3.2"] });
+      render(
+        <ConfigureProviderForm state={{ mode: "new", source: ollamaSource }} onClose={jest.fn()} />
+      );
+      await waitFor(() => expect(mockListProviderModels).toHaveBeenCalledTimes(1));
+      expect(mockListProviderModels).toHaveBeenCalledWith(
+        "openai-compatible",
+        "http://localhost:11434/v1",
+        expect.objectContaining({ apiKey: null })
+      );
+      // Discovered ids appear as unchecked candidates; user opts in.
+      await waitFor(() => expect(screen.getByTestId("model-row-llama3.2")).toBeTruthy());
+      expect(rowCheckbox("llama3.2").getAttribute("aria-checked")).toBe("false");
     });
-    mockBulkSet.mockResolvedValue(["cm1", "cm2", "cm-haiku", "cm-embed"]);
-    const onClose = jest.fn();
-    render(<ConfigureProviderForm state={{ mode: "edit", providerId: "p1" }} onClose={onClose} />);
-    // Wait for the fetched rows to appear, then check them.
-    await waitFor(() => expect(screen.getByTestId("model-row-claude-haiku")).toBeTruthy());
-    fireEvent.click(rowCheckbox("claude-haiku"));
-    fireEvent.click(rowCheckbox("voyage-embed"));
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-    await waitFor(() => expect(onClose).toHaveBeenCalled());
-    for (const backend of ["chat", "opencode"]) {
-      expect(mockEnableModel).toHaveBeenCalledWith(backend, "cm-haiku");
-    }
-    expect(mockEnableModel).not.toHaveBeenCalledWith(expect.anything(), "cm-embed");
-    expect(mockEnableModel).not.toHaveBeenCalledWith(expect.anything(), "cm1");
-    expect(mockEnableModel).not.toHaveBeenCalledWith(expect.anything(), "cm2");
-  });
 
-  it("Mount fetch uses the saved key (catalog-less edit row)", async () => {
-    mockGetApiKey.mockResolvedValue("saved-secret");
-    mockListProviderModels.mockResolvedValue({ ok: true, modelIds: ["gpt-x"] });
-    render(
-      <ConfigureProviderForm state={{ mode: "edit", providerId: "p-custom" }} onClose={jest.fn()} />
-    );
-    await waitFor(() => expect(mockListProviderModels).toHaveBeenCalled());
-    expect(mockListProviderModels).toHaveBeenCalledWith(
-      "openai-compatible",
-      "https://proxy.example/v1",
-      expect.objectContaining({ apiKey: "saved-secret" })
-    );
-  });
+    it("waits for Test before discovering models from a typed custom URL (https://github.com/logancyang/obsidian-copilot/issues/2895)", async () => {
+      mockVerifyCredentials.mockResolvedValue({ ok: true, checkedAt: 1 });
+      render(
+        <ConfigureProviderForm
+          state={{ mode: "new", source: CUSTOM_OPENAI_DEFINITION }}
+          onClose={jest.fn()}
+        />
+      );
+      const baseUrlInput = screen.getByText("Base URL").parentElement?.querySelector("input");
+      expect(baseUrlInput).not.toBeNull();
 
-  it("loads and updates the saved Quick Chat CORS choice (https://github.com/logancyang/obsidian-copilot-preview/issues/313)", async () => {
-    render(
-      <ConfigureProviderForm state={{ mode: "edit", providerId: "p-custom" }} onClose={jest.fn()} />
-    );
+      fireEvent.change(baseUrlInput!, { target: { value: "h" } });
+      fireEvent.change(baseUrlInput!, { target: { value: "https://work.example.com/v1" } });
+      expect(mockListProviderModels).not.toHaveBeenCalled();
 
-    const corsSwitch = await screen.findByRole("switch", { name: "Enable CORS" });
-    expect(corsSwitch.getAttribute("aria-checked")).toBe("true");
-    fireEvent.click(corsSwitch);
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-
-    await waitFor(() =>
-      expect(mockUpdate).toHaveBeenCalledWith(
-        "p-custom",
-        expect.objectContaining({ enableCors: false })
-      )
-    );
-  });
-
-  it("X button hidden on saved catalog models but visible on saved-custom rows", async () => {
-    // Catalog known → claude-sonnet (in metadata) is discovered; claude-opus
-    // (not in metadata, not in current fetch) is custom-added.
-    mockGetProvider.mockReturnValue({
-      ...anthropicCatalogMetadata,
-      models: { "claude-sonnet": anthropicCatalogMetadata.models["claude-sonnet"] },
+      fireEvent.click(screen.getByRole("button", { name: "Test" }));
+      await waitFor(() => expect(mockListProviderModels).toHaveBeenCalledTimes(1));
+      expect(mockListProviderModels).toHaveBeenCalledWith(
+        "openai-compatible",
+        "https://work.example.com/v1",
+        expect.objectContaining({ apiKey: null })
+      );
     });
-    mockListProviderModels.mockResolvedValue({ ok: true, modelIds: ["claude-sonnet"] });
-    render(
-      <ConfigureProviderForm state={{ mode: "edit", providerId: "p1" }} onClose={jest.fn()} />
-    );
-    await waitFor(() => expect(screen.getByTestId("model-row-claude-sonnet")).toBeTruthy());
-    await waitFor(() => expect(screen.getByTestId("model-row-claude-opus")).toBeTruthy());
-    // Discovered → no X.
-    expect(screen.queryByTestId("model-row-remove-claude-sonnet")).toBeNull();
-    // Catalog-unknown + not in live fetch → custom → X visible.
-    expect(screen.getByTestId("model-row-remove-claude-opus")).toBeTruthy();
-  });
 
-  it("clicking X on a saved-custom row hides it and persists removal on save", async () => {
-    // Catalog-less provider → both saved rows are custom (not in catalog,
-    // not in live fetch).
-    mockGetProvider.mockReturnValue(undefined);
-    mockListProviderModels.mockResolvedValue({ ok: true, modelIds: [] });
-    mockBulkSet.mockResolvedValue(["cm1"]);
-    const onClose = jest.fn();
-    render(<ConfigureProviderForm state={{ mode: "edit", providerId: "p1" }} onClose={onClose} />);
-    await waitFor(() => expect(screen.getByTestId("model-row-remove-claude-opus")).toBeTruthy());
-    fireEvent.click(screen.getByTestId("model-row-remove-claude-opus"));
-    // Row is gone from the candidate pool.
-    expect(screen.queryByTestId("model-row-claude-opus")).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-    // Save removes the removed-existing id from backend refs and bulkSets
-    // only the remaining (still-selected) infos.
-    await waitFor(() => expect(mockRemoveRefs).toHaveBeenCalledWith(["cm2"]));
-    expect(mockBulkSet).toHaveBeenCalledWith("p1", [
-      expect.objectContaining({ id: "claude-sonnet" }),
-    ]);
-    await waitFor(() => expect(onClose).toHaveBeenCalled());
-  });
-
-  it("Clear empties the field, keeps the dialog open, and persists nothing immediately", async () => {
-    mockGetApiKey.mockResolvedValue("saved-secret");
-    const onClose = jest.fn();
-    render(<ConfigureProviderForm state={{ mode: "edit", providerId: "p1" }} onClose={onClose} />);
-    const clear = await screen.findByTestId("api-key-clear");
-    fireEvent.click(clear);
-    // Field is wiped, but the keychain isn't touched and the dialog stays open —
-    // the removal is staged for Save, like every other field.
-    await waitFor(() => expect(screen.getByTestId<HTMLInputElement>("api-key").value).toBe(""));
-    expect(mockClearApiKey).not.toHaveBeenCalled();
-    expect(onClose).not.toHaveBeenCalled();
-    // Nothing left to clear → the button is gone.
-    expect(screen.queryByTestId("api-key-clear")).toBeNull();
-  });
-
-  it("disables Save after clearing a required-key provider's key", async () => {
-    mockGetApiKey.mockResolvedValue("saved-secret");
-    render(
-      <ConfigureProviderForm state={{ mode: "edit", providerId: "p1" }} onClose={jest.fn()} />
-    );
-    // p1 (anthropic, byok + catalogProviderId) requires a key and seeds two
-    // selected models, so the empty field is the only thing blocking Save.
-    fireEvent.click(await screen.findByTestId("api-key-clear"));
-    await waitFor(() =>
-      expect(screen.getByRole("button", { name: "Save" }).hasAttribute("disabled")).toBe(true)
-    );
-  });
-});
-
-describe("ConfigureProviderForm (re-fetch curation)", () => {
-  it("re-fetching never toggles selection — discovered ids are candidates only", async () => {
-    // 1st fetch returns "a","b" — both appear as unchecked candidates.
-    mockListProviderModels.mockResolvedValueOnce({ ok: true, modelIds: ["a", "b"] });
-    render(
-      <ConfigureProviderForm state={{ mode: "new", source: ollamaSource }} onClose={jest.fn()} />
-    );
-    await waitFor(() => expect(screen.getByTestId("model-row-a")).toBeTruthy());
-    expect(rowCheckbox("a").getAttribute("aria-checked")).toBe("false");
-    expect(rowCheckbox("b").getAttribute("aria-checked")).toBe("false");
-
-    // User explicitly ticks "a".
-    fireEvent.click(rowCheckbox("a"));
-    expect(rowCheckbox("a").getAttribute("aria-checked")).toBe("true");
-
-    // A subsequent Test success triggers a refetch returning the same ids;
-    // the user's selection state must be preserved verbatim — "a" stays
-    // ticked, "b" stays unchecked, no row duplication.
-    mockVerifyCredentials.mockResolvedValue({ ok: true, checkedAt: 1 });
-    mockListProviderModels.mockResolvedValueOnce({ ok: true, modelIds: ["a", "b"] });
-    fireEvent.click(screen.getByRole("button", { name: "Test" }));
-    await waitFor(() => expect(mockListProviderModels).toHaveBeenCalledTimes(2));
-    expect(rowCheckbox("a").getAttribute("aria-checked")).toBe("true");
-    expect(rowCheckbox("b").getAttribute("aria-checked")).toBe("false");
-  });
-});
-
-describe("ConfigureProviderForm (hydration gate)", () => {
-  it("holds back the stateful body until the provider row resolves", () => {
-    // Unknown providerId → `provider` never resolves from the atom, so the
-    // gate must render its placeholder and never mount the body (whose
-    // useState initializers would otherwise seed from blank values and let
-    // the user Save them).
-    render(
-      <ConfigureProviderForm state={{ mode: "edit", providerId: "missing" }} onClose={jest.fn()} />
-    );
-    expect(screen.queryByTestId("model-checklist-manual-input")).toBeNull();
-    expect(screen.queryByText(/^Configure/)).toBeNull();
-    // No fetch fires while gated.
-    expect(mockListProviderModels).not.toHaveBeenCalled();
-  });
-});
-
-describe("ConfigureProviderForm (custom-openai source)", () => {
-  it("shows the default 'Add a model id' / source-supplied hint in the manual input", () => {
-    render(
-      <ConfigureProviderForm
-        state={{ mode: "new", source: CUSTOM_OPENAI_DEFINITION }}
-        onClose={jest.fn()}
-      />
-    );
-    expect(screen.getByPlaceholderText("e.g. gpt-5.5")).toBeTruthy();
-  });
-});
-
-describe("ConfigureProviderForm (credential verification + save gating)", () => {
-  it("A1: a required-key provider with an empty field fails Test without probing", async () => {
-    render(
-      <ConfigureProviderForm state={{ mode: "new", source: anthropicSource }} onClose={jest.fn()} />
-    );
-    fireEvent.click(screen.getByRole("button", { name: "Test" }));
-    // No network probe — the guard short-circuits so a public /models 200
-    // can't read as "Verified".
-    expect(mockVerifyCredentials).not.toHaveBeenCalled();
-    expect(await screen.findByText("Enter an API key to verify this provider.")).toBeTruthy();
-  });
-
-  it("B2: Save is disabled for a required-key provider with no key", () => {
-    render(
-      <ConfigureProviderForm state={{ mode: "new", source: anthropicSource }} onClose={jest.fn()} />
-    );
-    manualAddId("claude-sonnet");
-    expect(screen.getByRole("button", { name: "Save" }).hasAttribute("disabled")).toBe(true);
-  });
-
-  it("B2: an untested invalid key auto-verifies on Save, aborts, and blocks further Save", async () => {
-    mockVerifyCredentials.mockResolvedValue({
-      ok: false,
-      code: "invalid_api_key",
-      message: "Authentication failed",
-      checkedAt: 1,
+    it("uses the source default URL as the input placeholder", () => {
+      render(
+        <ConfigureProviderForm
+          state={{ mode: "new", source: anthropicSource }}
+          onClose={jest.fn()}
+        />
+      );
+      expect(screen.getByPlaceholderText("https://api.anthropic.com")).toBeTruthy();
     });
-    render(
-      <ConfigureProviderForm state={{ mode: "new", source: anthropicSource }} onClose={jest.fn()} />
-    );
-    fireEvent.change(screen.getByTestId("api-key"), { target: { value: "sk-bad" } });
-    manualAddId("claude-sonnet");
-    // Untested key → Save is enabled, but Save auto-verifies first.
-    expect(screen.getByRole("button", { name: "Save" }).hasAttribute("disabled")).toBe(false);
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-    await waitFor(() => expect(mockVerifyCredentials).toHaveBeenCalled());
-    expect(mockSetupProvider).not.toHaveBeenCalled();
-    // The conclusive failure now disables Save.
-    await waitFor(() =>
-      expect(screen.getByRole("button", { name: "Save" }).hasAttribute("disabled")).toBe(true)
-    );
-  });
 
-  it("B2: an inconclusive verification (network) does not block Save", async () => {
-    mockVerifyCredentials.mockResolvedValue({
-      ok: false,
-      code: "network",
-      message: "connection refused",
-      checkedAt: 1,
+    it("falls back to a known default endpoint when the source ships none", async () => {
+      // OpenAI catalog has no defaultBaseUrl; the known-default lookup fills in.
+      render(
+        <ConfigureProviderForm state={{ mode: "new", source: openaiSource }} onClose={jest.fn()} />
+      );
+      expect(screen.getByPlaceholderText("https://api.openai.com/v1")).toBeTruthy();
     });
-    const onClose = jest.fn();
-    render(
-      <ConfigureProviderForm state={{ mode: "new", source: anthropicSource }} onClose={onClose} />
-    );
-    fireEvent.change(screen.getByTestId("api-key"), { target: { value: "sk-maybe" } });
-    manualAddId("claude-sonnet");
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-    // Offline users aren't stranded — the provider still saves.
-    await waitFor(() => expect(mockSetupProvider).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(onClose).toHaveBeenCalled());
-  });
 
-  it("B1/B2: edit mode pre-fills the saved key and saves without re-typing or re-writing it", async () => {
-    mockGetApiKey.mockResolvedValue("saved-secret");
-    mockBulkSet.mockResolvedValue(["cm1", "cm2"]);
-    const onClose = jest.fn();
-    render(<ConfigureProviderForm state={{ mode: "edit", providerId: "p1" }} onClose={onClose} />);
-    // The field is seeded with the stored key (visible, masked by PasswordInput).
-    const input = await screen.findByTestId<HTMLInputElement>("api-key");
-    expect(input.value).toBe("saved-secret");
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-    await waitFor(() => expect(onClose).toHaveBeenCalled());
-    // Unchanged key → no keychain churn and no re-verification.
-    expect(mockSetApiKey).not.toHaveBeenCalled();
-    expect(mockVerifyCredentials).not.toHaveBeenCalled();
-  });
+    it("Save is gated only on a non-empty selection", async () => {
+      render(
+        <ConfigureProviderForm state={{ mode: "new", source: ollamaSource }} onClose={jest.fn()} />
+      );
+      const save = screen.getByRole("button", { name: "Save" });
+      expect(save.hasAttribute("disabled")).toBe(true);
+      manualAddId("llama3.2");
+      expect(save.hasAttribute("disabled")).toBe(false);
+    });
 
-  it("B2: a keyless provider (requiresApiKey:false) Tests and Saves with an empty field", async () => {
-    mockVerifyCredentials.mockResolvedValue({ ok: true, checkedAt: 1 });
-    const onClose = jest.fn();
-    render(
-      <ConfigureProviderForm state={{ mode: "new", source: ollamaSource }} onClose={onClose} />
-    );
-    // Test with an empty field probes the endpoint (no required-key guard).
-    fireEvent.click(screen.getByRole("button", { name: "Test" }));
-    await waitFor(() => expect(mockVerifyCredentials).toHaveBeenCalled());
-    manualAddId("llama3.2");
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-    await waitFor(() => expect(mockSetupProvider).toHaveBeenCalledTimes(1));
-    expect(mockSetupProvider).toHaveBeenCalledWith(
-      expect.objectContaining({ requiresApiKey: false })
-    );
-    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    it("calls setupProvider with the catalog id + enriched model metadata", async () => {
+      mockGetProvider.mockReturnValue(anthropicCatalogMetadata);
+      mockVerifyCredentials.mockResolvedValue({ ok: true, checkedAt: 1 });
+      const onClose = jest.fn();
+      render(
+        <ConfigureProviderForm state={{ mode: "new", source: anthropicSource }} onClose={onClose} />
+      );
+      // A required-key provider can't save without a key, so supply one.
+      fireEvent.change(screen.getByTestId("api-key"), { target: { value: "sk-ant" } });
+      manualAddId("claude-sonnet");
+      fireEvent.click(screen.getByRole("button", { name: "Save" }));
+      await waitFor(() => expect(mockSetupProvider).toHaveBeenCalledTimes(1));
+      expect(mockSetupProvider).toHaveBeenCalledWith(
+        expect.objectContaining({
+          catalogProviderId: "anthropic",
+          providerType: "anthropic",
+          displayName: "Anthropic",
+          baseUrl: "https://api.anthropic.com",
+          models: [
+            // The manually-added id matches a catalog entry, so the saved
+            // ModelInfo carries the enriched displayName + limits.
+            expect.objectContaining({
+              id: "claude-sonnet",
+              displayName: "Claude Sonnet 4.5",
+              limits: { context: 200000 },
+            }),
+          ],
+        })
+      );
+      await waitFor(() => expect(onClose).toHaveBeenCalled());
+    });
+
+    it("synthesizes minimal ModelInfo for a manual id with no catalog entry", async () => {
+      const onClose = jest.fn();
+      render(
+        <ConfigureProviderForm state={{ mode: "new", source: ollamaSource }} onClose={onClose} />
+      );
+      manualAddId("nomic-embed-text");
+      fireEvent.click(screen.getByRole("button", { name: "Save" }));
+      await waitFor(() => expect(mockSetupProvider).toHaveBeenCalled());
+      expect(mockSetupProvider).toHaveBeenCalledWith(
+        expect.objectContaining({
+          // No catalogProviderId for a template-origin save.
+          providerType: "openai-compatible",
+          models: [
+            expect.objectContaining({
+              id: "nomic-embed-text",
+              displayName: "nomic-embed-text",
+              // Embedding heuristic kicks in for the embed-named id.
+              isEmbedding: true,
+            }),
+          ],
+        })
+      );
+    });
+
+    it("saves an explicit Quick Chat CORS choice for a new provider (https://github.com/logancyang/obsidian-copilot-preview/issues/313)", async () => {
+      mockVerifyCredentials.mockResolvedValue({ ok: true, checkedAt: 1 });
+      render(
+        <ConfigureProviderForm
+          state={{ mode: "new", source: CUSTOM_OPENAI_DEFINITION }}
+          onClose={jest.fn()}
+        />
+      );
+
+      fireEvent.change(screen.getByTestId("api-key"), { target: { value: "work-key" } });
+      const baseUrlInput = screen.getByText("Base URL").parentElement?.querySelector("input");
+      expect(baseUrlInput).not.toBeNull();
+      fireEvent.change(baseUrlInput!, { target: { value: "https://work.example.com/v1" } });
+      manualAddId("work-model");
+      fireEvent.click(screen.getByRole("switch", { name: "Enable CORS" }));
+      fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+      await waitFor(() =>
+        expect(mockSetupProvider).toHaveBeenCalledWith(
+          expect.objectContaining({ enableCors: true })
+        )
+      );
+    });
+
+    it("re-fetches the model list after a successful API key test", async () => {
+      mockVerifyCredentials.mockResolvedValue({ ok: true, checkedAt: 1 });
+      mockListProviderModels
+        // mount-skip (requiresApiKey + no key); post-test fetch returns ids
+        .mockResolvedValueOnce({ ok: true, modelIds: ["claude-sonnet"] });
+      render(
+        <ConfigureProviderForm
+          state={{ mode: "new", source: anthropicSource }}
+          onClose={jest.fn()}
+        />
+      );
+
+      fireEvent.change(screen.getByTestId("api-key"), { target: { value: "sk-ant" } });
+      fireEvent.click(screen.getByRole("button", { name: "Test" }));
+      await waitFor(() => expect(mockListProviderModels).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(screen.getByTestId("model-row-claude-sonnet")).toBeTruthy());
+      // Fetched ids are candidates only — user must explicitly tick them.
+      expect(rowCheckbox("claude-sonnet").getAttribute("aria-checked")).toBe("false");
+    });
+
+    it("surfaces a fetch error inline (mount fetch failure)", async () => {
+      mockListProviderModels.mockResolvedValue({ ok: false, message: "connection refused" });
+      render(
+        <ConfigureProviderForm state={{ mode: "new", source: ollamaSource }} onClose={jest.fn()} />
+      );
+      expect(await screen.findByText("connection refused")).toBeTruthy();
+    });
+
+    it("only manually-added ids get an X (remove) button — discovered rows do not", async () => {
+      mockGetProvider.mockReturnValue(anthropicCatalogMetadata);
+      mockListProviderModels.mockResolvedValueOnce({ ok: true, modelIds: ["claude-sonnet"] });
+      render(
+        <ConfigureProviderForm
+          state={{ mode: "new", source: anthropicSource }}
+          onClose={jest.fn()}
+        />
+      );
+      // Trigger a fetch by typing an API key + Test.
+      mockVerifyCredentials.mockResolvedValue({ ok: true, checkedAt: 1 });
+      fireEvent.change(screen.getByTestId("api-key"), { target: { value: "sk-ant" } });
+      fireEvent.click(screen.getByRole("button", { name: "Test" }));
+      await waitFor(() => expect(screen.getByTestId("model-row-claude-sonnet")).toBeTruthy());
+      // Discovered (live-fetched + catalog-known) row → no X.
+      expect(screen.queryByTestId("model-row-remove-claude-sonnet")).toBeNull();
+      // Manually-typed id → X visible.
+      manualAddId("my-private-model");
+      expect(screen.getByTestId("model-row-remove-my-private-model")).toBeTruthy();
+    });
+
+    it("saves a keyless custom endpoint (https://github.com/logancyang/obsidian-copilot/issues/2895)", async () => {
+      const onClose = jest.fn();
+      render(
+        <ConfigureProviderForm
+          state={{ mode: "new", source: CUSTOM_OPENAI_DEFINITION }}
+          onClose={onClose}
+        />
+      );
+      const baseUrlInput = screen.getByText("Base URL").parentElement?.querySelector("input");
+      expect(baseUrlInput).not.toBeNull();
+      fireEvent.change(baseUrlInput!, {
+        target: { value: "http://127.0.0.1:8000/v1" },
+      });
+      manualAddId("qwen3.8-27b");
+      fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+      await waitFor(() => expect(mockSetupProvider).toHaveBeenCalledTimes(1));
+      expect(mockSetupProvider).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiKey: undefined,
+          requiresApiKey: false,
+          models: [expect.objectContaining({ id: "qwen3.8-27b" })],
+        })
+      );
+      expect(mockVerifyCredentials).not.toHaveBeenCalled();
+      await waitFor(() => expect(onClose).toHaveBeenCalled());
+    });
+
+    it("requires a Base URL before saving a custom endpoint (https://github.com/logancyang/obsidian-copilot/issues/2895)", () => {
+      render(
+        <ConfigureProviderForm
+          state={{ mode: "new", source: CUSTOM_OPENAI_DEFINITION }}
+          onClose={jest.fn()}
+        />
+      );
+      manualAddId("qwen3.8-27b");
+
+      expect(screen.getByRole("button", { name: "Save" }).hasAttribute("disabled")).toBe(true);
+      expect(mockSetupProvider).not.toHaveBeenCalled();
+    });
+
+    it("seeds the selection from existing configured models", async () => {
+      render(
+        <ConfigureProviderForm state={{ mode: "edit", providerId: "p1" }} onClose={jest.fn()} />
+      );
+      await waitFor(() => expect(screen.getByTestId("model-row-claude-sonnet")).toBeTruthy());
+      expect(rowCheckbox("claude-sonnet").getAttribute("aria-checked")).toBe("true");
+      expect(rowCheckbox("claude-opus").getAttribute("aria-checked")).toBe("true");
+    });
+
+    it("does not auto-check newly fetched ids (no silent subscription)", async () => {
+      // Mount fetch returns claude-haiku as a new id, on top of the two seeded
+      // from existing configured models.
+      mockListProviderModels.mockResolvedValue({ ok: true, modelIds: ["claude-haiku"] });
+      render(
+        <ConfigureProviderForm state={{ mode: "edit", providerId: "p1" }} onClose={jest.fn()} />
+      );
+      await waitFor(() => expect(screen.getByTestId("model-row-claude-haiku")).toBeTruthy());
+      expect(rowCheckbox("claude-haiku").getAttribute("aria-checked")).toBe("false");
+    });
+
+    it("verifies without writing the API key (Test never persists)", async () => {
+      mockVerifyCredentials.mockResolvedValue({ ok: true, checkedAt: 1 });
+      render(
+        <ConfigureProviderForm state={{ mode: "edit", providerId: "p1" }} onClose={jest.fn()} />
+      );
+      // The body mounts once the gate resolves the saved key.
+      fireEvent.click(await screen.findByRole("button", { name: "Test" }));
+      await waitFor(() => expect(mockVerifyCredentials).toHaveBeenCalled());
+      expect(mockGetApiKey).toHaveBeenCalledWith("p1");
+      expect(mockSetApiKey).not.toHaveBeenCalled();
+    });
+
+    it("Test verifies the edited base URL, not the persisted one", async () => {
+      mockVerifyCredentials.mockResolvedValue({ ok: true, checkedAt: 1 });
+      render(
+        <ConfigureProviderForm state={{ mode: "edit", providerId: "p1" }} onClose={jest.fn()} />
+      );
+      const baseUrlInput = await screen.findByPlaceholderText("https://api.anthropic.com");
+      fireEvent.change(baseUrlInput, { target: { value: "https://proxy.example.com" } });
+      fireEvent.click(screen.getByRole("button", { name: "Test" }));
+      await waitFor(() => expect(mockVerifyCredentials).toHaveBeenCalled());
+      const [providerType, ctx] = mockVerifyCredentials.mock.calls[0];
+      expect(providerType).toBe("anthropic");
+      expect((ctx as { provider: { baseUrl?: string } }).provider.baseUrl).toBe(
+        "https://proxy.example.com"
+      );
+    });
+
+    it("removes de-selected models from every backend on save", async () => {
+      mockBulkSet.mockResolvedValue(["cm1"]);
+      const onClose = jest.fn();
+      render(
+        <ConfigureProviderForm state={{ mode: "edit", providerId: "p1" }} onClose={onClose} />
+      );
+      // Wait for seed to apply.
+      await waitFor(() =>
+        expect(rowCheckbox("claude-opus").getAttribute("aria-checked")).toBe("true")
+      );
+      fireEvent.click(rowCheckbox("claude-opus"));
+      fireEvent.click(screen.getByRole("button", { name: "Save" }));
+      await waitFor(() => expect(mockRemoveRefs).toHaveBeenCalledWith(["cm2"]));
+      expect(mockBulkSet).toHaveBeenCalledWith("p1", [
+        expect.objectContaining({ id: "claude-sonnet" }),
+      ]);
+      await waitFor(() => expect(onClose).toHaveBeenCalled());
+    });
+
+    it("auto-enrolls only newly-added chat models — skips embeddings, never re-enables existing", async () => {
+      mockGetProvider.mockReturnValue(anthropicCatalogMetadata);
+      mockListProviderModels.mockResolvedValue({
+        ok: true,
+        modelIds: ["claude-haiku", "voyage-embed"],
+      });
+      mockBulkSet.mockResolvedValue(["cm1", "cm2", "cm-haiku", "cm-embed"]);
+      const onClose = jest.fn();
+      render(
+        <ConfigureProviderForm state={{ mode: "edit", providerId: "p1" }} onClose={onClose} />
+      );
+      // Wait for the fetched rows to appear, then check them.
+      await waitFor(() => expect(screen.getByTestId("model-row-claude-haiku")).toBeTruthy());
+      fireEvent.click(rowCheckbox("claude-haiku"));
+      fireEvent.click(rowCheckbox("voyage-embed"));
+      fireEvent.click(screen.getByRole("button", { name: "Save" }));
+      await waitFor(() => expect(onClose).toHaveBeenCalled());
+      for (const backend of ["chat", "opencode"]) {
+        expect(mockEnableModel).toHaveBeenCalledWith(backend, "cm-haiku");
+      }
+      expect(mockEnableModel).not.toHaveBeenCalledWith(expect.anything(), "cm-embed");
+      expect(mockEnableModel).not.toHaveBeenCalledWith(expect.anything(), "cm1");
+      expect(mockEnableModel).not.toHaveBeenCalledWith(expect.anything(), "cm2");
+    });
+
+    it("Mount fetch uses the saved key (catalog-less edit row)", async () => {
+      mockGetApiKey.mockResolvedValue("saved-secret");
+      mockListProviderModels.mockResolvedValue({ ok: true, modelIds: ["gpt-x"] });
+      render(
+        <ConfigureProviderForm
+          state={{ mode: "edit", providerId: "p-custom" }}
+          onClose={jest.fn()}
+        />
+      );
+      await waitFor(() => expect(mockListProviderModels).toHaveBeenCalled());
+      expect(mockListProviderModels).toHaveBeenCalledWith(
+        "openai-compatible",
+        "https://proxy.example/v1",
+        expect.objectContaining({ apiKey: "saved-secret" })
+      );
+    });
+
+    it("reports a CORS-only save only after persistence completes (https://github.com/logancyang/obsidian-copilot/issues/3147) (https://github.com/logancyang/obsidian-copilot-preview/issues/313)", async () => {
+      const onSaved = jest.fn();
+      let finishUpdate!: () => void;
+      mockUpdate.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            finishUpdate = resolve;
+          })
+      );
+      render(
+        <ConfigureProviderForm
+          state={{ mode: "edit", providerId: "p-custom" }}
+          onClose={jest.fn()}
+          onSaved={onSaved}
+        />
+      );
+
+      const corsSwitch = await screen.findByRole("switch", { name: "Enable CORS" });
+      expect(corsSwitch.getAttribute("aria-checked")).toBe("true");
+      fireEvent.click(corsSwitch);
+      fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+      await waitFor(() =>
+        expect(mockUpdate).toHaveBeenCalledWith(
+          "p-custom",
+          expect.objectContaining({ enableCors: false })
+        )
+      );
+      expect(onSaved).not.toHaveBeenCalled();
+      act(() => {
+        finishUpdate();
+      });
+      await waitFor(() => expect(onSaved).toHaveBeenCalledTimes(1));
+    });
+
+    it("X button hidden on saved catalog models but visible on saved-custom rows", async () => {
+      // Catalog known → claude-sonnet (in metadata) is discovered; claude-opus
+      // (not in metadata, not in current fetch) is custom-added.
+      mockGetProvider.mockReturnValue({
+        ...anthropicCatalogMetadata,
+        models: { "claude-sonnet": anthropicCatalogMetadata.models["claude-sonnet"] },
+      });
+      mockListProviderModels.mockResolvedValue({ ok: true, modelIds: ["claude-sonnet"] });
+      render(
+        <ConfigureProviderForm state={{ mode: "edit", providerId: "p1" }} onClose={jest.fn()} />
+      );
+      await waitFor(() => expect(screen.getByTestId("model-row-claude-sonnet")).toBeTruthy());
+      await waitFor(() => expect(screen.getByTestId("model-row-claude-opus")).toBeTruthy());
+      // Discovered → no X.
+      expect(screen.queryByTestId("model-row-remove-claude-sonnet")).toBeNull();
+      // Catalog-unknown + not in live fetch → custom → X visible.
+      expect(screen.getByTestId("model-row-remove-claude-opus")).toBeTruthy();
+    });
+
+    it("clicking X on a saved-custom row hides it and persists removal on save", async () => {
+      // Catalog-less provider → both saved rows are custom (not in catalog,
+      // not in live fetch).
+      mockGetProvider.mockReturnValue(undefined);
+      mockListProviderModels.mockResolvedValue({ ok: true, modelIds: [] });
+      mockBulkSet.mockResolvedValue(["cm1"]);
+      const onClose = jest.fn();
+      render(
+        <ConfigureProviderForm state={{ mode: "edit", providerId: "p1" }} onClose={onClose} />
+      );
+      await waitFor(() => expect(screen.getByTestId("model-row-remove-claude-opus")).toBeTruthy());
+      fireEvent.click(screen.getByTestId("model-row-remove-claude-opus"));
+      // Row is gone from the candidate pool.
+      expect(screen.queryByTestId("model-row-claude-opus")).toBeNull();
+      fireEvent.click(screen.getByRole("button", { name: "Save" }));
+      // Save removes the removed-existing id from backend refs and bulkSets
+      // only the remaining (still-selected) infos.
+      await waitFor(() => expect(mockRemoveRefs).toHaveBeenCalledWith(["cm2"]));
+      expect(mockBulkSet).toHaveBeenCalledWith("p1", [
+        expect.objectContaining({ id: "claude-sonnet" }),
+      ]);
+      await waitFor(() => expect(onClose).toHaveBeenCalled());
+    });
+
+    it("Clear empties the field, keeps the dialog open, and persists nothing immediately", async () => {
+      mockGetApiKey.mockResolvedValue("saved-secret");
+      const onClose = jest.fn();
+      render(
+        <ConfigureProviderForm state={{ mode: "edit", providerId: "p1" }} onClose={onClose} />
+      );
+      const clear = await screen.findByTestId("api-key-clear");
+      fireEvent.click(clear);
+      // Field is wiped, but the keychain isn't touched and the dialog stays open —
+      // the removal is staged for Save, like every other field.
+      await waitFor(() => expect(screen.getByTestId<HTMLInputElement>("api-key").value).toBe(""));
+      expect(mockClearApiKey).not.toHaveBeenCalled();
+      expect(onClose).not.toHaveBeenCalled();
+      // Nothing left to clear → the button is gone.
+      expect(screen.queryByTestId("api-key-clear")).toBeNull();
+    });
+
+    it("disables Save after clearing a required-key provider's key", async () => {
+      mockGetApiKey.mockResolvedValue("saved-secret");
+      render(
+        <ConfigureProviderForm state={{ mode: "edit", providerId: "p1" }} onClose={jest.fn()} />
+      );
+      // p1 (anthropic, byok + catalogProviderId) requires a key and seeds two
+      // selected models, so the empty field is the only thing blocking Save.
+      fireEvent.click(await screen.findByTestId("api-key-clear"));
+      await waitFor(() =>
+        expect(screen.getByRole("button", { name: "Save" }).hasAttribute("disabled")).toBe(true)
+      );
+    });
+
+    it("re-fetching never toggles selection — discovered ids are candidates only", async () => {
+      // 1st fetch returns "a","b" — both appear as unchecked candidates.
+      mockListProviderModels.mockResolvedValueOnce({ ok: true, modelIds: ["a", "b"] });
+      render(
+        <ConfigureProviderForm state={{ mode: "new", source: ollamaSource }} onClose={jest.fn()} />
+      );
+      await waitFor(() => expect(screen.getByTestId("model-row-a")).toBeTruthy());
+      expect(rowCheckbox("a").getAttribute("aria-checked")).toBe("false");
+      expect(rowCheckbox("b").getAttribute("aria-checked")).toBe("false");
+
+      // User explicitly ticks "a".
+      fireEvent.click(rowCheckbox("a"));
+      expect(rowCheckbox("a").getAttribute("aria-checked")).toBe("true");
+
+      // A subsequent Test success triggers a refetch returning the same ids;
+      // the user's selection state must be preserved verbatim — "a" stays
+      // ticked, "b" stays unchecked, no row duplication.
+      mockVerifyCredentials.mockResolvedValue({ ok: true, checkedAt: 1 });
+      mockListProviderModels.mockResolvedValueOnce({ ok: true, modelIds: ["a", "b"] });
+      fireEvent.click(screen.getByRole("button", { name: "Test" }));
+      await waitFor(() => expect(mockListProviderModels).toHaveBeenCalledTimes(2));
+      expect(rowCheckbox("a").getAttribute("aria-checked")).toBe("true");
+      expect(rowCheckbox("b").getAttribute("aria-checked")).toBe("false");
+    });
+
+    it("holds back the stateful body until the provider row resolves", () => {
+      // Unknown providerId → `provider` never resolves from the atom, so the
+      // gate must render its placeholder and never mount the body (whose
+      // useState initializers would otherwise seed from blank values and let
+      // the user Save them).
+      render(
+        <ConfigureProviderForm
+          state={{ mode: "edit", providerId: "missing" }}
+          onClose={jest.fn()}
+        />
+      );
+      expect(screen.queryByTestId("model-checklist-manual-input")).toBeNull();
+      expect(screen.queryByText(/^Configure/)).toBeNull();
+      // No fetch fires while gated.
+      expect(mockListProviderModels).not.toHaveBeenCalled();
+    });
+
+    it("shows the default 'Add a model id' / source-supplied hint in the manual input", () => {
+      render(
+        <ConfigureProviderForm
+          state={{ mode: "new", source: CUSTOM_OPENAI_DEFINITION }}
+          onClose={jest.fn()}
+        />
+      );
+      expect(screen.getByPlaceholderText("e.g. gpt-5.5")).toBeTruthy();
+    });
+
+    it("A1: a required-key provider with an empty field fails Test without probing", async () => {
+      render(
+        <ConfigureProviderForm
+          state={{ mode: "new", source: anthropicSource }}
+          onClose={jest.fn()}
+        />
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Test" }));
+      // No network probe — the guard short-circuits so a public /models 200
+      // can't read as "Verified".
+      expect(mockVerifyCredentials).not.toHaveBeenCalled();
+      expect(await screen.findByText("Enter an API key to verify this provider.")).toBeTruthy();
+    });
+
+    it("B2: Save is disabled for a required-key provider with no key", () => {
+      render(
+        <ConfigureProviderForm
+          state={{ mode: "new", source: anthropicSource }}
+          onClose={jest.fn()}
+        />
+      );
+      manualAddId("claude-sonnet");
+      expect(screen.getByRole("button", { name: "Save" }).hasAttribute("disabled")).toBe(true);
+    });
+
+    it("B2: an untested invalid key auto-verifies on Save, aborts, and blocks further Save", async () => {
+      mockVerifyCredentials.mockResolvedValue({
+        ok: false,
+        code: "invalid_api_key",
+        message: "Authentication failed",
+        checkedAt: 1,
+      });
+      render(
+        <ConfigureProviderForm
+          state={{ mode: "new", source: anthropicSource }}
+          onClose={jest.fn()}
+        />
+      );
+      fireEvent.change(screen.getByTestId("api-key"), { target: { value: "sk-bad" } });
+      manualAddId("claude-sonnet");
+      // Untested key → Save is enabled, but Save auto-verifies first.
+      expect(screen.getByRole("button", { name: "Save" }).hasAttribute("disabled")).toBe(false);
+      fireEvent.click(screen.getByRole("button", { name: "Save" }));
+      await waitFor(() => expect(mockVerifyCredentials).toHaveBeenCalled());
+      expect(mockSetupProvider).not.toHaveBeenCalled();
+      // The conclusive failure now disables Save.
+      await waitFor(() =>
+        expect(screen.getByRole("button", { name: "Save" }).hasAttribute("disabled")).toBe(true)
+      );
+    });
+
+    it("B2: an inconclusive verification (network) does not block Save", async () => {
+      mockVerifyCredentials.mockResolvedValue({
+        ok: false,
+        code: "network",
+        message: "connection refused",
+        checkedAt: 1,
+      });
+      const onClose = jest.fn();
+      render(
+        <ConfigureProviderForm state={{ mode: "new", source: anthropicSource }} onClose={onClose} />
+      );
+      fireEvent.change(screen.getByTestId("api-key"), { target: { value: "sk-maybe" } });
+      manualAddId("claude-sonnet");
+      fireEvent.click(screen.getByRole("button", { name: "Save" }));
+      // Offline users aren't stranded — the provider still saves.
+      await waitFor(() => expect(mockSetupProvider).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(onClose).toHaveBeenCalled());
+    });
+
+    it("reports a changed key and endpoint only after both writes complete (https://github.com/logancyang/obsidian-copilot/issues/3147)", async () => {
+      const onSaved = jest.fn();
+      let finishUpdate!: () => void;
+      mockUpdate.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            finishUpdate = resolve;
+          })
+      );
+      mockVerifyCredentials.mockResolvedValue({ ok: true, checkedAt: 1 });
+      render(
+        <ConfigureProviderForm
+          state={{ mode: "edit", providerId: "p-custom" }}
+          onClose={jest.fn()}
+          onSaved={onSaved}
+        />
+      );
+      fireEvent.change(await screen.findByTestId("api-key"), { target: { value: "new-key" } });
+      fireEvent.change(screen.getByDisplayValue("https://proxy.example/v1"), {
+        target: { value: "https://new.example/v1" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Save" }));
+      await waitFor(() =>
+        expect(mockUpdate).toHaveBeenCalledWith(
+          "p-custom",
+          expect.objectContaining({ baseUrl: "https://new.example/v1" })
+        )
+      );
+      expect(mockSetApiKey).toHaveBeenCalledWith("p-custom", "new-key");
+      expect(onSaved).not.toHaveBeenCalled();
+      act(() => {
+        finishUpdate();
+      });
+      await waitFor(() => expect(onSaved).toHaveBeenCalledTimes(1));
+    });
+
+    it("B1/B2: edit mode pre-fills the saved key and saves without re-typing or re-writing it", async () => {
+      mockGetApiKey.mockResolvedValue("saved-secret");
+      mockBulkSet.mockResolvedValue(["cm1", "cm2"]);
+      const onClose = jest.fn();
+      render(
+        <ConfigureProviderForm state={{ mode: "edit", providerId: "p1" }} onClose={onClose} />
+      );
+      // The field is seeded with the stored key (visible, masked by PasswordInput).
+      const input = await screen.findByTestId<HTMLInputElement>("api-key");
+      expect(input.value).toBe("saved-secret");
+      fireEvent.click(screen.getByRole("button", { name: "Save" }));
+      await waitFor(() => expect(onClose).toHaveBeenCalled());
+      // Unchanged key → no keychain churn and no re-verification.
+      expect(mockSetApiKey).not.toHaveBeenCalled();
+      expect(mockVerifyCredentials).not.toHaveBeenCalled();
+    });
+
+    it("B2: a keyless provider (requiresApiKey:false) Tests and Saves with an empty field", async () => {
+      mockVerifyCredentials.mockResolvedValue({ ok: true, checkedAt: 1 });
+      const onClose = jest.fn();
+      const onSaved = jest.fn();
+      render(
+        <ConfigureProviderForm
+          state={{ mode: "new", source: ollamaSource }}
+          onClose={onClose}
+          onSaved={onSaved}
+        />
+      );
+      // Test with an empty field probes the endpoint (no required-key guard).
+      fireEvent.click(screen.getByRole("button", { name: "Test" }));
+      await waitFor(() => expect(mockVerifyCredentials).toHaveBeenCalled());
+      manualAddId("llama3.2");
+      fireEvent.click(screen.getByRole("button", { name: "Save" }));
+      await waitFor(() => expect(mockSetupProvider).toHaveBeenCalledTimes(1));
+      expect(mockSetupProvider).toHaveBeenCalledWith(
+        expect.objectContaining({ requiresApiKey: false })
+      );
+      await waitFor(() => expect(onClose).toHaveBeenCalled());
+      expect(onSaved).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/modelManagement/ui/dialogs/ConfigureProviderDialog.tsx
+++ b/src/modelManagement/ui/dialogs/ConfigureProviderDialog.tsx
@@ -71,6 +71,7 @@ export type ConfigureState =
 interface ConfigureProviderFormProps {
   state: ConfigureState;
   onClose: () => void;
+  onSaved?: () => void;
 }
 
 /**
@@ -82,7 +83,11 @@ interface ConfigureProviderFormProps {
  * seed the key field with the real value — so a genuinely keyless provider is
  * visibly empty — without an empty→filled flash.
  */
-export const ConfigureProviderForm: React.FC<ConfigureProviderFormProps> = ({ state, onClose }) => {
+export const ConfigureProviderForm: React.FC<ConfigureProviderFormProps> = ({
+  state,
+  onClose,
+  onSaved,
+}) => {
   const api = useModelManagement();
   const byokProviders = useAtomValue(byokProvidersAtom, { store: settingsStore });
   const configuredModels = useAtomValue(configuredModelsAtom, { store: settingsStore });
@@ -145,6 +150,7 @@ export const ConfigureProviderForm: React.FC<ConfigureProviderFormProps> = ({ st
     <ConfigureProviderBody
       state={state}
       onClose={onClose}
+      onSaved={onSaved}
       provider={provider}
       existingModels={existingModels}
       initialApiKey={initialApiKey}
@@ -155,6 +161,7 @@ export const ConfigureProviderForm: React.FC<ConfigureProviderFormProps> = ({ st
 interface ConfigureProviderBodyProps {
   state: ConfigureState;
   onClose: () => void;
+  onSaved?: () => void;
   /** Guaranteed defined in edit mode (the gate waits for it); undefined in new mode. */
   provider: Provider | undefined;
   existingModels: readonly ConfiguredModel[];
@@ -166,6 +173,7 @@ interface ConfigureProviderBodyProps {
 const ConfigureProviderBody: React.FC<ConfigureProviderBodyProps> = ({
   state,
   onClose,
+  onSaved,
   provider,
   existingModels,
   initialApiKey,
@@ -355,6 +363,9 @@ const ConfigureProviderBody: React.FC<ConfigureProviderBodyProps> = ({
         extras: Object.keys(extras).length > 0 ? extras : undefined,
         models: pool.buildSelectedModelInfos(),
       });
+      // https://github.com/logancyang/obsidian-copilot/issues/3147:
+      // Health checks must wait until the key and endpoint are both saved.
+      onSaved?.();
       onClose();
     } catch (err) {
       logError("[ConfigureProviderDialog] setupProvider failed", err);
@@ -391,6 +402,9 @@ const ConfigureProviderBody: React.FC<ConfigureProviderBodyProps> = ({
         selectedInfos: pool.buildSelectedModelInfos(),
         api,
       });
+      // https://github.com/logancyang/obsidian-copilot/issues/3147:
+      // Health checks must wait until the key and endpoint are both saved.
+      onSaved?.();
       onClose();
     } catch (err) {
       logError("[ConfigureProviderDialog] save changes failed", err);
@@ -683,8 +697,10 @@ async function saveProviderEdit({
 interface ConfigureProviderModalOptions {
   state: ConfigureState;
   api: ModelManagementApi;
+  onSaved?: () => void;
 }
 
+/** Hosts provider configuration and reports completed saves to the settings panel. */
 export class ConfigureProviderModal extends ReactModal {
   constructor(
     app: App,
@@ -708,7 +724,11 @@ export class ConfigureProviderModal extends ReactModal {
   protected renderContent(close: () => void): React.ReactElement {
     return (
       <ModelManagementProvider api={this.opts.api}>
-        <ConfigureProviderForm state={this.opts.state} onClose={close} />
+        <ConfigureProviderForm
+          state={this.opts.state}
+          onClose={close}
+          onSaved={this.opts.onSaved}
+        />
       </ModelManagementProvider>
     );
   }

--- a/src/modelManagement/ui/tabs/ByokPanel.test.tsx
+++ b/src/modelManagement/ui/tabs/ByokPanel.test.tsx
@@ -88,6 +88,15 @@ jest.mock("@/modelManagement/ui/dialogs/AddProviderDialog", () => ({
 }));
 
 import { ByokPanel } from "./ByokPanel";
+import { AddProviderModal } from "@/modelManagement/ui/dialogs/AddProviderDialog";
+import { ConfigureProviderModal } from "@/modelManagement/ui/dialogs/ConfigureProviderDialog";
+
+function completeProviderSave(): void {
+  fireEvent.click(screen.getByRole("button", { name: /Add a provider/i }));
+  const options = jest.mocked(AddProviderModal).mock.calls.at(-1)![1];
+  options.onPick({} as never);
+  jest.mocked(ConfigureProviderModal).mock.calls.at(-1)![1].onSaved!();
+}
 
 // Radix DropdownMenu portals resolve `activeDocument` at render time.
 beforeAll(() => {
@@ -149,7 +158,7 @@ describe("ByokPanel", () => {
       expect(screen.queryByRole("status")).toBeNull();
     });
 
-    it("rechecks rotated keys and ignores previous requests after a provider mutation (https://github.com/logancyang/obsidian-copilot/issues/3147)", async () => {
+    it("rechecks rotated keys and ignores previous requests after a completed save (https://github.com/logancyang/obsidian-copilot/issues/3147)", async () => {
       const oldResolvers: Array<(result: { ok: boolean; checkedAt: number }) => void> = [];
       mockVerify.mockImplementation(
         () =>
@@ -161,7 +170,7 @@ describe("ByokPanel", () => {
       await screen.findByText("Anthropic");
       mockVerify.mockResolvedValue({ ok: false, code: "missing_api_key", checkedAt: 1 });
       await act(async () => {
-        mockProviderListener!();
+        completeProviderSave();
       });
       expect(screen.getAllByText("No key")).toHaveLength(2);
       await act(async () => {
@@ -184,7 +193,7 @@ describe("ByokPanel", () => {
           })
       );
       act(() => {
-        mockProviderListener!();
+        completeProviderSave();
       });
       expect(screen.queryByText("Verified")).toBeNull();
       await act(async () => {
@@ -194,14 +203,27 @@ describe("ByokPanel", () => {
       expect(screen.queryByRole("status")).toBeNull();
     });
 
-    it("runs fresh checks when the tab remounts and unsubscribes on leave (https://github.com/logancyang/obsidian-copilot/issues/3147)", async () => {
+    it("runs fresh checks when the tab remounts (https://github.com/logancyang/obsidian-copilot/issues/3147)", async () => {
       const first = render(<ByokPanel />);
       await screen.findAllByText("Verified");
       first.unmount();
-      expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+      expect(mockSubscribe).not.toHaveBeenCalled();
       mockVerify.mockResolvedValue({ ok: false, code: "invalid_api_key", checkedAt: 1 });
       render(<ByokPanel />);
       await screen.findAllByText("Invalid key");
+      expect(mockVerify).toHaveBeenCalledTimes(4);
+    });
+
+    it("does not probe intermediate registry mutations before a save completes (https://github.com/logancyang/obsidian-copilot/issues/3147)", async () => {
+      render(<ByokPanel />);
+      await screen.findAllByText("Verified");
+      act(() => {
+        mockProviderListener?.();
+      });
+      expect(mockVerify).toHaveBeenCalledTimes(2);
+      await act(async () => {
+        completeProviderSave();
+      });
       expect(mockVerify).toHaveBeenCalledTimes(4);
     });
 

--- a/src/modelManagement/ui/tabs/ByokPanel.test.tsx
+++ b/src/modelManagement/ui/tabs/ByokPanel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 
 const mockEnsureLoaded = jest.fn().mockResolvedValue(undefined);
@@ -7,10 +7,17 @@ const mockOnChange = jest.fn().mockReturnValue(() => {});
 const mockRemoveProvider = jest.fn().mockResolvedValue(undefined);
 const mockAddProviderOpen = jest.fn();
 const mockConfigureOpen = jest.fn();
+const mockVerify = jest.fn();
+const mockListByOrigin = jest.fn();
+const mockUnsubscribe = jest.fn();
+let mockProviderListener: (() => void) | undefined;
+const mockSubscribe = jest.fn((listener: () => void) => {
+  mockProviderListener = listener;
+  return mockUnsubscribe;
+});
 
-jest.mock("@/modelManagement/ui/ModelManagementContext", () => ({
-  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real `useModelManagement` hook; the name must match the export
-  useModelManagement: () => ({
+jest.mock("@/modelManagement/ui/ModelManagementContext", () => {
+  const api = {
     catalogService: {
       ensureLoaded: mockEnsureLoaded,
       getAllProviders: mockGetAllProviders,
@@ -18,8 +25,15 @@ jest.mock("@/modelManagement/ui/ModelManagementContext", () => ({
       refresh: jest.fn(),
     },
     coordinator: { removeProvider: mockRemoveProvider },
-  }),
-}));
+    providerRegistry: {
+      verify: mockVerify,
+      listByOrigin: mockListByOrigin,
+      subscribe: mockSubscribe,
+    },
+  };
+  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook
+  return { useModelManagement: () => api };
+});
 // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real `useApp` hook; the name must match the export
 jest.mock("@/context", () => ({ useApp: () => ({}) }));
 jest.mock("@/modelManagement/state/atoms", () => {
@@ -31,6 +45,14 @@ jest.mock("@/modelManagement/state/atoms", () => {
       displayName: "Anthropic",
       origin: { kind: "byok", catalogProviderId: "anthropic" },
       addedAt: 0,
+    },
+    {
+      providerId: "p2",
+      providerType: "openai-compatible",
+      displayName: "Local",
+      origin: { kind: "byok" },
+      addedAt: 0,
+      requiresApiKey: false,
     },
   ]);
   return {
@@ -73,20 +95,148 @@ beforeAll(() => {
 });
 
 describe("ByokPanel", () => {
-  it("renders configured providers and their models after the catalog loads", async () => {
-    render(<ByokPanel />);
-    const providerCard = await screen.findByText("Anthropic");
-    expect(providerCard).toBeTruthy();
-
-    // Expand the provider card to see models (default collapsed)
-    fireEvent.click(providerCard);
-    expect(await screen.findByText("Claude Sonnet 4.5")).toBeTruthy();
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockListByOrigin.mockReturnValue([{ providerId: "p1" }, { providerId: "p2" }]);
+    mockVerify.mockReset().mockResolvedValue({ ok: true, checkedAt: 0 });
+    mockEnsureLoaded.mockResolvedValue(undefined);
   });
+  describe("ByokPanel()", () => {
+    it("renders configured providers and their models after the catalog loads", async () => {
+      render(<ByokPanel />);
+      const providerCard = await screen.findByText("Anthropic");
+      expect(providerCard).toBeTruthy();
 
-  it("opens the Add Provider modal from the add button", async () => {
-    render(<ByokPanel />);
-    await screen.findByText("Anthropic");
-    fireEvent.click(screen.getByRole("button", { name: /Add a provider/i }));
-    expect(mockAddProviderOpen).toHaveBeenCalled();
+      // Expand the provider card to see models (default collapsed)
+      fireEvent.click(providerCard);
+      expect(await screen.findByText("Claude Sonnet 4.5")).toBeTruthy();
+    });
+
+    it("opens the Add Provider modal from the add button", async () => {
+      render(<ByokPanel />);
+      await screen.findByText("Anthropic");
+      fireEvent.click(screen.getByRole("button", { name: /Add a provider/i }));
+      expect(mockAddProviderOpen).toHaveBeenCalled();
+    });
+    it("checks each provider independently and clears progress only after every result (https://github.com/logancyang/obsidian-copilot/issues/3147)", async () => {
+      let resolveFirst!: (result: { ok: boolean; checkedAt: number }) => void;
+      let resolveSecond!: (result: { ok: boolean; code: string; checkedAt: number }) => void;
+      mockVerify.mockImplementation((id: string) =>
+        id === "p1"
+          ? new Promise((resolve) => {
+              resolveFirst = resolve;
+            })
+          : new Promise((resolve) => {
+              resolveSecond = resolve;
+            })
+      );
+      render(<ByokPanel />);
+      await screen.findByText("Anthropic");
+      expect(mockListByOrigin).toHaveBeenCalledWith("byok");
+      expect(mockVerify.mock.calls).toEqual([["p1"], ["p2"]]);
+      expect(screen.getAllByText("Checking…")).toHaveLength(2);
+      expect(screen.getByRole("status")).toBeTruthy();
+      await act(async () => {
+        resolveFirst({ ok: true, checkedAt: 0 });
+      });
+      expect(screen.getByText("Verified")).toBeTruthy();
+      expect(screen.getByText("Checking…")).toBeTruthy();
+      expect(screen.getByRole("status")).toBeTruthy();
+      await act(async () => {
+        resolveSecond({ ok: false, code: "invalid_api_key", checkedAt: 0 });
+      });
+      expect(screen.getByText("Invalid key")).toBeTruthy();
+      expect(screen.queryByRole("status")).toBeNull();
+    });
+
+    it("rechecks rotated keys and ignores previous requests after a provider mutation (https://github.com/logancyang/obsidian-copilot/issues/3147)", async () => {
+      const oldResolvers: Array<(result: { ok: boolean; checkedAt: number }) => void> = [];
+      mockVerify.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            oldResolvers.push(resolve);
+          })
+      );
+      render(<ByokPanel />);
+      await screen.findByText("Anthropic");
+      mockVerify.mockResolvedValue({ ok: false, code: "missing_api_key", checkedAt: 1 });
+      await act(async () => {
+        mockProviderListener!();
+      });
+      expect(screen.getAllByText("No key")).toHaveLength(2);
+      await act(async () => {
+        oldResolvers.forEach((resolve) => resolve({ ok: true, checkedAt: 0 }));
+      });
+      expect(screen.queryByText("Verified")).toBeNull();
+      expect(screen.getAllByText("No key")).toHaveLength(2);
+      expect(screen.queryByRole("status")).toBeNull();
+    });
+
+    it("clears an earlier success while checking edited providers and shows rejected checks (https://github.com/logancyang/obsidian-copilot/issues/3147)", async () => {
+      render(<ByokPanel />);
+      await screen.findAllByText("Verified");
+      let rejectCheck!: (error: Error) => void;
+      mockListByOrigin.mockReturnValue([{ providerId: "p1" }]);
+      mockVerify.mockImplementation(
+        () =>
+          new Promise((_, reject) => {
+            rejectCheck = reject;
+          })
+      );
+      act(() => {
+        mockProviderListener!();
+      });
+      expect(screen.queryByText("Verified")).toBeNull();
+      await act(async () => {
+        rejectCheck(new Error("storage unavailable"));
+      });
+      expect(screen.getByText("Check failed")).toBeTruthy();
+      expect(screen.queryByRole("status")).toBeNull();
+    });
+
+    it("runs fresh checks when the tab remounts and unsubscribes on leave (https://github.com/logancyang/obsidian-copilot/issues/3147)", async () => {
+      const first = render(<ByokPanel />);
+      await screen.findAllByText("Verified");
+      first.unmount();
+      expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+      mockVerify.mockResolvedValue({ ok: false, code: "invalid_api_key", checkedAt: 1 });
+      render(<ByokPanel />);
+      await screen.findAllByText("Invalid key");
+      expect(mockVerify).toHaveBeenCalledTimes(4);
+    });
+
+    it("finishes without a progress banner when there are no providers (https://github.com/logancyang/obsidian-copilot/issues/3147)", async () => {
+      mockListByOrigin.mockReturnValue([]);
+      render(<ByokPanel />);
+      await waitFor(() => expect(mockEnsureLoaded).toHaveBeenCalled());
+      expect(mockVerify).not.toHaveBeenCalled();
+      expect(screen.queryByRole("status")).toBeNull();
+    });
+    it("shows current provider health while the catalog is still loading (https://github.com/logancyang/obsidian-copilot/issues/3147)", async () => {
+      mockEnsureLoaded.mockReturnValue(new Promise(() => {}));
+      render(<ByokPanel />);
+      expect(screen.getByText("Anthropic")).toBeTruthy();
+      await screen.findAllByText("Verified");
+    });
+
+    it("discards in-flight results after leaving and reopening the tab (https://github.com/logancyang/obsidian-copilot/issues/3147)", async () => {
+      const oldResolvers: Array<(result: { ok: boolean; checkedAt: number }) => void> = [];
+      mockVerify.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            oldResolvers.push(resolve);
+          })
+      );
+      const first = render(<ByokPanel />);
+      first.unmount();
+      mockVerify.mockResolvedValue({ ok: false, code: "invalid_api_key", checkedAt: 1 });
+      render(<ByokPanel />);
+      await screen.findAllByText("Invalid key");
+      await act(async () => {
+        oldResolvers.forEach((resolve) => resolve({ ok: true, checkedAt: 0 }));
+      });
+      expect(screen.queryByText("Verified")).toBeNull();
+      expect(screen.getAllByText("Invalid key")).toHaveLength(2);
+    });
   });
 });

--- a/src/modelManagement/ui/tabs/ByokPanel.tsx
+++ b/src/modelManagement/ui/tabs/ByokPanel.tsx
@@ -58,9 +58,14 @@ export const ByokPanel: React.FC = () => {
   const [query, setQuery] = useState("");
   const [verification, setVerification] =
     useState<Readonly<Record<string, VerificationResult>>>(EMPTY_VERIFICATION);
-  const [pendingChecks, setPendingChecks] = useState(0);
-  const [saveRevision, setSaveRevision] = useState(0);
-  const refreshVerification = (): void => setSaveRevision((revision) => revision + 1);
+  const [verificationProviders, setVerificationProviders] = useState(() =>
+    api.providerRegistry.listByOrigin("byok")
+  );
+  const pendingChecks = verificationProviders.length - Object.keys(verification).length;
+  const refreshVerification = (): void => {
+    setVerification(EMPTY_VERIFICATION);
+    setVerificationProviders([...api.providerRegistry.listByOrigin("byok")]);
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -68,10 +73,7 @@ export const ByokPanel: React.FC = () => {
     // Check completed saves, including CORS-only edits. Registry events can fire
     // between key and endpoint writes and would send the new key to the old URL.
 
-    const snapshot = api.providerRegistry.listByOrigin("byok");
-    setVerification(EMPTY_VERIFICATION);
-    setPendingChecks(snapshot.length);
-    for (const provider of snapshot) {
+    for (const provider of verificationProviders) {
       void api.providerRegistry
         .verify(provider.providerId)
         .catch(
@@ -84,13 +86,12 @@ export const ByokPanel: React.FC = () => {
         .then((result) => {
           if (cancelled) return;
           setVerification((results) => ({ ...results, [provider.providerId]: result }));
-          setPendingChecks((remaining) => remaining - 1);
         });
     }
     return () => {
       cancelled = true;
     };
-  }, [api, saveRevision]);
+  }, [api, verificationProviders]);
 
   // Load the catalog once and keep our snapshot in sync. The disk-load path
   // of `ensureLoaded` does NOT fire `onChange`, so we sync explicitly after

--- a/src/modelManagement/ui/tabs/ByokPanel.tsx
+++ b/src/modelManagement/ui/tabs/ByokPanel.tsx
@@ -19,6 +19,8 @@ import {
 import { configuredModelsAtom, visibleByokProvidersAtom } from "@/modelManagement/state/atoms";
 import { providerNeedsSelfHostWarning } from "@/modelManagement/providers/selfHostPolicy";
 import type { CatalogProvider } from "@/modelManagement/types/catalog";
+import type { VerificationResult } from "@/modelManagement/types/runtime";
+import { ProviderVerificationProgress } from "@/modelManagement/ui/components/ProviderVerificationStatus";
 import type { ConfiguredModel } from "@/modelManagement/types/persisted";
 import { useModelManagement } from "@/modelManagement/ui/ModelManagementContext";
 import {
@@ -33,6 +35,7 @@ import { Plus, ShieldCheck } from "lucide-react";
 import { Notice } from "obsidian";
 import React, { useEffect, useMemo, useState } from "react";
 
+const EMPTY_VERIFICATION: Readonly<Record<string, VerificationResult>> = Object.freeze({});
 const EMPTY_CATALOG: readonly CatalogProvider[] = Object.freeze([]);
 const EMPTY_MODELS: readonly ConfiguredModel[] = Object.freeze([]);
 
@@ -52,8 +55,46 @@ export const ByokPanel: React.FC = () => {
 
   const [catalogProviders, setCatalogProviders] =
     useState<readonly CatalogProvider[]>(EMPTY_CATALOG);
-  const [loadState, setLoadState] = useState<"loading" | "ready">("loading");
   const [query, setQuery] = useState("");
+  const [verification, setVerification] =
+    useState<Readonly<Record<string, VerificationResult>>>(EMPTY_VERIFICATION);
+  const [pendingChecks, setPendingChecks] = useState(0);
+
+  useEffect(() => {
+    let generation = 0;
+    // https://github.com/logancyang/obsidian-copilot/issues/3147:
+    // Re-read secrets on every visit and provider mutation, including rotations
+    // that leave the settings pointer unchanged. Old requests cannot restore a
+    // success badge after the user edits a provider or leaves the tab.
+    const verifyProviders = (): void => {
+      const current = ++generation;
+      const snapshot = api.providerRegistry.listByOrigin("byok");
+      setVerification(EMPTY_VERIFICATION);
+      setPendingChecks(snapshot.length);
+      for (const provider of snapshot) {
+        void api.providerRegistry
+          .verify(provider.providerId)
+          .catch(
+            (): VerificationResult => ({
+              ok: false,
+              message: "Could not verify this provider. Reopen this tab to retry.",
+              checkedAt: Date.now(),
+            })
+          )
+          .then((result) => {
+            if (current !== generation) return;
+            setVerification((results) => ({ ...results, [provider.providerId]: result }));
+            setPendingChecks((remaining) => remaining - 1);
+          });
+      }
+    };
+    const unsubscribe = api.providerRegistry.subscribe(verifyProviders);
+    verifyProviders();
+    return () => {
+      generation++;
+      unsubscribe();
+    };
+  }, [api]);
 
   // Load the catalog once and keep our snapshot in sync. The disk-load path
   // of `ensureLoaded` does NOT fire `onChange`, so we sync explicitly after
@@ -69,11 +110,9 @@ export const ByokPanel: React.FC = () => {
       .then(() => {
         if (cancelled) return;
         sync();
-        setLoadState("ready");
       })
       .catch((err) => {
         logError("[ByokPanel] catalog ensureLoaded failed", err);
-        if (!cancelled) setLoadState("ready");
       });
     return () => {
       cancelled = true;
@@ -95,15 +134,25 @@ export const ByokPanel: React.FC = () => {
           selfHostOn && providerNeedsSelfHostWarning(provider, { enableSelfHostMode: selfHostOn });
         const all = byProvider.get(provider.providerId) ?? (EMPTY_MODELS as ConfiguredModel[]);
         if (!q || provider.displayName.toLowerCase().includes(q)) {
-          return { provider, models: all, needsSelfHostWarning };
+          return {
+            provider,
+            models: all,
+            needsSelfHostWarning,
+            verification: verification[provider.providerId],
+          };
         }
         const models = all.filter(
           (m) => m.info.displayName.toLowerCase().includes(q) || m.info.id.toLowerCase().includes(q)
         );
-        return { provider, models, needsSelfHostWarning };
+        return {
+          provider,
+          models,
+          needsSelfHostWarning,
+          verification: verification[provider.providerId],
+        };
       })
       .filter((g) => !q || g.models.length > 0 || g.provider.displayName.toLowerCase().includes(q));
-  }, [providers, configuredModels, query, selfHostOn]);
+  }, [providers, configuredModels, query, selfHostOn, verification]);
 
   const handleAddProvider = (): void => {
     new AddProviderModal(app, {
@@ -137,7 +186,8 @@ export const ByokPanel: React.FC = () => {
   };
 
   return (
-    <div className="tw-flex tw-flex-col tw-gap-4 tw-py-4">
+    <div className="tw-relative tw-flex tw-flex-col tw-gap-4 tw-py-4">
+      <ProviderVerificationProgress pending={pendingChecks} />
       <div className="tw-flex tw-items-start tw-justify-between tw-gap-4">
         <div className="tw-flex tw-flex-col tw-gap-1">
           <div className="tw-text-xl tw-font-bold tw-text-normal">Bring Your Own Key</div>
@@ -165,23 +215,21 @@ export const ByokPanel: React.FC = () => {
       <SearchBar value={query} onChange={setQuery} placeholder="Search providers…" />
 
       <div className="tw-flex tw-flex-col">
-        {loadState === "loading" ? (
-          <div className="tw-text-sm tw-text-muted">Loading catalog…</div>
-        ) : (
-          <ByokGlobalTable
-            groups={groups}
-            emptyMessage={
-              query.trim() && providers.length > 0 ? "No providers match your search." : undefined
-            }
-            onConfigure={(id) =>
-              new ConfigureProviderModal(app, {
-                state: { mode: "edit", providerId: id },
-                api,
-              }).open()
-            }
-            onRemove={handleRemove}
-          />
-        )}
+        {/* https://github.com/logancyang/obsidian-copilot/issues/3147:
+            Current provider health must stay visible while the model catalog loads. */}
+        <ByokGlobalTable
+          groups={groups}
+          emptyMessage={
+            query.trim() && providers.length > 0 ? "No providers match your search." : undefined
+          }
+          onConfigure={(id) =>
+            new ConfigureProviderModal(app, {
+              state: { mode: "edit", providerId: id },
+              api,
+            }).open()
+          }
+          onRemove={handleRemove}
+        />
       </div>
     </div>
   );

--- a/src/modelManagement/ui/tabs/ByokPanel.tsx
+++ b/src/modelManagement/ui/tabs/ByokPanel.tsx
@@ -59,42 +59,38 @@ export const ByokPanel: React.FC = () => {
   const [verification, setVerification] =
     useState<Readonly<Record<string, VerificationResult>>>(EMPTY_VERIFICATION);
   const [pendingChecks, setPendingChecks] = useState(0);
+  const [saveRevision, setSaveRevision] = useState(0);
+  const refreshVerification = (): void => setSaveRevision((revision) => revision + 1);
 
   useEffect(() => {
-    let generation = 0;
+    let cancelled = false;
     // https://github.com/logancyang/obsidian-copilot/issues/3147:
-    // Re-read secrets on every visit and provider mutation, including rotations
-    // that leave the settings pointer unchanged. Old requests cannot restore a
-    // success badge after the user edits a provider or leaves the tab.
-    const verifyProviders = (): void => {
-      const current = ++generation;
-      const snapshot = api.providerRegistry.listByOrigin("byok");
-      setVerification(EMPTY_VERIFICATION);
-      setPendingChecks(snapshot.length);
-      for (const provider of snapshot) {
-        void api.providerRegistry
-          .verify(provider.providerId)
-          .catch(
-            (): VerificationResult => ({
-              ok: false,
-              message: "Could not verify this provider. Reopen this tab to retry.",
-              checkedAt: Date.now(),
-            })
-          )
-          .then((result) => {
-            if (current !== generation) return;
-            setVerification((results) => ({ ...results, [provider.providerId]: result }));
-            setPendingChecks((remaining) => remaining - 1);
-          });
-      }
-    };
-    const unsubscribe = api.providerRegistry.subscribe(verifyProviders);
-    verifyProviders();
+    // Check completed saves, including CORS-only edits. Registry events can fire
+    // between key and endpoint writes and would send the new key to the old URL.
+
+    const snapshot = api.providerRegistry.listByOrigin("byok");
+    setVerification(EMPTY_VERIFICATION);
+    setPendingChecks(snapshot.length);
+    for (const provider of snapshot) {
+      void api.providerRegistry
+        .verify(provider.providerId)
+        .catch(
+          (): VerificationResult => ({
+            ok: false,
+            message: "Could not verify this provider. Reopen this tab to retry.",
+            checkedAt: Date.now(),
+          })
+        )
+        .then((result) => {
+          if (cancelled) return;
+          setVerification((results) => ({ ...results, [provider.providerId]: result }));
+          setPendingChecks((remaining) => remaining - 1);
+        });
+    }
     return () => {
-      generation++;
-      unsubscribe();
+      cancelled = true;
     };
-  }, [api]);
+  }, [api, saveRevision]);
 
   // Load the catalog once and keep our snapshot in sync. The disk-load path
   // of `ensureLoaded` does NOT fire `onChange`, so we sync explicitly after
@@ -160,7 +156,11 @@ export const ByokPanel: React.FC = () => {
       localTemplates: LOCAL_PROVIDER_DEFINITIONS,
       customTemplate: CUSTOM_OPENAI_DEFINITION,
       onPick: (source) =>
-        new ConfigureProviderModal(app, { state: { mode: "new", source }, api }).open(),
+        new ConfigureProviderModal(app, {
+          state: { mode: "new", source },
+          api,
+          onSaved: refreshVerification,
+        }).open(),
     }).open();
   };
 
@@ -226,6 +226,7 @@ export const ByokPanel: React.FC = () => {
             new ConfigureProviderModal(app, {
               state: { mode: "edit", providerId: id },
               api,
+              onSaved: refreshVerification,
             }).open()
           }
           onRemove={handleRemove}


### PR DESCRIPTION
Relates to #3147

## Why

BYOK currently shows a green “API key set” badge when a saved keychain reference exists, even if its secret has disappeared or the provider rejects it. Local providers show “Running” without checking their endpoint.

## What

Opening BYOK checks each provider again and updates its badge as the response arrives. A small floating “Verifying providers…” indicator shows progress without moving the list. Missing keys, rejected credentials, and unsuccessful checks replace the green badge. Saving provider changes also refreshes the checks.

## Non goal

Repairing keys lost during an update or diagnosing the Agent Mode failure reported in #3147. Provider checks do not prove that every configured model can generate a response.

## Screenshot

Fresh capture from the test vault after rebuilding and reloading the plugin. Both configured providers completed their live checks and show “Verified”.

<img width="1224" height="768" alt="BYOK tab showing fresh Verified results for OpenRouter and Anthropic" src="https://github.com/user-attachments/assets/48df6d2c-1a53-4388-a4b3-82f05b7e0732" />

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Registry, panel, and status tests cover missing secrets, individual results, failed checks, and tab lifecycle |
| A defect would fail CI or be obvious on first use | ✅ | Status and lifecycle regressions are covered by deterministic tests |
| A revert fully restores prior state, including persisted data | ✅ | Verification results stay in memory; no settings or secret writes are added |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Tab visits now read stored credentials and check them with each configured provider |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Existing persisted provider data and verification result contracts are retained |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Async changes stay in the settings panel; chat and agent execution are unchanged |
| No hot-path behavior lacks deterministic coverage | ✅ | No chat hot path changes |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Rendered appearance and live provider responses are visible in BYOK |

Review: inspect `ProviderRegistry.verify` in `src/modelManagement/providers/ProviderRegistry.ts` and the verification effect in `src/modelManagement/ui/tabs/ByokPanel.tsx`. Follow the failure and concurrent-edit cases below.

## Verification

1. Open Settings → Copilot → BYOK with a working provider and a local endpoint. Observe the progress indicator and each badge updating without moving the list. Switch tabs and return to confirm the checks repeat.
2. In a disposable test vault, remove a provider's keychain secret while retaining its provider configuration. Reopen BYOK and expect “No key”. Test a rejected key and an unreachable endpoint, expecting “Invalid key” and “Check failed” respectively.
3. Save a provider change while an earlier check is pending, then leave and reopen the tab. Confirm an older response cannot restore a stale success badge. Check that ordinary search and provider configuration still work.
