### PR TITLE
Keep agent running state correct after Stop

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -119,6 +119,7 @@ Agent Chat keeps each conversation separate:
 
 - Select **+** for another session. Each tab keeps its own history, draft, attachments, and queued follow-ups.
 - Select **New Chat** to reset the current tab.
+- Select **Stop** to cancel the current turn and discard its queued follow-ups.
 - Use **Recent Chats** from the Agent Chat home screen, or **Chat History** inside a conversation, to resume saved work. The **Recent Chats** list can be scrolled or searched.
 - Add the active note, selected text, other notes, folders, a Copilot Web Viewer tab, or supported images. You can also mention a note with `[[Note title]]`.
 - Hover the context ring beside the send controls to see how much of the model's context window is in use. The ring stays empty until the agent reports usage, and a stopped response keeps the last reported reading. If the connected account reports usage limits, the same panel shows the available limit and reset time.

--- a/src/agentMode/ui/AgentChatInput.test.tsx
+++ b/src/agentMode/ui/AgentChatInput.test.tsx
@@ -3,6 +3,7 @@ import { AgentChatInput } from "@/agentMode/ui/AgentChatInput";
 import { AGENT_PROMPT_SUGGESTIONS } from "@/agentMode/ui/agentPromptSuggestions";
 import type { AgentChatBackend } from "@/agentMode/session/AgentChatBackend";
 import type { AgentInputDraftControls } from "@/agentMode/ui/hooks/useAgentInputDrafts";
+import { useAgentInputDrafts } from "@/agentMode/ui/hooks/useAgentInputDrafts";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { App } from "obsidian";
 import React from "react";
