### PR TITLE
Notify about updates on startup

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -73,10 +73,12 @@ jobs:
           node -p "process.platform + ' ' + process.arch" >> windows-test-results/environment.txt
       - run: npm ci
         id: install
-      - name: Run complete native Windows unit suite
+      # The PowerShell wrapper suite runs in publish-windows. Running it again
+      # in the full-suite process intermittently exceeds its subprocess timeout.
+      - name: Run remaining native Windows unit suite
         shell: pwsh
         run: |
-          npm.cmd test -- --runInBand --json --outputFile=windows-test-results/jest.json *> windows-test-results/jest.log
+          npm.cmd test -- --runInBand --testPathIgnorePatterns=openArtifactsPublishWrappers.test.ts --json --outputFile=windows-test-results/jest.json *> windows-test-results/jest.log
           $testExitCode = $LASTEXITCODE
           Get-Content windows-test-results/jest.log
           exit $testExitCode

--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -83,7 +83,7 @@ An empty Agent Chat shows a fixed hint: "Ask anything • @ to add context • /
 
 Agent Chat groups consecutive tool calls and reasoning into a compact activity row. The row reports the total tool commands, distinct files read or edited, and recorded reasoning time. Open it to inspect every step.
 
-Copilot checks for updates in the background when the plugin loads, including when Obsidian starts. If a newer version is available, a notice offers **View release notes**. You can keep using or close Obsidian while the check runs. Copilot reads the version from the published release’s manifest, and Settings and Agent Chat share that check.
+Copilot checks for updates in the background when the plugin loads, including when Obsidian starts. If a newer version is available, a notice offers **View release notes** once per release. This is remembered separately from dismissing the Agent Chat home banner. You can keep using or close Obsidian while the check runs. Copilot reads the version from the published release’s manifest, and Settings and Agent Chat share that check.
 
 Copilot also checks for the latest release whenever you create a new Agent Chat tab with **+**, so you can discover updates without reloading the plugin. When a newer Copilot release is available, the global Agent Chat home shows an update banner along the bottom of the pane. The banner stays above the home tabs when space is tight. Select **See what’s new** to read the release notes, or dismiss the banner for that release. Project homes and active conversations do not show it.
 

--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -83,7 +83,9 @@ An empty Agent Chat shows a fixed hint: "Ask anything • @ to add context • /
 
 Agent Chat groups consecutive tool calls and reasoning into a compact activity row. The row reports the total tool commands, distinct files read or edited, and recorded reasoning time. Open it to inspect every step.
 
-Copilot checks for the latest release whenever you create a new Agent Chat tab with **+**, so you can discover updates without reloading the plugin. When a newer Copilot release is available, the global Agent Chat home shows an update banner along the bottom of the pane. The banner stays above the home tabs when space is tight. Select **See what’s new** to read the release notes, or dismiss the banner for that release. Project homes and active conversations do not show it.
+Copilot checks for updates in the background when the plugin loads, including when Obsidian starts. If a newer version is available, a notice offers **View release notes**. You can keep using or close Obsidian while the check runs. Copilot reads the version from the published release’s manifest, and Settings and Agent Chat share that check.
+
+Copilot also checks for the latest release whenever you create a new Agent Chat tab with **+**, so you can discover updates without reloading the plugin. When a newer Copilot release is available, the global Agent Chat home shows an update banner along the bottom of the pane. The banner stays above the home tabs when space is tight. Select **See what’s new** to read the release notes, or dismiss the banner for that release. Project homes and active conversations do not show it.
 
 ## Models, effort, and permissions
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -816,6 +816,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   inlineEditCommands: [],
   projectList: [],
   lastDismissedVersion: null,
+  lastShownStartupVersion: null,
   passMarkdownImages: true,
   enableAutonomousAgent: true,
   enableCustomPromptTemplating: true,

--- a/src/hooks/useLatestVersion.test.tsx
+++ b/src/hooks/useLatestVersion.test.tsx
@@ -1,4 +1,8 @@
-import { refreshLatestVersion, useLatestVersion } from "@/hooks/useLatestVersion";
+import {
+  refreshLatestVersion,
+  requestLatestRelease,
+  useLatestVersion,
+} from "@/hooks/useLatestVersion";
 import { checkLatestVersion } from "@/utils";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import * as React from "react";
