### PR TITLE
Keep mobile Quick Chat clear of the keyboard and navigation

### DIFF
--- a/docs/chat-interface.md
+++ b/docs/chat-interface.md
@@ -8,6 +8,8 @@ On desktop, start with **Agent Chat** for multi-step work, reusable Skills, perm
 
 Run **Open Copilot Chat Window** from the command palette. On mobile, the Copilot ribbon button opens Quick Chat because Agent Chat requires desktop Obsidian.
 
+In a mobile workspace tab, the message box stays above the software keyboard and Obsidian's bottom navigation bar as you open and close the keyboard.
+
 ## Choose a model
 
 Use the model picker below the message box. It shows only models enabled under **Settings → Copilot → Basic → Agents → Quick Chat**, including Copilot-hosted and bring-your-own-key models.

--- a/docs/chat-interface.md
+++ b/docs/chat-interface.md
@@ -10,6 +10,8 @@ Run **Open Copilot Chat Window** from the command palette. On mobile, the Copilo
 
 In a mobile workspace tab, the message box stays above the software keyboard and Obsidian's bottom navigation bar as you open and close the keyboard.
 
+In the phone's right sidebar, the message box sits above the keyboard while typing and above the sidebar controls when the keyboard closes.
+
 ## Choose a model
 
 Use the model picker below the message box. It shows only models enabled under **Settings → Copilot → Basic → Agents → Quick Chat**, including Copilot-hosted and bring-your-own-key models.

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -31,6 +31,24 @@ If your plugin does not need CSS, delete this file.
   );
 }
 