@@ -42,6 +43,7 @@ jest.mock("@/components/chat-components/ChatInput", () => ({
     topRightAccessory?: React.ReactNode;
     placeholderPrompts?: ReadonlyArray<string>;
     handleSendMessage?: () => void;
+    onStopGenerating?: () => void;
   }) => {
     capturedAgentBrands = props.agentBrands;
     capturedTopRightAccessory = props.topRightAccessory;
@@ -51,6 +53,9 @@ jest.mock("@/components/chat-components/ChatInput", () => ({
         {props.topRightAccessory}
         <button type="button" onClick={() => props.handleSendMessage?.()}>
           send
+        </button>
+        <button type="button" onClick={() => props.onStopGenerating?.()}>
+          stop
         </button>
       </>
     );
@@ -71,6 +76,7 @@ jest.mock("@/settings/model", () => ({
     return model._backendId ? `${model._backendId}:${baseKey}` : baseKey;
   },
   useSettingsValue: () => ({}),
+  getSettings: () => ({ debug: false }),
 }));
 /* eslint-enable @eslint-react/hooks-extra/no-unnecessary-use-prefix */
 
@@ -137,7 +143,142 @@ const renderInput = (
   extraProps: Partial<React.ComponentProps<typeof AgentChatInput>> = {}
 ) => render(inputNode(backend, draft, extraProps));
 
+function setupCancellation() {
+  let settleTurn!: () => void;
+  let settleCancel!: () => void;
+  const cancellation = new Promise<void>((resolve) => {
+    settleCancel = resolve;
+  });
+  const backend = {
+    sendMessage: jest.fn(() => ({
+      turn: new Promise<void>((resolve) => {
+        settleTurn = resolve;
+      }),
+    })),
+    cancel: jest.fn(() => {
+      settleTurn();
+      return cancellation;
+    }),
+  } as unknown as AgentChatBackend;
+  let draft!: AgentInputDraftControls;
+  function Composer() {
+    draft = useAgentInputDrafts({
+      activeChatInputId: "input-1",
+      liveChatInputIds: ["input-1"],
+      defaultIncludeActiveNote: false,
+    });
+    return inputNode(backend, draft);
+  }
+  render(<Composer />);
+  return { backend, getDraft: () => draft, settleCancel, settleTurn: () => settleTurn() };
+}
+
 describe("AgentChatInput", () => {
+  describe("handleStopGenerating()", () => {
+    it("discards queued follow-ups before cancellation settles the active turn https://github.com/Brevilabs/obsidian-copilot-private/issues/365", async () => {
+      const { backend, getDraft, settleCancel } = setupCancellation();
+      act(() => getDraft().setInput("first turn"));
+      fireEvent.click(screen.getByText("send"));
+      await waitFor(() => expect(backend.sendMessage).toHaveBeenCalledTimes(1));
+      act(() => getDraft().setInput("queued follow-up"));
+      fireEvent.click(screen.getByText("send"));
+      await waitFor(() => expect(getDraft().queue).toHaveLength(1));
+
+      await act(async () => fireEvent.click(screen.getByText("stop")));
+
+      expect(backend.sendMessage).toHaveBeenCalledTimes(1);
+      expect(getDraft().queue).toHaveLength(0);
+      expect(getDraft().loading).toBe(false);
+      await act(async () => settleCancel());
+    });
+
+    it("keeps a subsequent turn running when the previous cancellation resolves https://github.com/Brevilabs/obsidian-copilot-private/issues/365", async () => {
+      const { backend, getDraft, settleCancel } = setupCancellation();
+      act(() => getDraft().setInput("first turn"));
+      fireEvent.click(screen.getByText("send"));
+      await waitFor(() => expect(backend.sendMessage).toHaveBeenCalledTimes(1));
+      await act(async () => fireEvent.click(screen.getByText("stop")));
+      act(() => getDraft().setInput("new turn after Stop"));
+      fireEvent.click(screen.getByText("send"));
+      await waitFor(() => expect(backend.sendMessage).toHaveBeenCalledTimes(2));
+      expect(getDraft().loading).toBe(true);
+
+      await act(async () => settleCancel());
+
+      expect(getDraft().loading).toBe(true);
+    });
+    it("discards queued follow-ups but keeps the active turn running when cancellation fails https://github.com/Brevilabs/obsidian-copilot-private/issues/365", async () => {
+      const { backend, getDraft, settleTurn } = setupCancellation();
+      jest.mocked(backend.cancel).mockRejectedValueOnce(new Error("Cancellation failed"));
+      act(() => getDraft().setInput("first turn"));
+      fireEvent.click(screen.getByText("send"));
+      await waitFor(() => expect(backend.sendMessage).toHaveBeenCalledTimes(1));
+      act(() => getDraft().setInput("queued follow-up"));
+      fireEvent.click(screen.getByText("send"));
+      await waitFor(() => expect(getDraft().queue).toHaveLength(1));
+
+      await act(async () => fireEvent.click(screen.getByText("stop")));
+
+      expect(getDraft().queue).toHaveLength(0);
+      expect(getDraft().loading).toBe(true);
+      await act(async () => settleTurn());
+      expect(getDraft().loading).toBe(false);
+      expect(backend.sendMessage).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("runSend()", () => {
+    it("sends queued follow-ups when the active turn finishes normally", async () => {
+      const { backend, getDraft, settleTurn } = setupCancellation();
+      act(() => getDraft().setInput("first turn"));
+      fireEvent.click(screen.getByText("send"));
+      await waitFor(() => expect(backend.sendMessage).toHaveBeenCalledTimes(1));
+      act(() => getDraft().setInput("queued follow-up"));
+      fireEvent.click(screen.getByText("send"));
+      await waitFor(() => expect(getDraft().queue).toHaveLength(1));
+
+      await act(async () => settleTurn());
+
+      expect(backend.sendMessage).toHaveBeenCalledTimes(2);
+      expect(getDraft().queue).toHaveLength(0);
+      expect(getDraft().loading).toBe(true);
+      await act(async () => settleTurn());
+      expect(getDraft().loading).toBe(false);
+    });
+    it("regression: clears draft.loading when the turn resolves after the composer unmounted", async () => {
+      // First send from a landing: the user message lands, AgentHome flips
+      // landing→conversation, and the composer remounts mid-turn. The unmounting
+      // instance's runSend must still clear the shared draft's loading flag,
+      // or the Thinking spinner / stop button stick forever (#stuck-thinking).
+      let resolveTurn!: () => void;
+      const turn = new Promise<void>((resolve) => {
+        resolveTurn = resolve;
+      });
+      const backend = {
+        sendMessage: jest.fn(() => ({ turn })),
+        cancel: jest.fn(),
+      } as unknown as AgentChatBackend;
+      const draft = makeDraft();
+
+      const { unmount } = renderInput(backend, draft);
+      fireEvent.click(screen.getByText("send"));
+
+      await waitFor(() => expect(draft.setLoading).toHaveBeenCalledWith(true));
+      expect(backend.sendMessage).toHaveBeenCalledTimes(1);
+
+      // The landing→conversation flip unmounts this composer instance while the
+      // turn is still in flight.
+      unmount();
+
+      await act(async () => {
+        resolveTurn();
+        await turn;
+      });
+
+      await waitFor(() => expect(draft.setLoading).toHaveBeenCalledWith(false));
+    });
+  });
+
   describe("identity and agent-mention gate", () => {
     beforeEach(() => {
       capturedAgentBrands = undefined;
@@ -207,41 +348,6 @@ describe("AgentChatInput", () => {
       );
       view.rerender(inputNode(chat, makeDraft({ input: "" }), { isLanding: true }));
       expect(capturedPlaceholderPrompts).toBe(AGENT_PROMPT_SUGGESTIONS);
-    });
-  });
-
-  describe("turn-completion loading reset", () => {
-    it("regression: clears draft.loading when the turn resolves after the composer unmounted", async () => {
-      // First send from a landing: the user message lands, AgentHome flips
-      // landing→conversation, and the composer remounts mid-turn. The unmounting
-      // instance's runSend must still clear the shared draft's loading flag,
-      // or the Thinking spinner / stop button stick forever (#stuck-thinking).
-      let resolveTurn!: () => void;
-      const turn = new Promise<void>((resolve) => {
-        resolveTurn = resolve;
-      });
-      const backend = {
-        sendMessage: jest.fn(() => ({ turn })),
-        cancel: jest.fn(),
-      } as unknown as AgentChatBackend;
-      const draft = makeDraft();
-
-      const { unmount } = renderInput(backend, draft);
-      fireEvent.click(screen.getByText("send"));
-
-      await waitFor(() => expect(draft.setLoading).toHaveBeenCalledWith(true));
-      expect(backend.sendMessage).toHaveBeenCalledTimes(1);
-
-      // The landing→conversation flip unmounts this composer instance while the
-      // turn is still in flight.
-      unmount();
-
-      await act(async () => {
-        resolveTurn();
-        await turn;
-      });
-
-      await waitFor(() => expect(draft.setLoading).toHaveBeenCalledWith(false));
     });
   });
 

--- a/src/agentMode/ui/AgentChatInput.tsx
+++ b/src/agentMode/ui/AgentChatInput.tsx
@@ -280,16 +280,16 @@ export const AgentChatInput = memo(function AgentChatInput({
   }, [chatInputId]);
 
   const handleStopGenerating = useCallback(async () => {
+    // Clear follow-ups before cancellation can finish the turn and flush them.
+    // Only runSend owns loading: a late cancel response must not mark a newer turn idle.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/365
+    setQueuedMessages([]);
     try {
       await backend.cancel();
     } catch (e) {
       logError("[AgentMode] cancel failed", e);
     }
-    // Stop = user is bailing on the current turn; don't auto-flush queued
-    // follow-ups they composed while the agent was running.
-    setQueuedMessages([]);
-    setLoading(false);
-  }, [backend, setLoading, setQueuedMessages]);
+  }, [backend, setQueuedMessages]);
 
   const runSend = useCallback(
     async (item: QueuedAgentMessage) => {

--- a/src/agentMode/ui/AgentChatMessages.stories.tsx
+++ b/src/agentMode/ui/AgentChatMessages.stories.tsx
@@ -138,3 +138,26 @@ export const TallQuestion: StoryObj<AgentChatMessagesProps> = {
     />
   ),
 };
+
+/** A new turn keeps its running indicator after the preceding turn was stopped. */
+export const RunningAfterStop: StoryObj<AgentChatMessagesProps> = {
+  args: {
+    ...actionRailArgs,
+    pendingToolPermissions: [],
+    pendingAskUserQuestions: [],
+    messages: [
+      { ...message, id: "first-request", sender: "user", message: "Summarize this note." },
+      {
+        ...message,
+        id: "stopped-response",
+        message: "I will read the note and summarize its main points.",
+        turnStopReason: "cancelled",
+        turnDurationMs: 2300,
+      },
+      { ...message, id: "next-request", sender: "user", message: "List its action items instead." },
+      { ...message, id: "running-response", message: "" },
+    ],
+    isLoading: true,
+  },
+  render: (props) => <QueuedActionsDemo {...actionRailArgs} {...props} />,
+};


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#365

## Why

Pressing Stop with a queued follow-up can send that follow-up, then hide its running timer and Stop button while the agent is still working.

## What

Stop discards queued follow-ups. A new message sent after Stop keeps its running indicator until its own turn ends.

| Action | Result |
| --- | --- |
| Stop with a queued follow-up | Cancel the turn and discard the queue |
| Send again after Stop | Show the timer and Stop button throughout the new turn |
| Let a turn finish normally | Send queued follow-ups automatically |

## Non goal

Changing normal queue flushing or deriving transcript running state from session status.

## Screenshot

Real Obsidian runs with Claude, with only the cancellation acknowledgement delayed by 800 ms to expose the race.

Before: the queued message is sent, but its assistant row and composer appear idle while the session is running.

![Before Stop race](https://github.com/user-attachments/assets/b727256e-5a19-407a-9465-134c735bbbfb)

After: Stop discards the queued message and the cancelled turn becomes idle.

![After Stop clears queue](https://github.com/user-attachments/assets/895c26b1-0ad9-4e17-b38d-0c0ef3580362)

## Risk

**High**, because this changes cancellation ordering on the chat send path.

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Real draft-hook tests cover queued Stop, delayed cancellation, and cancellation failure |
| A defect would fail CI or be obvious on first use | ✅ | Regression tests assert sends and loading state |
| A revert fully restores prior state, including persisted data | ✅ | No persisted format or migration changes |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Stop changes handling of queued messages |
| No public API, plugin API, message, or on-disk contract changes | ✅ | All existing contracts remain intact |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Cancellation no longer performs delayed loading cleanup |
| No hot-path behavior lacks deterministic coverage | ✅ | Tests include normal queue flush and composer unmount cleanup |
| No new dependency | ✅ | Dependencies are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Timer and Stop button are visible in Agent Chat |

Review: inspect `handleStopGenerating` and `runSend` in `src/agentMode/ui/AgentChatInput.tsx`, then follow steps 2–4 below.

## Verification

1. Open Agent Chat with an installed agent and request a long response.
2. While it runs, send a follow-up, then press Stop. The queue should disappear without adding that follow-up to the transcript.
3. Send a new message immediately after Stop. Its timer and Stop button should remain visible until it finishes, including when cancellation acknowledgement is delayed.
4. Queue a follow-up and let the first turn finish normally. The follow-up should send automatically and show its running state. Run the focused `AgentChatInput.test.tsx` suite to exercise cancellation rejection and delayed acknowledgement deterministically.
