### PR TITLE
Embed uploaded images in saved chat transcripts

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -126,6 +126,8 @@ Agent Chat keeps each conversation separate:
 
 Attachments apply to the next message. For instructions and context that should be reused, create a [Project](projects.md) or add rules to [`AGENTS.md`](system-prompts.md). See [Context and Mentions](context-and-mentions.md) for every context option.
 
+Uploaded images are embedded in saved conversation notes. Copilot stores the image files using your vault attachment setting and reuses them when the conversation is saved again.
+
 Type `/` to insert an enabled Skill or [Copilot command](custom-commands.md). For a quick question or rewrite beside the current selection, use [Quick Ask](custom-commands.md#quick-ask).
 
 ## Multi-agent answers

--- a/docs/chat-interface.md
+++ b/docs/chat-interface.md
@@ -59,6 +59,8 @@ Use **Chat History** to search saved conversations, reopen one, rename it, open 
 
 **Autosave Chat as Markdown** is enabled by default. Copilot saves after each user message and response under `<Copilot folder>/copilot-conversations/`. If autosave is off, use **Save Chat as Note** in the top bar. Change autosave and **Conversation Filename Template** under **Settings → Copilot → Basic → Saving conversations**.
 
+Uploaded images are embedded in saved conversation notes. Copilot stores the image files using your vault attachment setting and reuses them when the conversation is saved again.
+
 ## Chat settings
 
 Use **Chat Settings** (gear) to choose a **System Prompt** for the current chat or reset the session choice. These settings do not configure Agent Chat, which reads `AGENTS.md` instead. See [Instructions for Agent Chat and Quick Chat](system-prompts.md).

--- a/src/agentMode/session/AgentChatPersistenceManager.test.ts
+++ b/src/agentMode/session/AgentChatPersistenceManager.test.ts
@@ -10,6 +10,7 @@ import { getSettings } from "@/settings/model";
 import { getEffectiveConversationsFolder } from "@/settings/copilotFolder";
 
 jest.mock("obsidian", () => ({
+  normalizePath: (path: string) => path,
   Notice: jest.fn(),
   TFile: jest.fn(),
 }));
@@ -60,9 +61,8 @@ function makeApp() {
     files,
     vault: {
       createBinary: jest.fn(async (path: string, bytes: ArrayBuffer) => ({ path })),
-      getAvailablePathForAttachments: jest.fn(
-        async (name: string, extension: string) => `attachments/${name}.${extension}`
-      ),
+      getConfig: jest.fn(() => "attachments"),
+      createFolder: jest.fn(),
       getAbstractFileByPath: jest.fn((path: string) => files.get(path) ?? null),
       create: jest.fn(async (path: string, content: string) => {
         const basename = path.split("/").pop()!.replace(/\.md$/, "");
@@ -80,6 +80,7 @@ function makeApp() {
       adapter: {
         list: jest.fn(async () => ({ files: [], folders: [] })),
         readBinary: jest.fn(),
+        mkdir: jest.fn(),
         exists: jest.fn(async (path: string) => files.has(path)),
         read: jest.fn(async (path: string) => files.get(path)?.contents ?? ""),
         write: jest.fn(async (path: string, content: string) => {

--- a/src/agentMode/session/AgentChatPersistenceManager.test.ts
+++ b/src/agentMode/session/AgentChatPersistenceManager.test.ts
@@ -59,6 +59,10 @@ function makeApp() {
   return {
     files,
     vault: {
+      createBinary: jest.fn(async (path: string, bytes: ArrayBuffer) => ({ path })),
+      getAvailablePathForAttachments: jest.fn(
+        async (name: string, extension: string) => `attachments/${name}.${extension}`
+      ),
       getAbstractFileByPath: jest.fn((path: string) => files.get(path) ?? null),
       create: jest.fn(async (path: string, content: string) => {
         const basename = path.split("/").pop()!.replace(/\.md$/, "");
@@ -74,6 +78,8 @@ function makeApp() {
         files.delete(file.path);
       }),
       adapter: {
+        list: jest.fn(async () => ({ files: [], folders: [] })),
+        readBinary: jest.fn(),
         exists: jest.fn(async (path: string) => files.has(path)),
         read: jest.fn(async (path: string) => files.get(path)?.contents ?? ""),
         write: jest.fn(async (path: string, content: string) => {
@@ -116,6 +122,52 @@ describe("AgentChatPersistenceManager", () => {
   beforeEach(() => {
     app = makeApp();
     manager = new AgentChatPersistenceManager(app as unknown as App);
+  });
+
+  describe("saveSession()", () => {
+    it("saves uploaded image embeds beside the user message and preserves them on reload (https://github.com/logancyang/obsidian-copilot/issues/2900)", async () => {
+      const message = {
+        ...makeMessage(USER_SENDER, "Look at this"),
+        content: [{ type: "image_url", image_url: { url: "data:image/png;base64,AQID" } }],
+      };
+      app.vault.createBinary.mockImplementation(async (path) => {
+        expect(app.vault.create).not.toHaveBeenCalled();
+        return { path };
+      });
+      const saved = await manager.saveSession(
+        [message, makeMessage(AI_SENDER, "An image")],
+        "claude"
+      );
+      const imagePath = app.vault.createBinary.mock.calls[0][0];
+      const file = app.files.get(saved!.path)!;
+      expect(file.contents).toContain(`**user**: Look at this\n\n![](/${imagePath})\n[Timestamp:`);
+      expect(file.contents).toContain("**ai**: An image");
+      const loaded = await manager.loadFile(file as unknown as TFile);
+      expect(loaded.messages[0].message).toContain(`![](/${imagePath})`);
+      expect(message.message).toBe("Look at this");
+    });
+
+    it("preserves the existing transcript and reports failure when an image write fails (https://github.com/logancyang/obsidian-copilot/issues/2900)", async () => {
+      const messages = [makeMessage(USER_SENDER, "Original")];
+      const original = await manager.saveSession(messages, "claude");
+      const content = app.files.get(original!.path)!.contents;
+      app.vault.createBinary.mockRejectedValueOnce(new Error("disk full"));
+      const result = await manager.saveSession(
+        [
+          {
+            ...messages[0],
+            message: "Image",
+            content: [{ type: "image_url", image_url: { url: "data:image/png;base64,AQID" } }],
+          },
+        ],
+        "claude",
+        { existingPath: original!.path }
+      );
+      expect(result).toBeNull();
+      expect(app.files.get(original!.path)!.contents).toBe(content);
+      expect(app.vault.modify).not.toHaveBeenCalled();
+      expect(app.vault.adapter.write).not.toHaveBeenCalled();
+    });
   });
 
   it("round-trips messages, backendId, and label", async () => {

--- a/src/agentMode/session/AgentChatPersistenceManager.ts
+++ b/src/agentMode/session/AgentChatPersistenceManager.ts
@@ -1,3 +1,4 @@
+import { prepareChatImagesForSave } from "@/utils/chatImagePersistence";
 import { serializeFanoutComposite } from "@/agentMode/session/fanout/fanoutTypes";
 import { AGENT_CHAT_MODE, AI_SENDER, COPILOT_CONVERSATION_TAG, USER_SENDER } from "@/constants";
 import { logError, logInfo, logWarn } from "@/logger";
@@ -141,7 +142,6 @@ export class AgentChatPersistenceManager {
     if (messages.length === 0) return null;
 
     try {
-      const chatContent = this.formatChatContent(messages);
       const firstMessageEpoch = messages[0].timestamp?.epoch ?? Date.now();
 
       // Capture the conversations folder once so a concurrent Copilot-root
@@ -164,6 +164,13 @@ export class AgentChatPersistenceManager {
             conversationsFolder,
             existingMeta.topic
           );
+
+      const preparedMessages = await prepareChatImagesForSave(
+        this.app,
+        messages,
+        preferredFileName
+      );
+      const chatContent = this.formatChatContent(preparedMessages);
 
       const noteContent = this.generateNoteContent({
         chatContent,

--- a/src/core/ChatPersistenceManager.test.ts
+++ b/src/core/ChatPersistenceManager.test.ts
@@ -101,6 +101,8 @@ type MockApp = {
   vault: {
     getAbstractFileByPath: jest.Mock;
     createFolder: jest.Mock;
+    createBinary: jest.Mock;
+    getAvailablePathForAttachments: jest.Mock;
     create: jest.Mock;
     modify: jest.Mock;
     read: jest.Mock;
@@ -108,6 +110,7 @@ type MockApp = {
     adapter: {
       exists: jest.Mock;
       read: jest.Mock;
+      readBinary: jest.Mock;
       write: jest.Mock;
       list: jest.Mock;
       stat: jest.Mock;
@@ -133,6 +136,10 @@ describe("ChatPersistenceManager", () => {
       vault: {
         getAbstractFileByPath: jest.fn().mockReturnValue(null), // Default: file not found
         createFolder: jest.fn(),
+        createBinary: jest.fn(),
+        getAvailablePathForAttachments: jest.fn(
+          async (name, extension) => `attachments/${name}.${extension}`
+        ),
         create: jest.fn(),
         modify: jest.fn(),
         read: jest.fn(),
@@ -140,6 +147,7 @@ describe("ChatPersistenceManager", () => {
         adapter: {
           exists: jest.fn().mockResolvedValue(false),
           read: jest.fn().mockResolvedValue(""),
+          readBinary: jest.fn(),
           write: jest.fn().mockResolvedValue(undefined),
           list: jest.fn().mockResolvedValue({ files: [], folders: [] }),
           stat: jest.fn().mockResolvedValue({ ctime: Date.now(), mtime: Date.now(), size: 0 }),
@@ -353,6 +361,65 @@ Nature's quiet song`);
   });
 
   describe("saveChat", () => {
+    it("saves uploaded images with their message before context and timestamp metadata (https://github.com/logancyang/obsidian-copilot/issues/2900)", async () => {
+      const message: ChatMessage = {
+        id: "image",
+        sender: USER_SENDER,
+        message: "Look at this",
+        isVisible: true,
+        timestamp: {
+          epoch: 1695513480000,
+          display: "2024/09/23 22:18:00",
+          fileName: "2024_09_23_221800",
+        },
+        context: { notes: [], urls: ["https://example.com"] },
+        content: [{ type: "image_url", image_url: { url: "data:image/png;base64,AQID" } }],
+      };
+      mockMessageRepo.getDisplayMessages.mockReturnValue([message]);
+      mockApp.vault.createBinary.mockImplementation(async () => {
+        expect(mockApp.vault.create).not.toHaveBeenCalled();
+      });
+      await persistenceManager.saveChat("gpt-4");
+      const imagePath = mockApp.vault.createBinary.mock.calls[0][0] as string;
+      const saved = mockApp.vault.create.mock.calls[0][1] as string;
+      expect(saved).toContain(
+        `**user**: Look at this\n\n![](/${imagePath})\n[Context: URLs: https://example.com]\n[Timestamp:`
+      );
+      expect(message.message).toBe("Look at this");
+      expect(asInternal(persistenceManager).parseChatContent(saved)[0].message).toContain(
+        `![](/${imagePath})`
+      );
+    });
+
+    it("preserves an existing transcript when an uploaded image cannot be saved (https://github.com/logancyang/obsidian-copilot/issues/2900)", async () => {
+      const existingFile = mockTFile({ path: "test-folder/existing.md" });
+      jest.spyOn(persistenceManager, "getChatHistoryFiles").mockResolvedValue([existingFile]);
+      mockApp.metadataCache.getFileCache.mockReturnValue({ frontmatter: { epoch: 1695513480000 } });
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(existingFile);
+      mockMessageRepo.getDisplayMessages.mockReturnValue([
+        {
+          id: "image",
+          sender: USER_SENDER,
+          message: "New image",
+          isVisible: true,
+          timestamp: {
+            epoch: 1695513480000,
+            display: "2024/09/23 22:18:00",
+            fileName: "2024_09_23_221800",
+          },
+          content: [{ type: "image_url", image_url: { url: "data:image/png;base64,AQID" } }],
+        },
+      ]);
+      mockApp.vault.createBinary.mockRejectedValueOnce(new Error("disk full"));
+      await persistenceManager.saveChat("gpt-4");
+      expect(mockApp.vault.modify).not.toHaveBeenCalled();
+      expect(mockApp.vault.create).not.toHaveBeenCalled();
+      expect(mockApp.vault.adapter.write).not.toHaveBeenCalled();
+      expect(Notice).toHaveBeenCalledWith(
+        "Failed to save chat as note. Check console for details."
+      );
+    });
+
     it("should save chat to a markdown file", async () => {
       const messages: ChatMessage[] = [
         {

--- a/src/core/ChatPersistenceManager.test.ts
+++ b/src/core/ChatPersistenceManager.test.ts
@@ -20,6 +20,7 @@ const asInternal = (pm: ChatPersistenceManager): PMInternal => pm as unknown as 
 
 // Mock the imports
 jest.mock("obsidian", () => ({
+  normalizePath: (path: string) => path,
   Notice: jest.fn(),
   TFile: jest.fn(),
   TFolder: jest.fn(),
@@ -102,7 +103,7 @@ type MockApp = {
     getAbstractFileByPath: jest.Mock;
     createFolder: jest.Mock;
     createBinary: jest.Mock;
-    getAvailablePathForAttachments: jest.Mock;
+    getConfig: jest.Mock;
     create: jest.Mock;
     modify: jest.Mock;
     read: jest.Mock;
@@ -111,6 +112,7 @@ type MockApp = {
       exists: jest.Mock;
       read: jest.Mock;
       readBinary: jest.Mock;
+      mkdir: jest.Mock;
       write: jest.Mock;
       list: jest.Mock;
       stat: jest.Mock;
@@ -137,9 +139,7 @@ describe("ChatPersistenceManager", () => {
         getAbstractFileByPath: jest.fn().mockReturnValue(null), // Default: file not found
         createFolder: jest.fn(),
         createBinary: jest.fn(),
-        getAvailablePathForAttachments: jest.fn(
-          async (name, extension) => `attachments/${name}.${extension}`
-        ),
+        getConfig: jest.fn(() => "attachments"),
         create: jest.fn(),
         modify: jest.fn(),
         read: jest.fn(),
@@ -148,6 +148,7 @@ describe("ChatPersistenceManager", () => {
           exists: jest.fn().mockResolvedValue(false),
           read: jest.fn().mockResolvedValue(""),
           readBinary: jest.fn(),
+          mkdir: jest.fn(),
           write: jest.fn().mockResolvedValue(undefined),
           list: jest.fn().mockResolvedValue({ files: [], folders: [] }),
           stat: jest.fn().mockResolvedValue({ ctime: Date.now(), mtime: Date.now(), size: 0 }),

--- a/src/core/ChatPersistenceManager.ts
+++ b/src/core/ChatPersistenceManager.ts
@@ -1,3 +1,4 @@
+import { prepareChatImagesForSave } from "@/utils/chatImagePersistence";
 import { AI_SENDER, COPILOT_CONVERSATION_TAG, USER_SENDER } from "@/constants";
 import ChainManager from "@/LLMProviders/chainManager";
 import { parseReasoningBlock } from "@/LLMProviders/chainRunner/utils/AgentReasoningState";
@@ -61,7 +62,6 @@ export class ChatPersistenceManager {
         return;
       }
 
-      const chatContent = this.formatChatContent(messages);
       const firstMessageEpoch = messages[0].timestamp?.epoch || Date.now();
 
       // Capture the conversations folder once at the start of the save so a
@@ -99,6 +99,13 @@ export class ChatPersistenceManager {
       const preferredFileName = existingFile
         ? existingFile.path
         : this.generateFileName(messages, firstMessageEpoch, conversationsFolder, existingTopic);
+
+      const preparedMessages = await prepareChatImagesForSave(
+        this.app,
+        messages,
+        preferredFileName
+      );
+      const chatContent = this.formatChatContent(preparedMessages);
 
       const noteContent = this.generateNoteContent(
         chatContent,

--- a/src/utils/chatImagePersistence.test.ts
+++ b/src/utils/chatImagePersistence.test.ts
@@ -1,0 +1,229 @@
+import { prepareChatImagesForSave } from "@/utils/chatImagePersistence";
+import { arrayBufferToBase64, base64ToArrayBuffer } from "@/utils/base64";
+import { sha256 } from "@/utils/hash";
+import type { App } from "obsidian";
+
+const ISSUE = "https://github.com/logancyang/obsidian-copilot/issues/2900";
+const DATA = "iVBORw0KGgo=";
+const IMAGE = { type: "image_url", image_url: { url: `data:image/png;base64,${DATA}` } };
+
+function makeApp(attachmentFolder = "attachments") {
+  const files = new Map<string, ArrayBuffer>();
+  const vault = {
+    getAvailablePathForAttachments: jest.fn(
+      async (
+        name: string,
+        extension: string,
+        source: {
+          parent: { path: string; getParentPrefix(): string };
+        }
+      ) => {
+        const folder =
+          attachmentFolder === "."
+            ? source.parent.path
+            : attachmentFolder.startsWith("./")
+              ? `${source.parent.getParentPrefix()}${attachmentFolder.slice(2)}`
+              : attachmentFolder;
+        const prefix = folder ? `${folder}/` : "";
+        let path = `${prefix}${name}.${extension}`;
+        let suffix = 1;
+        while (files.has(path)) path = `${prefix}${name} ${suffix++}.${extension}`;
+        return path;
+      }
+    ),
+    createBinary: jest.fn(async (path: string, bytes: ArrayBuffer) => {
+      files.set(path, bytes);
+      return { path };
+    }),
+    adapter: {
+      list: jest.fn(async (folder: string) => ({
+        files: [...files.keys()].filter(
+          (path) => path.slice(0, Math.max(0, path.lastIndexOf("/"))) === folder
+        ),
+        folders: [],
+      })),
+      readBinary: jest.fn(async (path: string) => files.get(path)!),
+    },
+  };
+  return { files, vault, app: { vault } as unknown as App };
+}
+
+describe("chatImagePersistence", () => {
+  describe("prepareChatImagesForSave()", () => {
+    it(`embeds every uploaded image beside its own message without mutating live content (${ISSUE})`, async () => {
+      const { app, files, vault } = makeApp();
+      const messages = [
+        { id: "1", message: "First image", content: [IMAGE] },
+        {
+          id: "2",
+          message: "",
+          content: [{ type: "image_url", image_url: { url: "data:image/jpeg;base64,AQID" } }],
+        },
+      ];
+      const original = JSON.stringify(messages);
+      const prepared = await prepareChatImagesForSave(app, messages, "chats/new.md");
+      const paths = [...files.keys()];
+      expect(prepared[0].message).toBe(`First image\n\n![](/${paths[0]})`);
+      expect(prepared[1].message).toBe(`![](/${paths[1]})`);
+      expect(paths[1]).toMatch(/\.jpg$/);
+      expect(arrayBufferToBase64(files.get(paths[0])!)).toBe(DATA);
+      expect(JSON.stringify(messages)).toBe(original);
+      expect(vault.createBinary).toHaveBeenCalledTimes(2);
+    });
+
+    it.each(["attachments", ".", "./images", ""])(
+      `honors attachment folder %j before a new transcript exists (${ISSUE})`,
+      async (setting) => {
+        const { app, files, vault } = makeApp(setting);
+        await prepareChatImagesForSave(app, [{ message: "", content: [IMAGE] }], "chats/new.md");
+        const folder =
+          setting === "." ? "chats" : setting === "./images" ? "chats/images" : setting;
+        expect([...files.keys()][0]).toBe(
+          `${folder ? `${folder}/` : ""}copilot-image-${sha256(DATA)}.png`
+        );
+        const source = vault.getAvailablePathForAttachments.mock.calls[0][2];
+        expect(source.parent.path).toBe("chats");
+        expect(source.parent.getParentPrefix()).toBe("chats/");
+      }
+    );
+
+    it(`supports relative attachments for hidden and vault-root transcripts (${ISSUE})`, async () => {
+      for (const notePath of [".copilot/chats/new.md", "new.md"]) {
+        const { app, files } = makeApp("./images");
+        await prepareChatImagesForSave(app, [{ message: "", content: [IMAGE] }], notePath);
+        const prefix = notePath.startsWith(".") ? ".copilot/chats/" : "";
+        expect([...files.keys()][0]).toBe(`${prefix}images/copilot-image-${sha256(DATA)}.png`);
+      }
+    });
+
+    it(`reuses attachments within a message and across saves, including filename collisions (${ISSUE})`, async () => {
+      const { app, files, vault } = makeApp();
+      const collision = `attachments/copilot-image-${sha256(DATA)}.png`;
+      files.set(collision, base64ToArrayBuffer("AQID"));
+      const messages = [{ message: "two", content: [IMAGE, IMAGE] }];
+      const first = await prepareChatImagesForSave(app, messages, "chats/new.md");
+      const second = await prepareChatImagesForSave(app, messages, "chats/new.md");
+      const expectedPath = collision.replace(".png", " 1.png");
+      expect(first[0].message).toBe(
+        `two\n\n![](/${expectedPath.replace(" ", "%20")})\n\n![](/${expectedPath.replace(" ", "%20")})`
+      );
+      expect(second).toEqual(first);
+      expect(vault.createBinary).toHaveBeenCalledTimes(1);
+      expect(arrayBufferToBase64(files.get(collision)!)).toBe("AQID");
+    });
+
+    it(`completes both concurrent saves when the winning attachment contains the same bytes (${ISSUE})`, async () => {
+      const { app, files, vault } = makeApp();
+      let releaseFirst!: () => void;
+      let finishFirst!: () => void;
+      const secondCreating = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      const firstWritten = new Promise<void>((resolve) => {
+        finishFirst = resolve;
+      });
+      vault.createBinary.mockImplementation(async (path, bytes) => {
+        if (vault.createBinary.mock.calls.length === 1) {
+          await secondCreating;
+          files.set(path, bytes);
+          finishFirst();
+          return { path };
+        }
+        releaseFirst();
+        await firstWritten;
+        throw new Error("File already exists.");
+      });
+      const messages = [{ message: "", content: [IMAGE] }];
+      const results = await Promise.all([
+        prepareChatImagesForSave(app, messages, "chats/one.md"),
+        prepareChatImagesForSave(app, messages, "chats/two.md"),
+      ]);
+      expect(results[0]).toEqual(results[1]);
+      expect(results[0][0].message).toBe(`![](/attachments/copilot-image-${sha256(DATA)}.png)`);
+      expect(files.size).toBe(1);
+      expect(arrayBufferToBase64([...files.values()][0])).toBe(DATA);
+      expect(vault.createBinary).toHaveBeenCalledTimes(2);
+    });
+
+    it.each(["different", "unreadable"])(
+      `preserves the original collision error when the winning attachment is %s (${ISSUE})`,
+      async (winner) => {
+        const { app, files, vault } = makeApp();
+        const collision = new Error("File already exists.");
+        vault.createBinary.mockImplementation(async (path) => {
+          files.set(path, base64ToArrayBuffer("AQID"));
+          throw collision;
+        });
+        if (winner === "unreadable")
+          vault.adapter.readBinary.mockRejectedValueOnce(new Error("cannot read"));
+        await expect(
+          prepareChatImagesForSave(app, [{ message: "", content: [IMAGE] }], "chats/new.md")
+        ).rejects.toBe(collision);
+      }
+    );
+
+    it(`escapes folder characters that could break an image embed (${ISSUE})`, async () => {
+      const { app } = makeApp("images ] # % (reference)");
+      const prepared = await prepareChatImagesForSave(
+        app,
+        [{ message: "", content: [IMAGE] }],
+        "chats/new.md"
+      );
+      expect(prepared[0].message).toBe(
+        `![](/images%20%5D%20%23%20%25%20%28reference%29/copilot-image-${sha256(DATA)}.png)`
+      );
+    });
+
+    it(`leaves text, existing embeds, remote images, and non-image content unchanged (${ISSUE})`, async () => {
+      const { app, vault } = makeApp();
+      const messages = [
+        { message: "text ![[existing.png]]" },
+        {
+          message: "other",
+          content: [
+            null,
+            4,
+            {},
+            { type: "text", text: "hello" },
+            { type: "image_url" },
+            { type: "image_url", image_url: {} },
+            { type: "image_url", image_url: { url: "https://example.com/image.png" } },
+            { type: "image_url", image_url: { url: "data:application/pdf;base64,AQID" } },
+          ],
+        },
+      ];
+      const prepared = await prepareChatImagesForSave(app, messages, "chats/new.md");
+      expect(prepared).toEqual(messages);
+      expect(prepared[0]).toBe(messages[0]);
+      expect(vault.getAvailablePathForAttachments).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      "data:image/png;base64,",
+      "data:image/png;base64,???",
+      "data:image/x-invalid;base64,AQID",
+      "data:image/png;base64,A",
+    ])(
+      `rejects malformed uploaded image %j without writing an attachment (${ISSUE})`,
+      async (url) => {
+        const { app, vault } = makeApp();
+        await expect(
+          prepareChatImagesForSave(
+            app,
+            [{ message: "", content: [{ type: "image_url", image_url: { url } }] }],
+            "chats/new.md"
+          )
+        ).rejects.toThrow("invalid uploaded image");
+        expect(vault.createBinary).not.toHaveBeenCalled();
+      }
+    );
+
+    it(`rejects attachment write failures so the caller cannot save an incomplete transcript (${ISSUE})`, async () => {
+      const { app, vault } = makeApp();
+      vault.createBinary.mockRejectedValueOnce(new Error("disk full"));
+      await expect(
+        prepareChatImagesForSave(app, [{ message: "", content: [IMAGE] }], "chats/new.md")
+      ).rejects.toThrow("disk full");
+    });
+  });
+});

--- a/src/utils/chatImagePersistence.test.ts
+++ b/src/utils/chatImagePersistence.test.ts
@@ -9,33 +9,24 @@ const IMAGE = { type: "image_url", image_url: { url: `data:image/png;base64,${DA
 
 function makeApp(attachmentFolder = "attachments") {
   const files = new Map<string, ArrayBuffer>();
+  const folders = new Set<string>();
   const vault = {
-    getAvailablePathForAttachments: jest.fn(
-      async (
-        name: string,
-        extension: string,
-        source: {
-          parent: { path: string; getParentPrefix(): string };
-        }
-      ) => {
-        const folder =
-          attachmentFolder === "."
-            ? source.parent.path
-            : attachmentFolder.startsWith("./")
-              ? `${source.parent.getParentPrefix()}${attachmentFolder.slice(2)}`
-              : attachmentFolder;
-        const prefix = folder ? `${folder}/` : "";
-        let path = `${prefix}${name}.${extension}`;
-        let suffix = 1;
-        while (files.has(path)) path = `${prefix}${name} ${suffix++}.${extension}`;
-        return path;
-      }
-    ),
+    getConfig: jest.fn(() => attachmentFolder),
+    createFolder: jest.fn(async (path: string) => {
+      folders.add(path);
+    }),
     createBinary: jest.fn(async (path: string, bytes: ArrayBuffer) => {
       files.set(path, bytes);
       return { path };
     }),
     adapter: {
+      exists: jest.fn(async (path: string) => files.has(path) || folders.has(path)),
+      mkdir: jest.fn(async (path: string) => {
+        folders.add(path);
+      }),
+      writeBinary: jest.fn(async (path: string, bytes: ArrayBuffer) => {
+        files.set(path, bytes);
+      }),
       list: jest.fn(async (folder: string) => ({
         files: [...files.keys()].filter(
           (path) => path.slice(0, Math.max(0, path.lastIndexOf("/"))) === folder
@@ -81,9 +72,7 @@ describe("chatImagePersistence", () => {
         expect([...files.keys()][0]).toBe(
           `${folder ? `${folder}/` : ""}copilot-image-${sha256(DATA)}.png`
         );
-        const source = vault.getAvailablePathForAttachments.mock.calls[0][2];
-        expect(source.parent.path).toBe("chats");
-        expect(source.parent.getParentPrefix()).toBe("chats/");
+        expect(vault.getConfig).toHaveBeenCalledWith("attachmentFolderPath");
       }
     );
 
@@ -94,6 +83,112 @@ describe("chatImagePersistence", () => {
         const prefix = notePath.startsWith(".") ? ".copilot/chats/" : "";
         expect([...files.keys()][0]).toBe(`${prefix}images/copilot-image-${sha256(DATA)}.png`);
       }
+    });
+
+    it.each([".", "./images", ".attachments"])(
+      `writes and reuses hidden attachments with setting %j through the adapter (${ISSUE})`,
+      async (setting) => {
+        const { app, files, vault } = makeApp(setting);
+        vault.createBinary.mockRejectedValue(new Error("not in vault cache"));
+        const messages = [{ message: "", content: [IMAGE] }];
+        const first = await prepareChatImagesForSave(app, messages, ".copilot/chats/new.md");
+        expect(await prepareChatImagesForSave(app, messages, ".copilot/chats/new.md")).toEqual(
+          first
+        );
+        expect(files.size).toBe(1);
+        expect(arrayBufferToBase64([...files.values()][0])).toBe(DATA);
+        expect(vault.adapter.writeBinary).toHaveBeenCalledTimes(1);
+        expect(vault.createBinary).not.toHaveBeenCalled();
+      }
+    );
+
+    it.each([DATA, "AQID"])(
+      `preserves a hidden attachment created after allocation with bytes %s (${ISSUE})`,
+      async (winner) => {
+        const { app, files, vault } = makeApp(".");
+        vault.adapter.list.mockImplementation(async () => {
+          files.set(`.chats/copilot-image-${sha256(DATA)}.png`, base64ToArrayBuffer(winner));
+          return { files: [], folders: [] };
+        });
+        const saving = prepareChatImagesForSave(
+          app,
+          [{ message: "", content: [IMAGE] }],
+          ".chats/new.md"
+        );
+        if (winner === DATA) await expect(saving).resolves.toHaveLength(1);
+        else await expect(saving).rejects.toThrow("File already exists.");
+        expect(arrayBufferToBase64([...files.values()][0])).toBe(winner);
+        expect(vault.adapter.writeBinary).not.toHaveBeenCalled();
+      }
+    );
+
+    it.each(["Folder already exists.", "permission denied"])(
+      `handles attachment folder creation failure %s (${ISSUE})`,
+      async (error) => {
+        const { app, vault } = makeApp(".attachments");
+        vault.adapter.mkdir.mockRejectedValueOnce(new Error(error));
+        const saving = prepareChatImagesForSave(
+          app,
+          [{ message: "", content: [IMAGE] }],
+          "chats/new.md"
+        );
+        if (error === "Folder already exists.") await expect(saving).resolves.toHaveLength(1);
+        else {
+          await expect(saving).rejects.toThrow(error);
+          expect(vault.createBinary).not.toHaveBeenCalled();
+        }
+      }
+    );
+
+    it(`propagates hidden attachment write failures (${ISSUE})`, async () => {
+      const { app, vault } = makeApp(".");
+      vault.adapter.writeBinary.mockRejectedValueOnce(new Error("disk full"));
+      await expect(
+        prepareChatImagesForSave(app, [{ message: "", content: [IMAGE] }], ".chats/new.md")
+      ).rejects.toThrow("disk full");
+    });
+
+    it.each([
+      ["x-icon", "ico"],
+      ["vnd.microsoft.icon", "ico"],
+      ["svg+xml", "svg"],
+      ["x-ms-bmp", "bmp"],
+      ["vnd.adobe.photoshop", "vndadobephotoshop"],
+    ])(`saves image/%s uploads with a safe %s extension (${ISSUE})`, async (subtype, extension) => {
+      const { app, files } = makeApp();
+      await prepareChatImagesForSave(
+        app,
+        [
+          {
+            message: "",
+            content: [
+              { type: "image_url", image_url: { url: `data:image/${subtype};base64,${DATA}` } },
+            ],
+          },
+        ],
+        "chats/new.md"
+      );
+      expect([...files.keys()][0]).toBe(`attachments/copilot-image-${sha256(DATA)}.${extension}`);
+    });
+
+    it(`accepts unpadded base64 without changing the uploaded bytes (${ISSUE})`, async () => {
+      const { app, files } = makeApp();
+      await prepareChatImagesForSave(
+        app,
+        [
+          {
+            message: "",
+            content: [
+              {
+                type: "image_url",
+                image_url: { url: `data:image/png;base64,${DATA.replace(/=+$/, "")}` },
+              },
+            ],
+          },
+        ],
+        "chats/new.md"
+      );
+      expect(arrayBufferToBase64([...files.values()][0])).toBe(DATA);
     });
 
     it(`reuses attachments within a message and across saves, including filename collisions (${ISSUE})`, async () => {
@@ -195,13 +290,16 @@ describe("chatImagePersistence", () => {
       const prepared = await prepareChatImagesForSave(app, messages, "chats/new.md");
       expect(prepared).toEqual(messages);
       expect(prepared[0]).toBe(messages[0]);
-      expect(vault.getAvailablePathForAttachments).not.toHaveBeenCalled();
+      expect(vault.getConfig).not.toHaveBeenCalled();
     });
 
     it.each([
       "data:image/png;base64,",
       "data:image/png;base64,???",
-      "data:image/x-invalid;base64,AQID",
+      "data:image/png;base64,AAAAA",
+      "data:image/png;base64,AQID=",
+      "data:image/png;base64,AQ=",
+      "data:image/png;base64,AR==",
       "data:image/png;base64,A",
     ])(
       `rejects malformed uploaded image %j without writing an attachment (${ISSUE})`,

--- a/src/utils/chatImagePersistence.ts
+++ b/src/utils/chatImagePersistence.ts
@@ -1,7 +1,15 @@
 import { arrayBufferToBase64, base64ToArrayBuffer } from "@/utils/base64";
 import { sha256 } from "@/utils/hash";
 import { isFileAlreadyExistsError } from "@/utils/vaultAdapterUtils";
-import type { App, Vault } from "obsidian";
+import { normalizePath, type App, type Vault } from "obsidian";
+
+const IMAGE_EXTENSIONS = new Map([
+  ["jpeg", "jpg"],
+  ["svg+xml", "svg"],
+  ["x-icon", "ico"],
+  ["vnd.microsoft.icon", "ico"],
+  ["x-ms-bmp", "bmp"],
+]);
 
 interface MessageWithImages {
   message: string;
@@ -9,11 +17,7 @@ interface MessageWithImages {
 }
 
 interface AttachmentVault extends Vault {
-  getAvailablePathForAttachments(
-    name: string,
-    extension: string,
-    source: { parent: { path: string; getParentPrefix(): string } }
-  ): Promise<string>;
+  getConfig(key: "attachmentFolderPath"): string;
 }
 
 /**
@@ -58,29 +62,52 @@ export async function prepareChatImagesForSave<T extends MessageWithImages>(
       if (!match) throw new Error("Cannot save an invalid uploaded image.");
       const bytes = base64ToArrayBuffer(match[2]);
       const base64 = arrayBufferToBase64(bytes);
-      const extension = match[1].toLowerCase().replace("svg+xml", "svg").replace("jpeg", "jpg");
-      if (!bytes.byteLength || !/^[a-z0-9]+$/.test(extension)) {
+      const subtype = match[1].toLowerCase();
+      // Picker MIME subtypes can contain punctuation without making the upload corrupt.
+      // https://github.com/logancyang/obsidian-copilot/issues/2900
+      const extension = IMAGE_EXTENSIONS.get(subtype) ?? subtype.replace(/[^a-z0-9]/g, "");
+      if (
+        !bytes.byteLength ||
+        !extension ||
+        base64.replace(/=+$/, "") !== match[2].replace(/=+$/, "") ||
+        (match[2].includes("=") && match[2] !== base64)
+      ) {
         throw new Error("Cannot save an invalid uploaded image.");
       }
       const name = `copilot-image-${sha256(base64)}`;
 
-      // FileManager resolves a source by looking up an existing TFile, losing
-      // the destination folder for new or hidden notes. This internal Vault
-      // allocator is the same one FileManager uses; it needs only the source's
-      // parent to honor Obsidian's attachment-folder setting in those cases.
+      // Obsidian's attachment allocator uses cached folders and cannot allocate
+      // inside hidden chat roots. Resolve the same vault setting through the adapter.
       // https://github.com/logancyang/obsidian-copilot/issues/2900
-      let path = await (app.vault as AttachmentVault).getAvailablePathForAttachments(
-        name,
-        extension,
-        {
-          parent: {
-            path: parentPath,
-            getParentPrefix: () => (parentPath ? `${parentPath}/` : ""),
-          },
+      const setting = (app.vault as AttachmentVault).getConfig("attachmentFolderPath");
+      const folder = normalizePath(
+        setting === "." || setting === "./"
+          ? parentPath
+          : setting.startsWith("./")
+            ? `${parentPath}/${setting.slice(2)}`
+            : setting
+      ).replace(/^\/+|\/+$/g, "");
+      const hidden = folder.split("/").some((part) => part.startsWith("."));
+      let current = "";
+      for (const part of folder.split("/").filter(Boolean)) {
+        current = current ? `${current}/${part}` : part;
+        if (!(await app.vault.adapter.exists(current))) {
+          try {
+            if (hidden) await app.vault.adapter.mkdir(current);
+            else await app.vault.createFolder(current);
+          } catch (error) {
+            // Concurrent saves may create the shared attachment folder first.
+            // https://github.com/logancyang/obsidian-copilot/issues/2900
+            if (!isFileAlreadyExistsError(error)) throw error;
+          }
         }
-      );
-      const folder = path.slice(0, Math.max(0, path.lastIndexOf("/")));
+      }
       const prefix = folder ? `${folder}/` : "";
+      let path = `${prefix}${name}.${extension}`;
+      let suffix = 1;
+      while (await app.vault.adapter.exists(path)) {
+        path = `${prefix}${name} ${suffix++}.${extension}`;
+      }
       const candidates = (await app.vault.adapter.list(folder)).files.filter(
         (candidate) =>
           candidate.startsWith(`${prefix}${name}`) && candidate.endsWith(`.${extension}`)
@@ -99,7 +126,15 @@ export async function prepareChatImagesForSave<T extends MessageWithImages>(
       }
       if (!reused) {
         try {
-          await app.vault.createBinary(path, bytes);
+          // Hidden folders are absent from the vault cache. Adapter writes
+          // work there, but must not overwrite an existing attachment.
+          // https://github.com/logancyang/obsidian-copilot/issues/2900
+          if (hidden) {
+            if (await app.vault.adapter.exists(path)) throw new Error("File already exists.");
+            await app.vault.adapter.writeBinary(path, bytes);
+          } else {
+            await app.vault.createBinary(path, bytes);
+          }
         } catch (error) {
           // Concurrent saves can allocate the same path before either writes.
           // Only reuse that winner when its bytes match the uploaded image;

--- a/src/utils/chatImagePersistence.ts
+++ b/src/utils/chatImagePersistence.ts
@@ -1,0 +1,132 @@
+import { arrayBufferToBase64, base64ToArrayBuffer } from "@/utils/base64";
+import { sha256 } from "@/utils/hash";
+import { isFileAlreadyExistsError } from "@/utils/vaultAdapterUtils";
+import type { App, Vault } from "obsidian";
+
+interface MessageWithImages {
+  message: string;
+  content?: unknown[];
+}
+
+interface AttachmentVault extends Vault {
+  getAvailablePathForAttachments(
+    name: string,
+    extension: string,
+    source: { parent: { path: string; getParentPrefix(): string } }
+  ): Promise<string>;
+}
+
+/**
+ * Persist uploaded images before a transcript is written, returning message
+ * copies with vault embeds while leaving the live conversation untouched.
+ * A failed attachment write rejects the save rather than dropping the image.
+ *
+ * @param app - The vault in which the conversation is being saved.
+ * @param messages - Display messages, including their uploaded image data URLs.
+ * @param notePath - Destination transcript path, even when the note does not exist yet.
+ */
+export async function prepareChatImagesForSave<T extends MessageWithImages>(
+  app: App,
+  messages: T[],
+  notePath: string
+): Promise<T[]> {
+  const prepared: T[] = [];
+  const parentPath = notePath.slice(0, Math.max(0, notePath.lastIndexOf("/")));
+
+  for (const message of messages) {
+    const embeds: string[] = [];
+    for (const item of message.content ?? []) {
+      // Only uploaded images belong in the attachment store; remote URLs and
+      // other rich content are not downloads: https://github.com/logancyang/obsidian-copilot/issues/2900
+      if (!item || typeof item !== "object" || !("type" in item) || item.type !== "image_url") {
+        continue;
+      }
+      const image = "image_url" in item ? item.image_url : undefined;
+      if (
+        !image ||
+        typeof image !== "object" ||
+        !("url" in image) ||
+        typeof image.url !== "string"
+      ) {
+        continue;
+      }
+      if (!image.url.startsWith("data:image/")) continue;
+
+      // A corrupt uploaded image must fail the save, not silently disappear:
+      // https://github.com/logancyang/obsidian-copilot/issues/2900
+      const match = /^data:image\/([a-z0-9.+-]+);base64,([A-Za-z0-9+/]+={0,2})$/i.exec(image.url);
+      if (!match) throw new Error("Cannot save an invalid uploaded image.");
+      const bytes = base64ToArrayBuffer(match[2]);
+      const base64 = arrayBufferToBase64(bytes);
+      const extension = match[1].toLowerCase().replace("svg+xml", "svg").replace("jpeg", "jpg");
+      if (!bytes.byteLength || !/^[a-z0-9]+$/.test(extension)) {
+        throw new Error("Cannot save an invalid uploaded image.");
+      }
+      const name = `copilot-image-${sha256(base64)}`;
+
+      // FileManager resolves a source by looking up an existing TFile, losing
+      // the destination folder for new or hidden notes. This internal Vault
+      // allocator is the same one FileManager uses; it needs only the source's
+      // parent to honor Obsidian's attachment-folder setting in those cases.
+      // https://github.com/logancyang/obsidian-copilot/issues/2900
+      let path = await (app.vault as AttachmentVault).getAvailablePathForAttachments(
+        name,
+        extension,
+        {
+          parent: {
+            path: parentPath,
+            getParentPrefix: () => (parentPath ? `${parentPath}/` : ""),
+          },
+        }
+      );
+      const folder = path.slice(0, Math.max(0, path.lastIndexOf("/")));
+      const prefix = folder ? `${folder}/` : "";
+      const candidates = (await app.vault.adapter.list(folder)).files.filter(
+        (candidate) =>
+          candidate.startsWith(`${prefix}${name}`) && candidate.endsWith(`.${extension}`)
+      );
+      let reused = false;
+      for (const candidate of candidates) {
+        // Autosave reuses matching bytes, including collision-suffixed files;
+        // a matching name alone must not embed somebody else's attachment.
+        // Adapter reads also cover hidden conversation/attachment directories.
+        // https://github.com/logancyang/obsidian-copilot/issues/2900
+        if (arrayBufferToBase64(await app.vault.adapter.readBinary(candidate)) === base64) {
+          path = candidate;
+          reused = true;
+          break;
+        }
+      }
+      if (!reused) {
+        try {
+          await app.vault.createBinary(path, bytes);
+        } catch (error) {
+          // Concurrent saves can allocate the same path before either writes.
+          // Only reuse that winner when its bytes match the uploaded image;
+          // otherwise preserve the failure rather than embed another file.
+          // https://github.com/logancyang/obsidian-copilot/issues/2900
+          const existing = isFileAlreadyExistsError(error)
+            ? await app.vault.adapter.readBinary(path).catch(() => null)
+            : null;
+          if (!existing || arrayBufferToBase64(existing) !== base64) throw error;
+        }
+      }
+      // Root-relative Markdown also works when a configured folder contains
+      // characters that terminate wikilinks or Markdown destinations.
+      // https://github.com/logancyang/obsidian-copilot/issues/2900
+      const linkPath = path
+        .split("/")
+        .map(encodeURIComponent)
+        .join("/")
+        .replace(/\(/g, "%28")
+        .replace(/\)/g, "%29");
+      embeds.push(`![](/${linkPath})`);
+    }
+    prepared.push(
+      embeds.length
+        ? { ...message, message: [message.message, ...embeds].filter(Boolean).join("\n\n") }
+        : message
+    );
+  }
+  return prepared;
+}


### PR DESCRIPTION
Relates to #2900

## Why

Saving a conversation currently drops uploaded images, leaving a note that no longer shows what the user asked about.

## What

Quick Chat and Agent Mode saved notes embed uploaded images beside the corresponding message. Image files follow the vault attachment setting and are reused on subsequent saves. An attachment-write failure leaves an existing transcript intact.

## Non goal

Repairing previously saved transcripts or embedding non-image attachments.

## Screenshot

| Before | Quick Chat after | Agent Mode after |
| --- | --- | --- |
| ![Image omitted from saved note](https://github.com/user-attachments/assets/559099ad-f810-474c-b427-c552a31521a7) | ![Quick Chat note with uploaded image](https://github.com/user-attachments/assets/4ea340d8-9bb6-401c-abeb-149a4d87e8c9) | ![Agent Mode note with uploaded image](https://github.com/user-attachments/assets/231b1172-1dc8-42b8-9c6c-9033c2a94727) |

## Risk

**High** because saving writes vault attachments and changes transcript content.

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or visible cosmetic/copy/docs/config change, or deterministic tests cover changed behavior | ✅ | Tests cover both save methods, attachment placement, reuse, malformed data, and write failures |
| A defect would fail CI or be obvious on first use | ✅ | Save regressions are tested; missing images appear when opening the note |
| A revert fully restores prior state, including persisted data | ❌ | Reverting leaves already-created attachments and embeds in the vault |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Uploaded image data is decoded into vault files |
| No public API, plugin API, message, or on-disk contract changes | ❌ | Saved Markdown now contains image embeds |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Saves await attachment writes; a deterministic race test covers concurrent matching uploads |
| No hot-path behavior lacks deterministic coverage | ✅ | Shared helper and both save integrations have unit coverage |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Obsidian's attachment allocation and note rendering are checked in the test vault |

Review: inspect `prepareChatImagesForSave` in `src/utils/chatImagePersistence.ts`, `saveChat` in `src/core/ChatPersistenceManager.ts`, and `saveSession` in `src/agentMode/session/AgentChatPersistenceManager.ts`. Follow the verification below, including the concurrent-save and failure cases. Existing notes remain readable after reverting, but created image files remain.

## Verification

1. In a test vault, upload an image to Quick Chat, save the conversation, and open the saved note. Repeat in Agent Mode. The image should appear under its user message, before the next message.
2. Repeat with attachment settings for the vault root, the same folder as the note, and `./images [review] #1 (test)`. Save again and confirm the image still renders without duplicate attachments.
3. Save two Agent Mode conversations containing the same new image at once. Both notes should save successfully.
4. Run `npm test -- --runInBand chatImagePersistence ChatPersistenceManager AgentChatPersistenceManager` to exercise forced write failures and file collisions. An unsuccessful image write must preserve the previous transcript and must not overwrite unrelated attachment bytes.