+/* Obsidian's phone drawer stays full-height and reserves its own bottom
+   controls. Constrain this host to the keyboard-visible area instead of
+   adding keyboard padding on top of that reservation, which strands the
+   composer above the keyboard. Match the drawer's top safe-area padding.
+   https://github.com/Brevilabs/obsidian-copilot-private/issues/400 */
+.is-phone
+  .workspace-drawer.mod-right
+  .workspace-leaf-content[data-type="copilot-chat-view"]
+  .view-content {
+  max-height: calc(
+    100vh - max(var(--size-4-2), var(--safe-area-inset-top)) - var(--keyboard-height)
+  );
+  padding-bottom: max(
+    var(--size-4-8),
+    calc(var(--safe-area-inset-bottom) - var(--keyboard-height))
+  );
+}
+
 .copilot-openartifacts-modal {
   width: min(32rem, calc(100vw - 2rem));
   min-width: 0;

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -15,6 +15,22 @@ If your plugin does not need CSS, delete this file.
 
 */
 
+/* Obsidian owns this host element and already resizes mobile workspace tabs
+   for the keyboard. Its safe-area bottom padding would reserve that space
+   again and clip Quick Chat's input. Obsidian's view spacing also clears its
+   bottom navigation bar; when unavailable, remove the keyboard contribution
+   from the safe area while retaining the host's usual minimum padding.
+   https://github.com/Brevilabs/obsidian-copilot-private/issues/400 */
+.is-mobile
+  .workspace-tab-container
+  .workspace-leaf-content[data-type="copilot-chat-view"]
+  .view-content {
+  padding-bottom: max(
+    var(--size-4-8),
+    var(--view-bottom-spacing, calc(var(--safe-area-inset-bottom) - var(--keyboard-height)))
+  );
+}
+
 .copilot-openartifacts-modal {
   width: min(32rem, calc(100vw - 2rem));
   min-width: 0;

--- a/src/styles/tailwind.test.ts
+++ b/src/styles/tailwind.test.ts
@@ -3,7 +3,7 @@ import path from "path";
 
 describe("tailwind", () => {
   describe("Quick Chat host padding", () => {
-    it("keeps mobile main-tab input clear of the keyboard and bottom navigation without changing other hosts (https://github.com/Brevilabs/obsidian-copilot-private/issues/400)", () => {
+    it("keeps mobile main-tab input clear of the keyboard and bottom navigation and removes the phone sidebar keyboard gap without changing other hosts (https://github.com/Brevilabs/obsidian-copilot-private/issues/400)", () => {
       const css = readFileSync(path.join(__dirname, "tailwind.css"), "utf8").replace(
         /\/\*[\s\S]*?\*\//g,
         ""
@@ -12,6 +12,11 @@ describe("tailwind", () => {
         css.matchAll(/([^{};]*\[data-type="copilot-chat-view"\][^{};]*)\{([^{}]*)\}/g),
         ([, selector, declarations]) => ({
           selector: selector.trim(),
+          maxHeight: declarations
+            .match(/max-height:\s*([^;]+);/)?.[1]
+            .replace(/\s+/g, " ")
+            .replace(/\( /g, "(")
+            .replace(/ \)/g, ")"),
           value: declarations
             .match(/padding-bottom:\s*([^;]+);/)?.[1]
             .replace(/\s+/g, " ")
@@ -20,21 +25,29 @@ describe("tailwind", () => {
         })
       );
 
-      for (const [mobile, container, viewType, expected] of [
+      for (const [platform, container, viewType, expected] of [
         [
-          true,
+          "is-mobile is-phone",
           "workspace-tab-container",
           "copilot-chat-view",
           [
             "max(var(--size-4-8), var(--view-bottom-spacing, calc(var(--safe-area-inset-bottom) - var(--keyboard-height))))",
           ],
         ],
-        [true, "workspace-drawer-tab-container", "copilot-chat-view", []],
-        [false, "workspace-tab-container", "copilot-chat-view", []],
-        [true, "workspace-tab-container", "markdown", []],
+        [
+          "is-mobile is-phone",
+          "workspace-drawer mod-right",
+          "copilot-chat-view",
+          ["max(var(--size-4-8), calc(var(--safe-area-inset-bottom) - var(--keyboard-height)))"],
+        ],
+        ["is-mobile is-phone", "workspace-drawer mod-left", "copilot-chat-view", []],
+        ["", "workspace-drawer mod-right", "copilot-chat-view", []],
+        ["is-mobile", "workspace-drawer mod-right", "copilot-chat-view", []],
+        ["", "workspace-tab-container", "copilot-chat-view", []],
+        ["is-mobile is-phone", "workspace-tab-container", "markdown", []],
       ] as const) {
         const host = document.createElement("div");
-        host.className = mobile ? "is-mobile" : "";
+        host.className = platform;
         const tab = document.createElement("div");
         tab.className = container;
         const leaf = document.createElement("div");
@@ -49,6 +62,17 @@ describe("tailwind", () => {
         expect(
           paddingRules.filter(({ selector }) => content.matches(selector)).map(({ value }) => value)
         ).toEqual(expected);
+        expect(
+          paddingRules
+            .filter(({ selector }) => content.matches(selector))
+            .map(({ maxHeight }) => maxHeight)
+        ).toEqual(
+          expected.map(() =>
+            container === "workspace-drawer mod-right"
+              ? "calc(100vh - max(var(--size-4-2), var(--safe-area-inset-top)) - var(--keyboard-height))"
+              : undefined
+          )
+        );
       }
     });
   });

--- a/src/styles/tailwind.test.ts
+++ b/src/styles/tailwind.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from "fs";
+import path from "path";
+
+describe("tailwind", () => {
+  describe("Quick Chat host padding", () => {
+    it("keeps mobile main-tab input clear of the keyboard and bottom navigation without changing other hosts (https://github.com/Brevilabs/obsidian-copilot-private/issues/400)", () => {
+      const css = readFileSync(path.join(__dirname, "tailwind.css"), "utf8").replace(
+        /\/\*[\s\S]*?\*\//g,
+        ""
+      );
+      const paddingRules = Array.from(
+        css.matchAll(/([^{};]*\[data-type="copilot-chat-view"\][^{};]*)\{([^{}]*)\}/g),
+        ([, selector, declarations]) => ({
+          selector: selector.trim(),
+          value: declarations
+            .match(/padding-bottom:\s*([^;]+);/)?.[1]
+            .replace(/\s+/g, " ")
+            .replace(/\( /g, "(")
+            .replace(/ \)/g, ")"),
+        })
+      );
+
+      for (const [mobile, container, viewType, expected] of [
+        [
+          true,
+          "workspace-tab-container",
+          "copilot-chat-view",
+          [
+            "max(var(--size-4-8), var(--view-bottom-spacing, calc(var(--safe-area-inset-bottom) - var(--keyboard-height))))",
+          ],
+        ],
+        [true, "workspace-drawer-tab-container", "copilot-chat-view", []],
+        [false, "workspace-tab-container", "copilot-chat-view", []],
+        [true, "workspace-tab-container", "markdown", []],
+      ] as const) {
+        const host = document.createElement("div");
+        host.className = mobile ? "is-mobile" : "";
+        const tab = document.createElement("div");
+        tab.className = container;
+        const leaf = document.createElement("div");
+        leaf.className = "workspace-leaf-content";
+        leaf.dataset.type = viewType;
+        const content = document.createElement("div");
+        content.className = "view-content";
+        host.append(tab);
+        tab.append(leaf);
+        leaf.append(content);
+
+        expect(
+          paddingRules.filter(({ selector }) => content.matches(selector)).map(({ value }) => value)
+        ).toEqual(expected);
+      }
+    });
+  });
+});


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#400

## Why

On iPhone, opening the software keyboard in a Quick Chat workspace tab clips the message box and leaves a large blank area. With the keyboard closed, Obsidian's bottom navigation can cover the composer controls. In the phone's right sidebar, keyboard padding combines with the drawer's reserved controls and leaves a 108 px gap beneath the composer.

## What

Keep the message box and send controls above the keyboard and bottom navigation. In the phone's right sidebar, cap the chat host at the visible keyboard boundary and remove duplicate keyboard padding. Its keyboard-closed spacing is preserved. Desktop, tablet sidebars, and other view types are excluded.

## Non goal

Enabling desktop agents on mobile or redesigning Quick Chat and its message behavior.

## Screenshot

Real iPhone 15 Pro, iOS 26.6.1, Obsidian with Copilot 4.0.7. The final CSS rule was applied through Web Inspector; this is not a deployment of a replacement iPhone plugin bundle.

![Quick Chat composer visible above the native keyboard](https://github.com/user-attachments/assets/73591c8f-3cfd-4d44-be77-cb07781d86d7)

A matching main-tab before capture was not obtained during inspection interruptions. Live measurements provide the comparison:

| State | Before | After |
| --- | --- | --- |
| Keyboard open | Chat height 59 px; input outside clipping boundary | Chat height 342 px; entire composer ends at 465 px, above keyboard at 517 px |
| Keyboard closed | Composer extends beneath navigation | Composer ends at 766 px, above navigation at 768 px |

The phone right sidebar was checked live with the keyboard open and closed. Composer-to-keyboard clearance improved from 108 px to 32 px, and input bottom moved from 374.67 px to 450.67 px. Closed-keyboard input bounds remain 581.67–641.67 px. Sidebar verification used a live QuickTime preview and Web Inspector measurements. The compiled stylesheet was then transferred directly to the phone test vault, backed up, written and read back identically, and loaded by reloading Copilot. With the temporary style removed, the installed CSS reproduced the same keyboard-open measurements. The phone retains its installed Copilot 4.0.7 JavaScript bundle; this was a stylesheet-only test deployment. No additional sidebar image is attached.

## Risk

**Medium**: layout depends on Obsidian's mobile host and needs a real-device check.

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Visible spacing correction; selector tests cover which hosts receive it |
| A defect would fail CI or be obvious on first use | ✅ | An overlap is visible when opening or closing the keyboard |
| A revert fully restores prior state, including persisted data | ✅ | CSS and documentation only; no persisted state changes |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Input events and message submission are unchanged |
| No public API, plugin API, message, or on-disk contract changes | ✅ | No contract changes |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | No runtime TypeScript changes |
| No hot-path behavior lacks deterministic coverage | ✅ | Only static layout changes; native rendering is checked separately |
| No new dependency | ✅ | Dependency manifests unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Quick Chat mobile tab and sidebar spacing |

Review: inspect the mobile Quick Chat host rules in `src/styles/tailwind.css`, then run the following device checks.

## Verification

1. Install the PR build in a test vault on an iPhone. Open Quick Chat in a main workspace tab with an existing conversation.
2. Focus the message box. Confirm the input and send controls remain visible above the software keyboard. Close and reopen the keyboard twice.
3. Close the keyboard and confirm Obsidian's bottom navigation does not cover the message box or its controls.
4. Repeat in the phone right sidebar. Confirm the composer sits just above the keyboard and clears the drawer controls after closing it.
5. Open Quick Chat on desktop and check that its existing spacing and scrolling are unchanged.

Local validation passed: focused Jest, formatting, lint, production build, and Obsidian review. Existing review warnings remain; no new review errors. Selector tests also cover desktop, tablet sidebar, left drawer, and other-view exclusions. Native portrait testing used a real iPhone 15 Pro; landscape and tablet rendering were not physically tested.