@@ -24,6 +28,23 @@ describe("useLatestVersion", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     refreshLatestVersion();
+  });
+  describe("requestLatestRelease()", () => {
+    it("shares the startup request with settings and chat consumers", async () => {
+      jest
+        .mocked(checkLatestVersion)
+        .mockResolvedValue({ error: null, release: RELEASE, version: RELEASE.version });
+      const startup = requestLatestRelease();
+      expect(requestLatestRelease()).toBe(startup);
+      render(<LatestVersionProbe />);
+      await act(async () => {
+        await expect(startup).resolves.toEqual(RELEASE);
+      });
+      await waitFor(() =>
+        expect(screen.getByRole("status").textContent).toContain(RELEASE.version)
+      );
+      expect(checkLatestVersion).toHaveBeenCalledTimes(1);
+    });
   });
   describe("useLatestVersion()", () => {
     it(`shares one release payload and request across remounted consumers for ${ISSUE_URL}`, async () => {

--- a/src/hooks/useLatestVersion.ts
+++ b/src/hooks/useLatestVersion.ts
@@ -10,7 +10,8 @@ interface UseLatestVersionResult {
 
 let latestReleaseRequest: Promise<LatestRelease | null> | null = null;
 
-function requestLatestRelease(): Promise<LatestRelease | null> {
+/** Shares the latest release request between startup and mounted update surfaces. */
+export function requestLatestRelease(): Promise<LatestRelease | null> {
   // Release surfaces share one request until a new agent tab invalidates it.
   // https://github.com/Brevilabs/obsidian-copilot-private/issues/317
   latestReleaseRequest ??= checkLatestVersion().then((result) => result.release);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import { startReleaseUpdateCheck } from "@/services/releaseUpdateNotice";
 import type { AgentSessionManager, SkillManager } from "@/agentMode";
 // Deep import (not the barrel): these run on the load path for every
 // platform, and the barrel pulls Node-only modules that crash mobile.
@@ -197,6 +198,7 @@ export default class CopilotPlugin extends Plugin {
     resetPersistenceState();
     KeychainService.resetInstance();
     KeychainService.getInstance(this.app);
+    this.register(startReleaseUpdateCheck(this.app, this.manifest.version));
     await this.loadSettings();
     this.modelManagement = createModelManagement({
       app: this.app,

--- a/src/main.ts
+++ b/src/main.ts
@@ -198,7 +198,6 @@ export default class CopilotPlugin extends Plugin {
     resetPersistenceState();
     KeychainService.resetInstance();
     KeychainService.getInstance(this.app);
-    this.register(startReleaseUpdateCheck(this.app, this.manifest.version));
     await this.loadSettings();
     this.modelManagement = createModelManagement({
       app: this.app,
@@ -239,6 +238,16 @@ export default class CopilotPlugin extends Plugin {
         }
       })();
     });
+    // Startup notices remember their own last shown release; Agent Home dismissal
+    // is independent. Hydration and the save subscriber must precede this check.
+    this.register(
+      startReleaseUpdateCheck(
+        this.app,
+        this.manifest.version,
+        getSettings().lastShownStartupVersion,
+        (version) => updateSetting("lastShownStartupVersion", version)
+      )
+    );
     // One-time settings migrations. Runs after the persist subscriber is wired
     // (so every mutation is saved) and after createModelManagement, and before
     // agent/model-discovery init below — so migrated BYOK providers are present

--- a/src/services/releaseUpdateNotice.test.ts
+++ b/src/services/releaseUpdateNotice.test.ts
@@ -1,0 +1,94 @@
+import { startReleaseUpdateCheck } from "@/services/releaseUpdateNotice";
+import { requestLatestRelease } from "@/hooks/useLatestVersion";
+import { ReleaseNotesModal } from "@/components/release-update/ReleaseNotesDialog";
+import { isNewerVersion } from "@/utils";
+import { logWarn } from "@/logger";
+import { App, Notice } from "obsidian";
+
+jest.mock("@/hooks/useLatestVersion", () => ({ requestLatestRelease: jest.fn() }));
+jest.mock("@/components/release-update/ReleaseNotesDialog", () => ({
+  ReleaseNotesModal: jest.fn().mockImplementation(() => ({ open: jest.fn() })),
+}));
+jest.mock("@/logger", () => ({ logWarn: jest.fn() }));
+jest.mock("@/utils", () => ({
+  isNewerVersion: jest.fn(() => true),
+}));
+
+const release = { version: "4.1.0", body: "New features", htmlUrl: "https://github.com/release" };
+const app = { workspace: { containerEl: document.createElement("div") } } as unknown as App;
+const settle = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+describe("releaseUpdateNotice", () => {
+  describe("startReleaseUpdateCheck()", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      jest.mocked(isNewerVersion).mockReturnValue(true);
+      jest.mocked(requestLatestRelease).mockResolvedValue(release);
+    });
+
+    it("returns cleanup immediately and opens matching release notes from the notice CTA", async () => {
+      const cleanup = startReleaseUpdateCheck(app, "4.0.0");
+      expect(typeof cleanup).toBe("function");
+      expect(Notice).not.toHaveBeenCalled();
+      await settle();
+      const fragment = jest.mocked(Notice).mock.calls[0][0] as DocumentFragment;
+      expect(fragment.textContent).toContain("Copilot 4.1.0 is available.");
+      fragment.querySelector("button")!.click();
+      expect(ReleaseNotesModal).toHaveBeenCalledWith(app, release);
+      const modal = jest.mocked(ReleaseNotesModal).mock.results[0].value as ReleaseNotesModal;
+      expect(modal.open).toHaveBeenCalledTimes(1);
+      cleanup();
+    });
+
+    it.each(["4.1.0", "4.2.0"])("does not notify an installed version of %s", async (version) => {
+      jest.mocked(isNewerVersion).mockReturnValue(false);
+      startReleaseUpdateCheck(app, version);
+      await settle();
+      expect(isNewerVersion).toHaveBeenCalledWith(release.version, version);
+      await settle();
+      expect(Notice).not.toHaveBeenCalled();
+    });
+
+    it("suppresses a response arriving after unload without waiting for the request", async () => {
+      let resolve!: (value: typeof release) => void;
+      jest.mocked(requestLatestRelease).mockReturnValue(
+        new Promise((done) => {
+          resolve = done;
+        })
+      );
+      const cleanup = startReleaseUpdateCheck(app, "4.0.0");
+      expect(cleanup()).toBeUndefined();
+      resolve(release);
+      await settle();
+      expect(Notice).not.toHaveBeenCalled();
+    });
+
+    it("hides an existing notice and disables its CTA on unload", async () => {
+      const cleanup = startReleaseUpdateCheck(app, "4.0.0");
+      await settle();
+      const fragment = jest.mocked(Notice).mock.calls[0][0] as DocumentFragment;
+      cleanup();
+      expect(jest.mocked(Notice).mock.instances[0].hide).toHaveBeenCalledTimes(1);
+      fragment.querySelector("button")!.click();
+      expect(ReleaseNotesModal).not.toHaveBeenCalled();
+    });
+
+    it("does not notify when the version request fails", async () => {
+      jest.mocked(requestLatestRelease).mockResolvedValue(null);
+      startReleaseUpdateCheck(app, "4.0.0");
+      await settle();
+      expect(Notice).not.toHaveBeenCalled();
+    });
+
+    it("handles an unexpected rejection without an unhandled promise", async () => {
+      jest.mocked(requestLatestRelease).mockRejectedValue(new Error("offline"));
+      startReleaseUpdateCheck(app, "4.0.0");
+      await settle();
+      expect(logWarn).toHaveBeenCalled();
+      expect(Notice).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/services/releaseUpdateNotice.test.ts
+++ b/src/services/releaseUpdateNotice.test.ts
@@ -37,7 +37,7 @@ describe("releaseUpdateNotice", () => {
       expect(onShown).not.toHaveBeenCalled();
       await settle();
       const fragment = jest.mocked(Notice).mock.calls[0][0] as DocumentFragment;
-      expect(fragment.textContent).toContain("Copilot 4.1.0 is available.");
+      expect(fragment.textContent).toContain("Copilot 4.1.0 is available");
       fragment.querySelector("button")!.click();
       expect(ReleaseNotesModal).toHaveBeenCalledWith(app, release);
       const modal = jest.mocked(ReleaseNotesModal).mock.results[0].value as ReleaseNotesModal;

--- a/src/services/releaseUpdateNotice.test.ts
+++ b/src/services/releaseUpdateNotice.test.ts
@@ -23,6 +23,7 @@ const settle = async () => {
 
 describe("releaseUpdateNotice", () => {
   describe("startReleaseUpdateCheck()", () => {
+    const onShown = jest.fn<void, [string]>();
     beforeEach(() => {
       jest.clearAllMocks();
       jest.mocked(isNewerVersion).mockReturnValue(true);
@@ -30,9 +31,10 @@ describe("releaseUpdateNotice", () => {
     });
 
     it("returns cleanup immediately and opens matching release notes from the notice CTA", async () => {
-      const cleanup = startReleaseUpdateCheck(app, "4.0.0");
+      const cleanup = startReleaseUpdateCheck(app, "4.0.0", null, onShown);
       expect(typeof cleanup).toBe("function");
       expect(Notice).not.toHaveBeenCalled();
+      expect(onShown).not.toHaveBeenCalled();
       await settle();
       const fragment = jest.mocked(Notice).mock.calls[0][0] as DocumentFragment;
       expect(fragment.textContent).toContain("Copilot 4.1.0 is available.");
@@ -43,13 +45,45 @@ describe("releaseUpdateNotice", () => {
       cleanup();
     });
 
+    it("suppresses a release already shown at startup", async () => {
+      startReleaseUpdateCheck(app, "4.0.0", release.version, onShown);
+      await settle();
+      expect(Notice).not.toHaveBeenCalled();
+      expect(onShown).not.toHaveBeenCalled();
+    });
+
+    it("shows a newer release after an earlier startup notice was recorded", async () => {
+      const cleanup = startReleaseUpdateCheck(app, "4.0.0", "4.0.9", onShown);
+      await settle();
+      expect(Notice).toHaveBeenCalledTimes(1);
+      expect(onShown).toHaveBeenCalledTimes(1);
+      expect(onShown).toHaveBeenCalledWith(release.version);
+      cleanup();
+    });
+
+    it("records the startup version exactly once after showing the notice", async () => {
+      const cleanup = startReleaseUpdateCheck(app, "4.0.0", null, onShown);
+      expect(onShown).not.toHaveBeenCalled();
+      await settle();
+      expect(onShown).toHaveBeenCalledTimes(1);
+      expect(onShown).toHaveBeenCalledWith(release.version);
+      expect(jest.mocked(Notice).mock.invocationCallOrder[0]).toBeLessThan(
+        onShown.mock.invocationCallOrder[0]
+      );
+      const fragment = jest.mocked(Notice).mock.calls[0][0] as DocumentFragment;
+      fragment.querySelector("button")!.click();
+      cleanup();
+      expect(onShown).toHaveBeenCalledTimes(1);
+    });
+
     it.each(["4.1.0", "4.2.0"])("does not notify an installed version of %s", async (version) => {
       jest.mocked(isNewerVersion).mockReturnValue(false);
-      startReleaseUpdateCheck(app, version);
+      startReleaseUpdateCheck(app, version, null, onShown);
       await settle();
       expect(isNewerVersion).toHaveBeenCalledWith(release.version, version);
       await settle();
       expect(Notice).not.toHaveBeenCalled();
+      expect(onShown).not.toHaveBeenCalled();
     });
 
     it("suppresses a response arriving after unload without waiting for the request", async () => {
@@ -59,15 +93,16 @@ describe("releaseUpdateNotice", () => {
           resolve = done;
         })
       );
-      const cleanup = startReleaseUpdateCheck(app, "4.0.0");
+      const cleanup = startReleaseUpdateCheck(app, "4.0.0", null, onShown);
       expect(cleanup()).toBeUndefined();
       resolve(release);
       await settle();
       expect(Notice).not.toHaveBeenCalled();
+      expect(onShown).not.toHaveBeenCalled();
     });
 
     it("hides an existing notice and disables its CTA on unload", async () => {
-      const cleanup = startReleaseUpdateCheck(app, "4.0.0");
+      const cleanup = startReleaseUpdateCheck(app, "4.0.0", null, onShown);
       await settle();
       const fragment = jest.mocked(Notice).mock.calls[0][0] as DocumentFragment;
       cleanup();
@@ -78,17 +113,19 @@ describe("releaseUpdateNotice", () => {
 
     it("does not notify when the version request fails", async () => {
       jest.mocked(requestLatestRelease).mockResolvedValue(null);
-      startReleaseUpdateCheck(app, "4.0.0");
+      startReleaseUpdateCheck(app, "4.0.0", null, onShown);
       await settle();
       expect(Notice).not.toHaveBeenCalled();
+      expect(onShown).not.toHaveBeenCalled();
     });
 
     it("handles an unexpected rejection without an unhandled promise", async () => {
       jest.mocked(requestLatestRelease).mockRejectedValue(new Error("offline"));
-      startReleaseUpdateCheck(app, "4.0.0");
+      startReleaseUpdateCheck(app, "4.0.0", null, onShown);
       await settle();
       expect(logWarn).toHaveBeenCalled();
       expect(Notice).not.toHaveBeenCalled();
+      expect(onShown).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/services/releaseUpdateNotice.ts
+++ b/src/services/releaseUpdateNotice.ts
@@ -30,8 +30,9 @@ export function startReleaseUpdateCheck(
       )
         return;
       const fragment = app.workspace.containerEl.doc.win.createFragment();
-      fragment.createDiv({ text: `Copilot ${release.version} is available.` });
-      const button = fragment.createEl("button", { text: "View release notes" });
+      const content = fragment.createDiv({ cls: "copilot-release-notice" });
+      content.createDiv({ text: `Copilot ${release.version} is available` });
+      const button = content.createEl("button", { text: "View release notes" });
       button.addEventListener("click", () => {
         if (!active) return;
         notice?.hide();

--- a/src/services/releaseUpdateNotice.ts
+++ b/src/services/releaseUpdateNotice.ts
@@ -1,0 +1,34 @@
+import { ReleaseNotesModal } from "@/components/release-update/ReleaseNotesDialog";
+import { requestLatestRelease } from "@/hooks/useLatestVersion";
+import { logWarn } from "@/logger";
+import { isNewerVersion } from "@/utils";
+import { App, Notice } from "obsidian";
+
+/**
+ * Starts a background update check and returns synchronous plugin-unload cleanup.
+ * @param app - Obsidian app that owns the notice and release notes dialog.
+ * @param currentVersion - Installed plugin version to compare with the released manifest.
+ */
+export function startReleaseUpdateCheck(app: App, currentVersion: string): () => void {
+  let active = true;
+  let notice: Notice | undefined;
+  void requestLatestRelease()
+    .then((release) => {
+      // requestUrl cannot be cancelled; an unloaded plugin must not show late UI.
+      if (!active || !release || !isNewerVersion(release.version, currentVersion)) return;
+      const fragment = app.workspace.containerEl.doc.win.createFragment();
+      fragment.createDiv({ text: `Copilot ${release.version} is available.` });
+      const button = fragment.createEl("button", { text: "View release notes" });
+      button.addEventListener("click", () => {
+        if (!active) return;
+        notice?.hide();
+        new ReleaseNotesModal(app, release).open();
+      });
+      notice = new Notice(fragment, 15000);
+    })
+    .catch((error) => logWarn("Copilot update check failed", error));
+  return () => {
+    active = false;
+    notice?.hide();
+  };
+}

--- a/src/services/releaseUpdateNotice.ts
+++ b/src/services/releaseUpdateNotice.ts
@@ -36,7 +36,10 @@ export function startReleaseUpdateCheck(
       content.createDiv({ text: `Copilot ${release.version} is available` });
       const button = content.createEl("button", {
         text: "View release notes",
-        cls: cn(buttonVariants({ variant: "secondary" }), "tw-max-w-full tw-whitespace-normal"),
+        cls: cn(
+          buttonVariants({ variant: "secondary", size: "sm" }),
+          "tw-max-w-full tw-whitespace-normal"
+        ),
       });
       button.addEventListener("click", () => {
         if (!active) return;

--- a/src/services/releaseUpdateNotice.ts
+++ b/src/services/releaseUpdateNotice.ts
@@ -8,14 +8,27 @@ import { App, Notice } from "obsidian";
  * Starts a background update check and returns synchronous plugin-unload cleanup.
  * @param app - Obsidian app that owns the notice and release notes dialog.
  * @param currentVersion - Installed plugin version to compare with the released manifest.
+ * @param lastShownVersion - Release already announced at startup, independent of banner dismissal.
+ * @param onShown - Persists the release version after its notice is displayed.
  */
-export function startReleaseUpdateCheck(app: App, currentVersion: string): () => void {
+export function startReleaseUpdateCheck(
+  app: App,
+  currentVersion: string,
+  lastShownVersion: string | null,
+  onShown: (version: string) => void
+): () => void {
   let active = true;
   let notice: Notice | undefined;
   void requestLatestRelease()
     .then((release) => {
       // requestUrl cannot be cancelled; an unloaded plugin must not show late UI.
-      if (!active || !release || !isNewerVersion(release.version, currentVersion)) return;
+      if (
+        !active ||
+        !release ||
+        release.version === lastShownVersion ||
+        !isNewerVersion(release.version, currentVersion)
+      )
+        return;
       const fragment = app.workspace.containerEl.doc.win.createFragment();
       fragment.createDiv({ text: `Copilot ${release.version} is available.` });
       const button = fragment.createEl("button", { text: "View release notes" });
@@ -25,6 +38,7 @@ export function startReleaseUpdateCheck(app: App, currentVersion: string): () =>
         new ReleaseNotesModal(app, release).open();
       });
       notice = new Notice(fragment, 15000);
+      onShown(release.version);
     })
     .catch((error) => logWarn("Copilot update check failed", error));
   return () => {

--- a/src/services/releaseUpdateNotice.ts
+++ b/src/services/releaseUpdateNotice.ts
@@ -1,5 +1,7 @@
+import { buttonVariants } from "@/components/ui/button";
 import { ReleaseNotesModal } from "@/components/release-update/ReleaseNotesDialog";
 import { requestLatestRelease } from "@/hooks/useLatestVersion";
+import { cn } from "@/lib/utils";
 import { logWarn } from "@/logger";
 import { isNewerVersion } from "@/utils";
 import { App, Notice } from "obsidian";
@@ -32,7 +34,10 @@ export function startReleaseUpdateCheck(
       const fragment = app.workspace.containerEl.doc.win.createFragment();
       const content = fragment.createDiv({ cls: "copilot-release-notice" });
       content.createDiv({ text: `Copilot ${release.version} is available` });
-      const button = content.createEl("button", { text: "View release notes" });
+      const button = content.createEl("button", {
+        text: "View release notes",
+        cls: cn(buttonVariants({ variant: "secondary" }), "tw-max-w-full tw-whitespace-normal"),
+      });
       button.addEventListener("click", () => {
         if (!active) return;
         notice?.hide();

--- a/src/services/settingsPersistence.test.ts
+++ b/src/services/settingsPersistence.test.ts
@@ -418,6 +418,18 @@ describe("settingsPersistence", () => {
   });
 
   describe("persistSettings()", () => {
+    it("round-trips the startup notice marker independently of the Agent Home dismissal", async () => {
+      const { module } = await loadModule();
+      let stored = makeSettings({ lastDismissedVersion: "4.0.9", lastShownStartupVersion: null });
+      const saveData = jest.fn(async (data: CopilotSettings) => {
+        stored = data;
+      });
+      await module.persistSettings({ ...stored, lastShownStartupVersion: "4.1.0" }, saveData);
+      module.resetPersistenceState();
+      const loaded = await module.loadSettingsWithKeychain(APP, stored, saveData, backedUp);
+      expect(loaded.lastShownStartupVersion).toBe("4.1.0");
+      expect(loaded.lastDismissedVersion).toBe("4.0.9");
+    });
     it("tombstones cleared credentials and never writes them to data.json", async () => {
       const { module, keychain } = await loadModule({
         persistSecrets: jest.fn().mockReturnValue({

--- a/src/settings/model.test.ts
+++ b/src/settings/model.test.ts
@@ -699,6 +699,23 @@ describe("sanitizeSettings - docProcessorBackend (v6 field)", () => {
 
 describe("model", () => {
   describe("sanitizeSettings()", () => {
+    it("defaults the startup notice marker without inheriting the Agent Home dismissal", () => {
+      const persisted = { ...DEFAULT_SETTINGS, lastDismissedVersion: "4.1.0" };
+      delete (persisted as Partial<CopilotSettings>).lastShownStartupVersion;
+      const loaded = sanitizeSettings(persisted);
+      expect(loaded.lastShownStartupVersion).toBeNull();
+      expect(loaded.lastDismissedVersion).toBe("4.1.0");
+    });
+
+    it("preserves distinct startup notice and Agent Home dismissal versions", () => {
+      const loaded = sanitizeSettings({
+        ...DEFAULT_SETTINGS,
+        lastDismissedVersion: "4.0.9",
+        lastShownStartupVersion: "4.1.0",
+      });
+      expect(loaded.lastShownStartupVersion).toBe("4.1.0");
+      expect(loaded.lastDismissedVersion).toBe("4.0.9");
+    });
     it.each(["parallel", "exa"] as const)(
       "preserves the %s self-host search provider (https://github.com/Brevilabs/obsidian-copilot-private/issues/285)",
       (provider) => {

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -68,6 +68,7 @@ export interface CopilotSettings {
   defaultModelKey: string;
   contextTurns: number;
   lastDismissedVersion: string | null;
+  lastShownStartupVersion: string | null;
   // DEPRECATED: Do not use this directly, migrated to file-based system prompts
   userSystemPrompt: string;
   openAIProxyBaseUrl: string;
@@ -899,6 +900,7 @@ export function sanitizeSettings(settings: CopilotSettings): CopilotSettings {
   }
 
   const sanitizedSettings: CopilotSettings = { ...settingsToSanitize };
+  sanitizedSettings.lastShownStartupVersion ??= null;
   const sanitizedSettingsRecord = sanitizedSettings as unknown as Record<string, unknown>;
   delete sanitizedSettingsRecord.miyoRemoteVaultPath;
   delete sanitizedSettingsRecord.miyoVaultName;

--- a/src/settings/v2/SettingsMainV2.test.tsx
+++ b/src/settings/v2/SettingsMainV2.test.tsx
@@ -36,9 +36,11 @@ jest.mock("@/settings/skillLoadErrorState", () => ({
   // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook; the name must match the export
   useSkillLoadErrorCount: () => mockSkillLoadErrorCount,
 }));
+let mockLatestVersion: string | null = null;
+let mockHasUpdate = false;
 jest.mock("@/hooks/useLatestVersion", () => ({
   // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook; the name must match the export
-  useLatestVersion: () => ({ latestVersion: null, hasUpdate: false }),
+  useLatestVersion: () => ({ latestVersion: mockLatestVersion, hasUpdate: mockHasUpdate }),
 }));
 jest.mock("@/utils/desktopRuntime", () => ({ isDesktopRuntime: () => true }));
 
@@ -52,7 +54,23 @@ describe("SettingsMainV2", () => {
   describe("SettingsMainV2()", () => {
     beforeEach(() => {
       mockSkillLoadErrorCount = 0;
+      mockLatestVersion = null;
+      mockHasUpdate = false;
       mockSkillManagerRefresh.mockClear();
+    });
+
+    it("shows the installed version and latest version from the shared update hook", () => {
+      mockLatestVersion = "4.1.0";
+      mockHasUpdate = true;
+      render(<SettingsMainV2 plugin={plugin} />);
+      expect(screen.getByText("v1.2.3")).toBeTruthy();
+      expect(screen.getByRole("link", { name: "(Update to v4.1.0)" })).toBeTruthy();
+    });
+
+    it("shows up to date when the shared check finds no newer release", () => {
+      mockLatestVersion = "1.2.3";
+      render(<SettingsMainV2 plugin={plugin} />);
+      expect(screen.getByText("(up to date)")).toBeTruthy();
     });
 
     it("lists the tabs in the agreed order", () => {

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -509,37 +509,10 @@ If your plugin does not need CSS, delete this file.
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: var(--size-4-1);
+  gap: var(--size-4-2);
   font-size: var(--font-ui-medium);
   font-weight: var(--font-medium);
   text-align: left;
-}
-
-.copilot-release-notice button {
-  height: auto;
-  min-height: var(--size-4-8);
-  max-width: 100%;
-  margin: 0;
-  padding: var(--size-4-1) 0;
-  border: 0;
-  border-radius: var(--radius-s);
-  background: transparent;
-  box-shadow: none;
-  color: inherit;
-  font-size: var(--font-ui-small);
-  font-weight: var(--font-normal);
-  text-align: left;
-  white-space: normal;
-  cursor: var(--cursor-link);
-}
-
-.copilot-release-notice button:hover {
-  text-decoration: underline;
-}
-
-.copilot-release-notice button:focus-visible {
-  outline: 2px solid currentcolor;
-  outline-offset: 2px;
 }
 
 .copilot-notice-container {

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -504,6 +504,44 @@ If your plugin does not need CSS, delete this file.
   box-shadow: 0 0 0 2px rgb(0 123 255 / 25%);
 }
 
+/* Obsidian Notice owns this native DOM outside React; inherit its theme-specific foreground. */
+.copilot-release-notice {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--size-4-1);
+  font-size: var(--font-ui-medium);
+  font-weight: var(--font-medium);
+  text-align: left;
+}
+
+.copilot-release-notice button {
+  height: auto;
+  min-height: var(--size-4-8);
+  max-width: 100%;
+  margin: 0;
+  padding: var(--size-4-1) 0;
+  border: 0;
+  border-radius: var(--radius-s);
+  background: transparent;
+  box-shadow: none;
+  color: inherit;
+  font-size: var(--font-ui-small);
+  font-weight: var(--font-normal);
+  text-align: left;
+  white-space: normal;
+  cursor: var(--cursor-link);
+}
+
+.copilot-release-notice button:hover {
+  text-decoration: underline;
+}
+
+.copilot-release-notice button:focus-visible {
+  outline: 2px solid currentcolor;
+  outline-offset: 2px;
+}
+
 .copilot-notice-container {
   display: flex;
   flex-direction: column;

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -2,6 +2,7 @@ import * as Obsidian from "obsidian";
 import { TFile } from "obsidian";
 import {
   checkLatestVersion,
+  isNewerVersion,
   extractNoteFiles,
   extractTemplateNoteFiles,
   formatDateTime,
@@ -346,6 +347,20 @@ describe("getNotesFromTags", () => {
 });
 
 describe("utils", () => {
+  describe("isNewerVersion()", () => {
+    it.each([
+      ["4.0.8", "4.0.7", true],
+      ["4.0.8", "4.0.7-dev.abc", true],
+      ["4.0.8", "4.0.7+build.123", true],
+      ["4.0.7", "4.0.7", false],
+      ["4.0.7", "4.0.7-dev.abc", false],
+      ["4.0.7", "4.0.8", false],
+      ["4.1.0", "4.0.9", true],
+      ["5.0.0", "4.9.9", true],
+    ])("compares release %s with installed %s as %s", (latest, current, expected) => {
+      expect(isNewerVersion(latest, current)).toBe(expected);
+    });
+  });
   describe("checkLatestVersion()", () => {
     const issueUrl = "https://github.com/Brevilabs/obsidian-copilot-private/issues/317";
     const mockedRequestUrl = Obsidian.requestUrl as jest.MockedFunction<typeof Obsidian.requestUrl>;
@@ -354,18 +369,26 @@ describe("utils", () => {
       mockedRequestUrl.mockReset();
     });
 
-    it(`returns the release body and destination from the version-check request for ${issueUrl}`, async () => {
-      mockedRequestUrl.mockResolvedValue({
-        status: 200,
-        text: "",
-        json: {
-          tag_name: "v4.0.4",
-          body: "# Copilot 4.0.4",
-          html_url: "https://github.com/logancyang/obsidian-copilot/releases/tag/4.0.4",
-        },
-        arrayBuffer: new ArrayBuffer(0),
-        headers: {},
-      });
+    const manifestUrl =
+      "https://github.com/logancyang/obsidian-copilot/releases/download/v4.0.4/manifest.json";
+    const response = (json: unknown): Obsidian.RequestUrlResponse => ({
+      status: 200,
+      text: "",
+      json,
+      arrayBuffer: new ArrayBuffer(0),
+      headers: {},
+    });
+    const releaseResponse = {
+      tag_name: "v4.0.3",
+      body: "# Copilot 4.0.4",
+      html_url: "https://github.com/logancyang/obsidian-copilot/releases/tag/v4.0.4",
+      assets: [{ name: "manifest.json", browser_download_url: manifestUrl }],
+    };
+
+    it(`returns release notes with the manifest version even when the tag differs for ${issueUrl}`, async () => {
+      mockedRequestUrl
+        .mockResolvedValueOnce(response(releaseResponse))
+        .mockResolvedValueOnce(response({ version: "4.0.4" }));
 
       await expect(checkLatestVersion()).resolves.toEqual({
         version: "4.0.4",
@@ -373,34 +396,93 @@ describe("utils", () => {
         release: {
           version: "4.0.4",
           body: "# Copilot 4.0.4",
-          htmlUrl: "https://github.com/logancyang/obsidian-copilot/releases/tag/4.0.4",
+          htmlUrl: releaseResponse.html_url,
         },
       });
-      expect(mockedRequestUrl).toHaveBeenCalledTimes(1);
+      expect(mockedRequestUrl).toHaveBeenNthCalledWith(1, {
+        url: "https://api.github.com/repos/logancyang/obsidian-copilot/releases/latest",
+        method: "GET",
+      });
+      expect(mockedRequestUrl).toHaveBeenNthCalledWith(2, {
+        url: manifestUrl,
+        method: "GET",
+      });
+      expect(mockedRequestUrl).toHaveBeenCalledTimes(2);
     });
 
-    it("returns an error when GitHub does not provide a release tag", async () => {
-      mockedRequestUrl.mockResolvedValue({
-        status: 200,
-        text: "",
-        json: {},
-        arrayBuffer: new ArrayBuffer(0),
-        headers: {},
-      });
+    it.each([
+      undefined,
+      [],
+      [{ name: "main.js", browser_download_url: manifestUrl }],
+      [{ name: "manifest.json" }],
+    ])(
+      "returns an error when the release has no downloadable manifest asset (%j)",
+      async (assets) => {
+        mockedRequestUrl.mockResolvedValueOnce(response({ ...releaseResponse, assets }));
+        await expect(checkLatestVersion()).resolves.toEqual({
+          version: null,
+          error: "The latest Copilot release has no manifest.json asset.",
+          release: null,
+        });
+        expect(mockedRequestUrl).toHaveBeenCalledTimes(1);
+      }
+    );
 
+    it.each([undefined, null, 404, "", "v4.0.4", "4.0", "4.0.x", "4.0.4-", "04.0.4"])(
+      "returns an error for malformed manifest version %j",
+      async (version) => {
+        mockedRequestUrl
+          .mockResolvedValueOnce(response(releaseResponse))
+          .mockResolvedValueOnce(response({ version }));
+        await expect(checkLatestVersion()).resolves.toEqual({
+          version: null,
+          error: "The latest Copilot manifest has no valid version.",
+          release: null,
+        });
+      }
+    );
+
+    it.each(["4.0.4-beta.1", "4.0.4+build.123", "4.0.4-beta.1+build.123"])(
+      "preserves valid manifest version suffixes in %s",
+      async (version) => {
+        mockedRequestUrl
+          .mockResolvedValueOnce(response(releaseResponse))
+          .mockResolvedValueOnce(response({ version }));
+        await expect(checkLatestVersion()).resolves.toMatchObject({ version, error: null });
+      }
+    );
+
+    it("keeps the manifest version when optional release notes are absent", async () => {
+      mockedRequestUrl
+        .mockResolvedValueOnce(response({ assets: releaseResponse.assets }))
+        .mockResolvedValueOnce(response({ version: "4.0.4" }));
       await expect(checkLatestVersion()).resolves.toEqual({
-        version: null,
-        error: "The latest Copilot release has no version tag.",
-        release: null,
+        version: "4.0.4",
+        error: null,
+        release: {
+          version: "4.0.4",
+          body: "",
+          htmlUrl: "https://github.com/logancyang/obsidian-copilot/releases/latest",
+        },
       });
     });
 
     it("returns the request error when GitHub cannot be reached", async () => {
       mockedRequestUrl.mockRejectedValue(new Error("offline"));
-
       await expect(checkLatestVersion()).resolves.toEqual({
         version: null,
         error: "offline",
+        release: null,
+      });
+    });
+
+    it("returns the manifest request error without falling back to the release tag", async () => {
+      mockedRequestUrl
+        .mockResolvedValueOnce(response(releaseResponse))
+        .mockRejectedValueOnce(new Error("manifest unavailable"));
+      await expect(checkLatestVersion()).resolves.toEqual({
+        version: null,
+        error: "manifest unavailable",
         release: null,
       });
     });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { compareSemver } from "@/utils/semver";
 // Reason: `buffer` is the npm polyfill (browser-compatible), bundled by esbuild
 // so the same Buffer code path works on desktop (Electron) and mobile (WebView).
 import { Buffer } from "buffer/";
@@ -1010,18 +1011,12 @@ export async function insertIntoEditor(app: App, message: string, replace: boole
 export { debounce } from "@/utils/debounce";
 
 /**
- * Compare two semantic version strings.
- * @returns true if latest version is newer than current version
+ * Whether a released version has a newer major/minor/patch than the installed build.
+ * @param latest - Version from the released plugin manifest.
+ * @param current - Installed manifest version, possibly carrying a development suffix.
  */
 export function isNewerVersion(latest: string, current: string): boolean {
-  const latestParts = latest.split(".").map(Number);
-  const currentParts = current.split(".").map(Number);
-
-  for (let i = 0; i < 3; i++) {
-    if (latestParts[i] > currentParts[i]) return true;
-    if (latestParts[i] < currentParts[i]) return false;
-  }
-  return false;
+  return compareSemver(latest, current) > 0;
 }
 
 const LATEST_RELEASE_API_URL =
@@ -1036,10 +1031,10 @@ export interface LatestRelease {
 interface GitHubReleaseResponse {
   body?: unknown;
   html_url?: unknown;
-  tag_name?: unknown;
+  assets?: { name?: unknown; browser_download_url?: unknown }[];
 }
 
-/** Check the latest GitHub release for both update detection and release-note presentation. */
+/** Read the latest release's installable manifest version and its release notes. */
 export async function checkLatestVersion(): Promise<{
   version: string | null;
   error: string | null;
@@ -1051,8 +1046,29 @@ export async function checkLatestVersion(): Promise<{
       method: "GET",
     });
     const responseRelease = response.json as GitHubReleaseResponse;
-    if (typeof responseRelease.tag_name !== "string") {
-      throw new Error("The latest Copilot release has no version tag.");
+    const manifestAsset = Array.isArray(responseRelease?.assets)
+      ? responseRelease.assets.find((asset) => asset?.name === "manifest.json")
+      : undefined;
+    if (
+      typeof manifestAsset?.browser_download_url !== "string" ||
+      !manifestAsset.browser_download_url
+    ) {
+      throw new Error("The latest Copilot release has no manifest.json asset.");
+    }
+    // The installed plugin gets its version from this asset; a release tag can differ.
+    const manifestResponse = await requestUrl({
+      url: manifestAsset.browser_download_url,
+      method: "GET",
+    });
+    const manifest = manifestResponse.json as { version?: unknown } | null;
+    const version = manifest?.version;
+    if (
+      typeof version !== "string" ||
+      !/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[\da-zA-Z-]+(?:\.[\da-zA-Z-]+)*)?(?:\+[\da-zA-Z-]+(?:\.[\da-zA-Z-]+)*)?$/.test(
+        version
+      )
+    ) {
+      throw new Error("The latest Copilot manifest has no valid version.");
     }
 
     const release: LatestRelease = {
@@ -1061,7 +1077,7 @@ export async function checkLatestVersion(): Promise<{
         typeof responseRelease.html_url === "string"
           ? responseRelease.html_url
           : "https://github.com/logancyang/obsidian-copilot/releases/latest",
-      version: responseRelease.tag_name.replace(/^v/, ""),
+      version,
     };
     return {
       version: release.version,


### PR DESCRIPTION
## Why

Update checks trusted the GitHub release tag instead of the installed artifact's version, and users received no update notice when Obsidian started.

## What

Read the released manifest version for the shared startup, settings, and chat checks; show an unload-safe startup notice once per release with a **View release notes** button, independently of Agent Home banner dismissal, and recognize patch updates for installed development builds. The notice uses a clear announcement and a small, left-aligned secondary button with an 8 px gap and visible keyboard focus.

## Non goal

Prerelease channel selection, automatic installation, or changes to existing chat refresh triggers

## Screenshot

Native Obsidian startup notice, with an older installed version simulated in memory. The announcement is the primary line; the small secondary button sits 8 px below it with a centered label.

| Theme | Before styling | After styling |
| --- | --- | --- |
| Dark | ![Before dark](https://raw.githubusercontent.com/logancyang/obsidian-copilot/ee70ad71a86cd24e4d00521ceb52a37e36b09ed1/test-evidence/pr-3181/before-dark.png) | ![After dark](https://raw.githubusercontent.com/logancyang/obsidian-copilot/145e5cc4e495435f6cb9a087e6362037b1420453/test-evidence/pr-3181/small-dark.png) |
| Light | ![Before light](https://raw.githubusercontent.com/logancyang/obsidian-copilot/ee70ad71a86cd24e4d00521ceb52a37e36b09ed1/test-evidence/pr-3181/before-light.png) | ![After light](https://raw.githubusercontent.com/logancyang/obsidian-copilot/145e5cc4e495435f6cb9a087e6362037b1420453/test-evidence/pr-3181/small-light.png) |

Keyboard focus in a 320 px window:

![Visible keyboard focus on View release notes](https://raw.githubusercontent.com/logancyang/obsidian-copilot/145e5cc4e495435f6cb9a087e6362037b1420453/test-evidence/pr-3181/small-narrow-window.png)

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Manifest validation, shared requests, settings display, notice CTA, and unload cleanup covered |
| A defect would fail CI or be obvious on first use | ✅ | Focused regression tests and visible startup notice |
| A revert fully restores prior state, including persisted data | ✅ | Additive last-shown marker; older builds ignore it without losing user data |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Same public GitHub release source; no user input or credentials |
| No public API, plugin API, message, or on-disk contract changes | ❌ | Optional last-shown startup version persisted; older settings default to no notice shown |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Background request starts during plugin load; cleanup suppresses late responses |
| No hot-path behavior lacks deterministic coverage | ✅ | Deferred-response and unload tests cover the new async path |
| No new dependency | ✅ | Existing comparator and request API reused |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Native notice and release dialog |

Review: inspect `startReleaseUpdateCheck` in `src/services/releaseUpdateNotice.ts`, its registration in `CopilotPlugin.onload` in `src/main.ts`, `requestLatestRelease` in `src/hooks/useLatestVersion.ts`, and `checkLatestVersion`/`isNewerVersion` in `src/utils.ts`, plus the independent marker default in `sanitizeSettings` in `src/settings/model.ts`, including the unload, repeat-notice, and persistence tests.

## Verification

1. Load an older Copilot build in a test vault; expect a startup notice whose **View release notes** button opens the matching release
2. Restart without updating; expect no repeat startup notice, while Agent Home banner dismissal remains independent
3. Open Copilot Settings and create an Agent Chat tab with **+**; expect the same latest version
4. Unload during a pending check, then after the notice appears; expect no late notice and removal of the visible notice
5. Exercise missing or malformed manifests and failed requests; expect no update notice or unhandled rejection

6. Check the notice in light and dark themes and a narrow window. Use Tab to focus **View release notes**, then Enter to open the matching release.
