### PR TITLE
Show and release open agent sessions from chat history

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -123,6 +123,7 @@ Agent Chat keeps each conversation separate:
 - Select **New Chat** to reset the current tab.
 - Select **Stop** to cancel the current turn and discard its queued follow-ups.
 - Use **Recent Chats** from the Agent Chat home screen, or **Chat History** inside a conversation, to resume saved work. The **Recent Chats** list can be scrolled or searched.
+- A subtle dot before a recent chat means its session is still open, even when it is idle. Hover the row and select **Close session** to stop its current turn and release that session. Saved history stays available to reopen, and other chats keep running. If the agent does not support closing individual sessions or release fails, the chat stays marked open with an error.
 - Add the active note, selected text, other notes, folders, a Copilot Web Viewer tab, or supported images. You can also mention a note with `[[Note title]]`.
 - Hover the context ring beside the send controls to see how much of the model's context window is in use. The ring stays empty until the agent reports usage, and a stopped response keeps the last reported reading. If the connected account reports usage limits, the same panel shows the available limit and reset time.
 

--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -123,7 +123,7 @@ Agent Chat keeps each conversation separate:
 - Select **New Chat** to reset the current tab.
 - Select **Stop** to cancel the current turn and discard its queued follow-ups.
 - Use **Recent Chats** from the Agent Chat home screen, or **Chat History** inside a conversation, to resume saved work. The **Recent Chats** list can be scrolled or searched.
-- A subtle dot before a recent chat means its session is still open, even when it is idle. Hover the row and select **Close session** to stop its current turn and release that session. Saved history stays available to reopen, and other chats keep running. If the agent does not support closing individual sessions or release fails, the chat stays marked open with an error.
+- A green dot on the top-right corner of a recent chat’s icon means its session is still open, even when it is idle. Hover the row and select **Close session** to stop its current turn and release that session. Saved history stays available to reopen, and other chats keep running. If the agent does not support closing individual sessions or release fails, the chat stays marked open with an error.
 - Add the active note, selected text, other notes, folders, a Copilot Web Viewer tab, or supported images. You can also mention a note with `[[Note title]]`.
 - Hover the context ring beside the send controls to see how much of the model's context window is in use. The ring stays empty until the agent reports usage, and a stopped response keeps the last reported reading. If the connected account reports usage limits, the same panel shows the available limit and reset time.
 

--- a/src/agentMode/acp/AcpBackendProcess.test.ts
+++ b/src/agentMode/acp/AcpBackendProcess.test.ts
@@ -17,6 +17,7 @@ jest.mock("@/logger", () => ({
 let mockInitializeResult: unknown = { protocolVersion: 1 };
 const mockNewSession = jest.fn(async (..._args: unknown[]) => ({ sessionId: "test-session" }));
 const mockResumeSession = jest.fn(async (..._args: unknown[]) => ({}));
+const mockCloseSession = jest.fn(async (..._args: unknown[]) => ({}));
 const mockLoadSession = jest.fn(async (..._args: unknown[]) => ({}));
 
 jest.mock("@agentclientprotocol/sdk", () => {
@@ -36,6 +37,7 @@ jest.mock("@agentclientprotocol/sdk", () => {
     initialize = jest.fn(async () => mockInitializeResult);
     newSession = (...args: unknown[]) => mockNewSession(...args);
     resumeSession = (...args: unknown[]) => mockResumeSession(...args);
+    closeSession = (...args: unknown[]) => mockCloseSession(...args);
     loadSession = (...args: unknown[]) => mockLoadSession(...args);
     prompt = jest.fn(async () => ({ stopReason: "end_turn" }));
     cancel = jest.fn(async () => undefined);
@@ -115,8 +117,71 @@ describe("AcpBackendProcess", () => {
     mockNewSession.mockResolvedValue({ sessionId: "test-session" });
     mockResumeSession.mockClear();
     mockResumeSession.mockResolvedValue({});
+    mockCloseSession.mockReset();
+    mockCloseSession.mockResolvedValue({});
     mockLoadSession.mockClear();
     mockLoadSession.mockResolvedValue({});
+  });
+
+  describe("closeSession()", () => {
+    it("releases only the requested session and keeps the shared backend running https://github.com/Brevilabs/obsidian-copilot-private/issues/429", async () => {
+      mockInitializeResult = {
+        protocolVersion: 1,
+        agentCapabilities: { sessionCapabilities: { close: {} } },
+      };
+      const backend = new AcpBackendProcess(
+        buildApp(),
+        buildStubBackend(),
+        "1.0.0",
+        buildStubDescriptor()
+      );
+      await backend.start();
+      const sibling = jest.fn();
+      backend.registerSessionHandler("sibling", sibling);
+      await backend.closeSession({ sessionId: "closed" });
+      expect(mockCloseSession).toHaveBeenCalledWith({ sessionId: "closed" });
+      expect(backend.isRunning()).toBe(true);
+      await getVaultClient(backend).sessionUpdate({
+        sessionId: "sibling",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "still here" },
+        },
+      });
+      expect(sibling).toHaveBeenCalledWith(expect.objectContaining({ sessionId: "sibling" }));
+    });
+
+    it("rejects unsupported close without sending a request https://github.com/Brevilabs/obsidian-copilot-private/issues/429", async () => {
+      const backend = new AcpBackendProcess(
+        buildApp(),
+        buildStubBackend(),
+        "1.0.0",
+        buildStubDescriptor()
+      );
+      await backend.start();
+      await expect(backend.closeSession({ sessionId: "open" })).rejects.toThrow(
+        "Agent does not implement session/close"
+      );
+      expect(mockCloseSession).not.toHaveBeenCalled();
+      expect(backend.isRunning()).toBe(true);
+    });
+
+    it("preserves the close failure for callers to keep the session open https://github.com/Brevilabs/obsidian-copilot-private/issues/429", async () => {
+      mockInitializeResult = {
+        protocolVersion: 1,
+        agentCapabilities: { sessionCapabilities: { close: {} } },
+      };
+      mockCloseSession.mockRejectedValueOnce(new Error("backend busy"));
+      const backend = new AcpBackendProcess(
+        buildApp(),
+        buildStubBackend(),
+        "1.0.0",
+        buildStubDescriptor()
+      );
+      await backend.start();
+      await expect(backend.closeSession({ sessionId: "open" })).rejects.toThrow("backend busy");
+      expect(backend.isRunning()).toBe(true);
+    });
   });
 
   describe("start()", () => {

--- a/src/agentMode/acp/AcpBackendProcess.ts
+++ b/src/agentMode/acp/AcpBackendProcess.ts
@@ -71,6 +71,7 @@ import {
  * handler instead of touching reset / probe / getter sites.
  */
 export type AcpCapability =
+  | "session/close"
   | "session/list"
   | "session/resume"
   | "session/load"
@@ -280,6 +281,11 @@ export class AcpBackendProcess implements BackendProcess {
           version: this.clientVersion,
         },
       });
+      // Closing a local chat must not claim to release resources on an unsupported agent.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/429
+      if (init.agentCapabilities?.sessionCapabilities?.close != null) {
+        this.capabilities.set("session/close", true);
+      }
       if (init.agentCapabilities?.sessionCapabilities?.list != null) {
         this.capabilities.set("session/list", true);
       }
@@ -513,6 +519,22 @@ export class AcpBackendProcess implements BackendProcess {
       sessionId,
       update: { sessionUpdate: "plan_usage_update", planUsage: this.planUsageFor(sessionId) },
     });
+  }
+
+  /**
+   * Release backend resources for one session while preserving the shared subprocess.
+   * @param params Identifies the live session to release.
+   */
+  async closeSession(params: { sessionId: SessionId }): Promise<void> {
+    await this.dispatchCapability(
+      "session/close",
+      (connection) => connection.closeSession(params),
+      {
+        mustBeAdvertised: true,
+      }
+    );
+    this.sessionWireState.delete(params.sessionId);
+    this.pendingUpdates.delete(params.sessionId);
   }
 
   async cancel(params: CancelInput): Promise<void> {

--- a/src/agentMode/sdk/ClaudeSdkBackendProcess.test.ts
+++ b/src/agentMode/sdk/ClaudeSdkBackendProcess.test.ts
@@ -292,10 +292,81 @@ describe("ClaudeSdkBackendProcess", () => {
     });
   });
 
+  describe("closeSession()", () => {
+    function makeBackend() {
+      return new ClaudeSdkBackendProcess({
+        pathToClaudeCodeExecutable: "/usr/local/bin/claude",
+        app: { vault: {} } as unknown as import("obsidian").App,
+        clientVersion: "1.2.3",
+        descriptor: fakeDescriptor(),
+      });
+    }
+
+    it("removes an idle session while another session remains usable https://github.com/Brevilabs/obsidian-copilot-private/issues/429", async () => {
+      const backend = makeBackend();
+      const closed = await backend.newSession({ cwd: "/vault" });
+      const sibling = await backend.newSession({ cwd: "/vault" });
+      await backend.closeSession({ sessionId: closed.sessionId });
+      await expect(
+        backend.setSessionModel({ sessionId: closed.sessionId, modelId: "claude-sonnet-4" })
+      ).rejects.toThrow("Unknown session");
+      await expect(
+        backend.setSessionModel({ sessionId: sibling.sessionId, modelId: "claude-sonnet-4" })
+      ).resolves.toBeDefined();
+    });
+
+    it("terminates only the closing session's active query https://github.com/Brevilabs/obsidian-copilot-private/issues/429", async () => {
+      const backend = makeBackend();
+      const first = await backend.newSession({ cwd: "/vault" });
+      const sibling = await backend.newSession({ cwd: "/vault" });
+      const a = makeControlledQuery();
+      const b = makeControlledQuery();
+      const closeA = jest.fn(a.finish);
+      const closeB = jest.fn(b.finish);
+      queryMock
+        .mockReset()
+        .mockReturnValueOnce(Object.assign(a.query, { close: closeA }))
+        .mockReturnValueOnce(Object.assign(b.query, { close: closeB }));
+      const pendingA = backend.prompt({ sessionId: first.sessionId, prompt: [] });
+      const pendingB = backend.prompt({ sessionId: sibling.sessionId, prompt: [] });
+      await flushMicrotasks();
+      await backend.closeSession({ sessionId: first.sessionId });
+      expect(closeA).toHaveBeenCalledTimes(1);
+      expect(closeB).not.toHaveBeenCalled();
+      b.finish();
+      await Promise.all([pendingA, pendingB]);
+      await expect(backend.prompt({ sessionId: first.sessionId, prompt: [] })).rejects.toThrow(
+        "Unknown session"
+      );
+    });
+  });
+
   describe("prompt()", () => {
     beforeEach(() => {
       queryMock.mockReset();
       createSdkMcpServerMock.mockClear();
+    });
+
+    it("does not start a query when its session closes during environment preparation https://github.com/Brevilabs/obsidian-copilot-private/issues/429", async () => {
+      let finishEnvironment!: (env: Record<string, string>) => void;
+      const environment = new Promise<Record<string, string>>((resolve) => {
+        finishEnvironment = resolve;
+      });
+      const backend = new ClaudeSdkBackendProcess({
+        pathToClaudeCodeExecutable: "/usr/local/bin/claude",
+        app: { vault: {} } as unknown as import("obsidian").App,
+        clientVersion: "1.2.3",
+        descriptor: fakeDescriptor(),
+        getManagedEnv: () => environment,
+      });
+      const { sessionId } = await backend.newSession({ cwd: "/vault" });
+      queryMock.mockImplementation(() => makeQuery([resultMessage()]));
+      const pending = backend.prompt({ sessionId, prompt: [] });
+      await flushMicrotasks();
+      await backend.closeSession({ sessionId });
+      finishEnvironment({});
+      await expect(pending).resolves.toEqual({ stopReason: "cancelled" });
+      expect(getPromptQueryCalls()).toHaveLength(0);
     });
 
     it("translates SDK text deltas to agent_message_chunk and resolves with end_turn", async () => {

--- a/src/agentMode/sdk/ClaudeSdkBackendProcess.ts
+++ b/src/agentMode/sdk/ClaudeSdkBackendProcess.ts
@@ -497,6 +497,9 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
     const turnAbort = new AbortController();
     options.abortController = turnAbort;
 
+    // Closing during async preparation must not launch an orphan query afterward.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/429
+    if (this.sessions.get(params.sessionId) !== session) return { stopReason: "cancelled" };
     const q = query({ prompt: promptStream, options });
     session.active = q;
     session.firstPromptStarted = true;
@@ -557,6 +560,18 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
     }
     logSdkOutboundResult("prompt", { stopReason }, params.sessionId);
     return { stopReason };
+  }
+
+  /**
+   * Release one session and its query without touching persisted history or sibling queries.
+   * @param params Identifies the live session to release.
+   */
+  async closeSession(params: { sessionId: SessionId }): Promise<void> {
+    // Interrupt alone leaves the query's resources alive; each SDK query owns its own process.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/429
+    this.sessions.get(params.sessionId)?.active?.close();
+    this.sessions.delete(params.sessionId);
+    this.pendingUpdates.delete(params.sessionId);
   }
 
   async cancel(params: CancelInput): Promise<void> {

--- a/src/agentMode/session/AgentSession.closeSession.test.ts
+++ b/src/agentMode/session/AgentSession.closeSession.test.ts
@@ -1,0 +1,172 @@
+import { AgentSession } from "@/agentMode/session/AgentSession";
+import { MethodUnsupportedError } from "@/agentMode/session/errors";
+import type { BackendProcess, BackendState } from "@/agentMode/session/types";
+
+jest.mock("@/logger", () => ({ logInfo: jest.fn(), logWarn: jest.fn(), logError: jest.fn() }));
+jest.mock("@/settings/model", () => ({ getSettings: jest.fn(() => ({ agentMode: {} })) }));
+jest.mock("@/plusUtils", () => ({
+  ensureMultiAgentEntitlement: jest.fn(async () => true),
+  showMultiAgentUpgradePrompt: jest.fn(),
+}));
+
+// Isolate close lifecycle from the legacy session suite's model/fan-out setup.
+function makeMockBackend() {
+  const prompt = jest.fn(async () => ({ stopReason: "end_turn" as const }));
+  const cancel = jest.fn(async () => undefined);
+  const newSession = jest.fn(
+    async (): Promise<{ sessionId: string; state: BackendState }> => ({
+      sessionId: "acp-1",
+      state: { model: null, mode: null },
+    })
+  );
+  const asBackend = {
+    prompt,
+    cancel,
+    newSession,
+    registerSessionHandler: jest.fn(() => () => {}),
+  } as unknown as BackendProcess;
+  return { asBackend, prompt, cancel, newSession };
+}
+
+describe("AgentSession", () => {
+  describe("AgentSession", () => {
+    describe("releaseBackendSession()", () => {
+      function setup() {
+        const mock = makeMockBackend();
+        const close = jest
+          .fn<Promise<void>, [{ sessionId: string }]>()
+          .mockResolvedValue(undefined);
+        mock.asBackend.closeSession = close;
+        const session = new AgentSession({
+          backend: mock.asBackend,
+          backendSessionId: "acp-1",
+          internalId: "internal-1",
+          backendId: "opencode",
+        });
+        return { mock, close, session };
+      }
+
+      it("blocks new sends before awaiting release and preserves messages through disposal https://github.com/Brevilabs/obsidian-copilot-private/issues/429", async () => {
+        const { session, mock, close } = setup();
+        await session.sendPrompt("saved conversation").turn;
+        const messages = session.store.getDisplayMessages();
+        let finish!: () => void;
+        let markStarted!: () => void;
+        const started = new Promise<void>((resolve) => {
+          markStarted = resolve;
+        });
+        close.mockImplementation(
+          () =>
+            new Promise<void>((resolve) => {
+              finish = resolve;
+              markStarted();
+            })
+        );
+        const release = session.releaseBackendSession();
+        expect(() => session.sendPrompt("racing send")).toThrow("Session is closing");
+        await started;
+        expect(close).toHaveBeenCalledWith({ sessionId: "acp-1" });
+        expect(() => session.sendPrompt("during close")).toThrow("Session is closing");
+        expect(mock.prompt).toHaveBeenCalledTimes(1);
+        expect(session.store.getDisplayMessages()).toEqual(messages);
+        finish();
+        await release;
+        expect(() => session.sendPrompt("after release")).toThrow("Session is closing");
+        await session.dispose();
+        expect(session.getStatus()).toBe("closed");
+        expect(session.store.getDisplayMessages()).toEqual(messages);
+      });
+
+      it("rejects a duplicate close without reopening sending or issuing another RPC https://github.com/Brevilabs/obsidian-copilot-private/issues/429", async () => {
+        const { session, close } = setup();
+        let finish!: () => void;
+        let markStarted!: () => void;
+        const started = new Promise<void>((resolve) => {
+          markStarted = resolve;
+        });
+        const pending = new Promise<void>((resolve) => {
+          finish = resolve;
+        });
+        close
+          .mockImplementationOnce(() => {
+            markStarted();
+            return pending;
+          })
+          .mockRejectedValue(new Error("duplicate RPC"));
+        const first = session.releaseBackendSession();
+        await started;
+        const second = session.releaseBackendSession();
+        try {
+          await expect(second).rejects.toThrow("Session is already closing");
+          expect(close).toHaveBeenCalledTimes(1);
+          expect(() => session.sendPrompt("duplicate close race")).toThrow("Session is closing");
+        } finally {
+          finish();
+          await first;
+        }
+        expect(() => session.sendPrompt("released session")).toThrow("Session is closing");
+      });
+
+      it("waits for startup before releasing its new backend session https://github.com/Brevilabs/obsidian-copilot-private/issues/429", async () => {
+        const mock = makeMockBackend();
+        const close = jest.fn().mockResolvedValue(undefined);
+        mock.asBackend.closeSession = close;
+        let finish!: (result: { sessionId: string; state: BackendState }) => void;
+        mock.newSession.mockReturnValueOnce(
+          new Promise((resolve) => {
+            finish = resolve;
+          })
+        );
+        const session = AgentSession.start({
+          backend: mock.asBackend,
+          cwd: "/vault",
+          internalId: "internal-1",
+          backendId: "opencode",
+        });
+        const release = session.releaseBackendSession();
+        expect(close).not.toHaveBeenCalled();
+        expect(() => session.sendPrompt("during startup")).toThrow("Session is closing");
+        finish({ sessionId: "new-backend-session", state: { model: null, mode: null } });
+        await release;
+        expect(close).toHaveBeenCalledWith({ sessionId: "new-backend-session" });
+      });
+
+      it("allows disposal after failed startup without a backend close request https://github.com/Brevilabs/obsidian-copilot-private/issues/429", async () => {
+        const mock = makeMockBackend();
+        const close = jest.fn().mockResolvedValue(undefined);
+        mock.asBackend.closeSession = close;
+        mock.newSession.mockRejectedValueOnce(new Error("startup failed"));
+        const session = AgentSession.start({
+          backend: mock.asBackend,
+          cwd: "/vault",
+          internalId: "internal-1",
+          backendId: "opencode",
+        });
+        await session.releaseBackendSession();
+        await session.dispose();
+        expect(close).not.toHaveBeenCalled();
+        expect(session.getStatus()).toBe("closed");
+      });
+
+      it("restores sending when backend release fails https://github.com/Brevilabs/obsidian-copilot-private/issues/429", async () => {
+        const { session, close } = setup();
+        close.mockRejectedValueOnce(new Error("backend busy"));
+        await expect(session.releaseBackendSession()).rejects.toThrow("backend busy");
+        await expect(session.sendPrompt("try again").turn).resolves.toBe("end_turn");
+      });
+
+      it.each(["missing", "unsupported"])(
+        "explains %s close support and restores sending https://github.com/Brevilabs/obsidian-copilot-private/issues/429",
+        async (kind) => {
+          const { session, mock, close } = setup();
+          if (kind === "missing") delete mock.asBackend.closeSession;
+          else close.mockRejectedValueOnce(new MethodUnsupportedError("session/close"));
+          await expect(session.releaseBackendSession()).rejects.toThrow(
+            "This agent does not support closing individual sessions."
+          );
+          await expect(session.sendPrompt("still usable").turn).resolves.toBe("end_turn");
+        }
+      );
+    });
+  });
+});

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -326,6 +326,7 @@ export class AgentSession {
   /** Resolves when startup and any initial model selection have settled. */
   readonly ready: Promise<void>;
   private backendSessionId: SessionId | null = null;
+  private closing = false;
   private readonly backend: BackendProcess;
   private readonly cwd: string | null;
   // Resolves to the project's context-materialization result; awaited before
@@ -942,6 +943,9 @@ export class AgentSession {
     promptContent?: PromptContent[],
     mentionedAgents?: ReadonlyArray<BackendId>
   ): { userMessageId: string; turn: Promise<StopReason> } {
+    // A slow backend release must not accept a new turn into the session being closed.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/429
+    if (this.closing) throw new Error("Session is closing");
     const status = this.getStatus();
     if (status === "starting") {
       throw new Error("Session is still starting");
@@ -1363,6 +1367,33 @@ export class AgentSession {
       await this.backend.cancel({ sessionId: this.backendSessionId });
     } catch (e) {
       logWarn(`[AgentMode] cancel notification failed`, e);
+    }
+  }
+
+  /** Release backend resources while blocking new turns until disposal, or restore sending on failure. */
+  async releaseBackendSession(): Promise<void> {
+    // Duplicate closes must not undo the first caller's send guard on failure.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/429
+    if (this.closing) throw new Error("Session is already closing");
+    this.closing = true;
+    try {
+      // Failed startup must still permit closing the local chat.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/429
+      await this.ready.catch(() => {});
+      await this.cancel();
+      // A failed startup owns no backend session to release.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/429
+      if (!this.backendSessionId) return;
+      if (!this.backend.closeSession) throw new MethodUnsupportedError("session/close");
+      await this.backend.closeSession({ sessionId: this.backendSessionId });
+    } catch (error) {
+      // Unsupported agents must leave the chat usable and explain why it remains open.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/429
+      this.closing = false;
+      if (error instanceof MethodUnsupportedError) {
+        throw new Error("This agent does not support closing individual sessions.");
+      }
+      throw error;
     }
   }
 

--- a/src/agentMode/session/AgentSessionManager.test.ts
+++ b/src/agentMode/session/AgentSessionManager.test.ts
@@ -35,6 +35,7 @@ import { getProjectContextSignature } from "@/projects/projectContextSignature";
 import { MethodUnsupportedError } from "@/agentMode/session/errors";
 import { buildCodexModeMapping } from "@/agentMode/backends/codex/codexModeMapping";
 import type {
+  BackendProcess,
   BackendDescriptor,
   BackendId,
   BackendModelCatalog,
@@ -143,6 +144,7 @@ function makeMockBackendProcess() {
     },
     isRunning: () => mockBackendIsRunning,
     shutdown: mockBackendShutdown,
+    closeSession: jest.fn(async (_params: { sessionId: string }) => undefined),
     // Stub the session-event surface so warm-adoption tests can construct
     // a real `AgentSession` via the state-options branch without throwing.
     registerSessionHandler: jest.fn(() => () => {}),
@@ -177,6 +179,7 @@ function makeMockSession(overrides: {
   chatInputId?: string;
   backendSessionId?: string;
   backendId: string;
+  backend?: BackendProcess;
   projectId?: string;
   ready?: Promise<void>;
 }): AgentSession {
@@ -199,6 +202,9 @@ function makeMockSession(overrides: {
     getStatus: () => status,
     store: { getDisplayMessages: () => displayMessages },
     cancel: mockSessionCancel,
+    backend: overrides.backend,
+    backendSessionId: sessionId,
+    releaseBackendSession: AgentSession.prototype.releaseBackendSession,
     dispose: mockSessionDispose,
     setModel: jest.fn(),
     setMode: jest.fn(),
@@ -246,6 +252,7 @@ const sessionCreateSpy = jest.spyOn(AgentSession, "start").mockImplementation((o
     internalId: opts.internalId,
     chatInputId: opts.chatInputId,
     backendId: opts.backendId,
+    backend: opts.backend,
     projectId: opts.projectId,
   })
 );
@@ -351,7 +358,8 @@ function modelCatalog(baseModelId: string): BackendModelCatalog {
 }
 
 function buildManager(
-  modelPreloaderOverrides: Partial<AgentModelPreloader> = {}
+  modelPreloaderOverrides: Partial<AgentModelPreloader> = {},
+  persistenceManager?: ConstructorParameters<typeof AgentSessionManager>[2]["persistenceManager"]
 ): AgentSessionManager {
   const descriptor = buildDescriptor();
   const modelPreloader = {
@@ -371,6 +379,7 @@ function buildManager(
     buildPlugin() as unknown as ConstructorParameters<typeof AgentSessionManager>[1],
     {
       permissionPrompter: jest.fn(),
+      persistenceManager,
       resolveDescriptor: (id) => (id === descriptor.id ? descriptor : undefined),
       modelPreloader: modelPreloader as unknown as ConstructorParameters<
         typeof AgentSessionManager
@@ -400,6 +409,109 @@ beforeEach(() => {
 
 describe("AgentSessionManager", () => {
   describe("AgentSessionManager", () => {
+    describe("getOpenChatIds()", () => {
+      it("includes idle and running conversations and removes released sessions for https://github.com/Brevilabs/obsidian-copilot-private/issues/429", async () => {
+        const mgr = buildManager();
+        const empty = mgr.getOpenChatIds();
+        expect(mgr.getOpenChatIds()).toBe(empty);
+        const idle = await mgr.createSession();
+        const running = await mgr.createSession();
+        getSessionTestHandle(running).setStatus("running");
+        const idleId = buildNativeChatId(idle.backendId, idle.getBackendSessionId()!);
+        const runningId = buildNativeChatId(running.backendId, running.getBackendSessionId()!);
+        expect(mgr.getOpenChatIds()).toEqual(new Set([idleId, runningId]));
+        await mgr.closeChatSession(idleId);
+        expect(mgr.getOpenChatIds()).toEqual(new Set([runningId]));
+      });
+    });
+
+    describe("closeChatSession()", () => {
+      it("closes by saved or stale native identity and retains the saved transcript for https://github.com/Brevilabs/obsidian-copilot-private/issues/429", async () => {
+        for (const useNativeId of [false, true]) {
+          const saved = new Map<string, unknown>();
+          const persistence = {
+            saveSession: jest.fn(async (messages: unknown) => {
+              saved.set("chats/research.md", messages);
+              return { path: "chats/research.md" };
+            }),
+          };
+          const mgr = buildManager(
+            {},
+            persistence as unknown as ConstructorParameters<
+              typeof AgentSessionManager
+            >[2]["persistenceManager"]
+          );
+          const session = await mgr.createSession();
+          getSessionTestHandle(session).setMessages([{ message: "Initial answer" }]);
+          await mgr.saveActiveSession();
+          const nativeId = buildNativeChatId(session.backendId, session.getBackendSessionId()!);
+          expect(mgr.getOpenChatIds()).toEqual(new Set([nativeId, "chats/research.md"]));
+          await mgr.closeChatSession(useNativeId ? nativeId : "chats/research.md");
+          expect(saved.get("chats/research.md")).toEqual([{ message: "Initial answer" }]);
+          expect(mgr.getOpenChatIds().size).toBe(0);
+          expect(mgr.getSessions()).toEqual([]);
+        }
+      });
+
+      it("releases only the selected backend session while preserving another active chat for https://github.com/Brevilabs/obsidian-copilot-private/issues/429", async () => {
+        const mgr = buildManager();
+        const selected = await mgr.createSession();
+        const sibling = await mgr.createSession();
+        const proc = mgr.getBackendProcess(selected.backendId)!;
+        const id = buildNativeChatId(selected.backendId, selected.getBackendSessionId()!);
+        await mgr.closeChatSession(id);
+        expect(proc.closeSession).toHaveBeenCalledWith({
+          sessionId: selected.getBackendSessionId(),
+        });
+        expect(mgr.getSessions()).toEqual([sibling]);
+        expect(mgr.getActiveSession()).toBe(sibling);
+        expect(proc.shutdown).not.toHaveBeenCalled();
+      });
+
+      it("keeps the chat open when backend release fails so the user can retry for https://github.com/Brevilabs/obsidian-copilot-private/issues/429", async () => {
+        const mgr = buildManager();
+        const session = await mgr.createSession();
+        const proc = mgr.getBackendProcess(session.backendId)!;
+        (proc.closeSession as jest.Mock).mockRejectedValueOnce(new Error("release failed"));
+        const id = buildNativeChatId(session.backendId, session.getBackendSessionId()!);
+        await expect(mgr.closeChatSession(id)).rejects.toThrow("release failed");
+        expect(mgr.getOpenChatIds().has(id)).toBe(true);
+        expect(mgr.getSessions()).toEqual([session]);
+        expect(mockSessionDispose).not.toHaveBeenCalled();
+      });
+
+      it("reports unsupported release without hiding the open chat for https://github.com/Brevilabs/obsidian-copilot-private/issues/429", async () => {
+        const mgr = buildManager();
+        const session = await mgr.createSession();
+        mgr.getBackendProcess(session.backendId)!.closeSession = undefined;
+        const id = buildNativeChatId(session.backendId, session.getBackendSessionId()!);
+        await expect(mgr.closeChatSession(id)).rejects.toThrow(/does not support closing/);
+        expect(mgr.getOpenChatIds().has(id)).toBe(true);
+      });
+
+      it("explains unsupported backend capabilities without hiding the open chat for https://github.com/Brevilabs/obsidian-copilot-private/issues/429", async () => {
+        const mgr = buildManager();
+        const session = await mgr.createSession();
+        const proc = mgr.getBackendProcess(session.backendId)!;
+        (proc.closeSession as jest.Mock).mockRejectedValueOnce(
+          new MethodUnsupportedError("session/close")
+        );
+        const id = buildNativeChatId(session.backendId, session.getBackendSessionId()!);
+        await expect(mgr.closeChatSession(id)).rejects.toThrow(
+          "This agent does not support closing individual sessions."
+        );
+        expect(mgr.getOpenChatIds().has(id)).toBe(true);
+      });
+
+      it("leaves sessions unchanged when a stale history row is already closed for https://github.com/Brevilabs/obsidian-copilot-private/issues/429", async () => {
+        const mgr = buildManager();
+        const session = await mgr.createSession();
+        await mgr.closeChatSession("missing.md");
+        expect(mgr.getSessions()).toEqual([session]);
+        expect(mockSessionCancel).not.toHaveBeenCalled();
+      });
+    });
+
     describe("createSession()", () => {
       it("creates a session and sets it as the active one", async () => {
         const mgr = buildManager();

--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -837,6 +837,30 @@ export class AgentSessionManager {
     return ids;
   }
 
+  /** Recent-list identities of sessions still held by Copilot, including idle chats. */
+  getOpenChatIds(): ReadonlySet<string> {
+    const ids = new Set<string>();
+    for (const [internalId, session] of this.sessions) {
+      for (const id of this.recentChatIdsForSession(internalId, session)) ids.add(id);
+    }
+    return ids.size === 0 ? EMPTY_RECENT_CHAT_IDS : ids;
+  }
+
+  /**
+   * Release an open conversation without deleting its saved history.
+   * @param historyId The markdown path or native chat identity shown in history.
+   */
+  async closeChatSession(historyId: string): Promise<void> {
+    for (const [internalId, session] of this.sessions) {
+      // History can still display the native identity after the first autosave.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/429
+      if (this.recentChatIdsForSession(internalId, session).includes(historyId)) {
+        await this.closeSession(internalId, { releaseBackend: true });
+        return;
+      }
+    }
+  }
+
   /**
    * Recent-list ids of pool sessions whose backend turn is currently
    * `"running"`, so the landing rows can swap their relative-time chip for a
@@ -2475,9 +2499,12 @@ export class AgentSessionManager {
    * Cancel any in-flight turn, dispose the session, and remove it from the
    * pool. If the closed session was active, picks the right neighbor (or the
    * last remaining session) as the new active — `null` when none remain.
-   * Backend stays up.
+   * The shared backend process stays up. Explicit resource release retains the
+   * local session on failure so history can still offer a retry.
+   * @param id The internal session identity to remove.
+   * @param options Request backend release for a user-initiated session close.
    */
-  async closeSession(id: string): Promise<void> {
+  async closeSession(id: string, options?: { releaseBackend: boolean }): Promise<void> {
     const session = this.sessions.get(id);
     if (!session) return;
     const closedScope = session.projectId;
@@ -2485,13 +2512,19 @@ export class AgentSessionManager {
     // neighbour pick stays in-scope (never jumps the user to another project).
     const scopeIdsBefore = this.getSessionIdsForScope(closedScope);
     const closedIdx = scopeIdsBefore.indexOf(id);
-    try {
-      await session.cancel();
-    } catch (e) {
-      logWarn(`[AgentMode] cancel during closeSession failed`, e);
+    // User-requested release must block new sends before cancellation and saving.
+    // Internal teardown also works when the whole backend is being restarted.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/429
+    if (options?.releaseBackend) {
+      await session.releaseBackendSession();
+    } else {
+      try {
+        await session.cancel();
+      } catch (e) {
+        logWarn(`[AgentMode] cancel during closeSession failed`, e);
+      }
     }
-    // Drain any pending debounced auto-save before tearing the session
-    // down — otherwise the last few tokens of a fast turn never reach disk.
+    // Drain the final transcript before disposing subscriptions and pending saves.
     await this.drainAutoSave(session);
     try {
       await session.dispose();

--- a/src/agentMode/session/types.ts
+++ b/src/agentMode/session/types.ts
@@ -783,6 +783,12 @@ export interface BackendProcess {
   newSession(params: OpenSessionInput): Promise<OpenSessionOutput>;
   prompt(params: PromptInput): Promise<PromptOutput>;
   cancel(params: CancelInput): Promise<void>;
+  /**
+   * Release one live session without deleting its persisted history or stopping sibling sessions.
+   * Rejects when the backend cannot release it; callers must retain their live session on failure.
+   * @param params Identifies the live session whose resources should be released.
+   */
+  closeSession?(params: { sessionId: SessionId }): Promise<void>;
   setSessionModel(params: { sessionId: SessionId; modelId: string }): Promise<BackendState>;
   isSetSessionModelSupported(): boolean | null;
   setSessionMode(params: { sessionId: SessionId; modeId: string }): Promise<BackendState>;

--- a/src/agentMode/ui/AgentChatControls.test.tsx
+++ b/src/agentMode/ui/AgentChatControls.test.tsx
@@ -2,7 +2,7 @@ import { AgentChatControls } from "@/agentMode/ui/AgentChatControls";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { PLUS_UTM_MEDIUMS } from "@/constants";
 import { navigateToPlusPage, useCanUseMultiAgent } from "@/plusUtils";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import * as React from "react";
 
 jest.mock("@/plusUtils", () => ({
@@ -10,10 +10,11 @@ jest.mock("@/plusUtils", () => ({
   navigateToPlusPage: jest.fn(),
 }));
 
-// Autosave on so the Save-Chat button stays out of the way; this suite is about
-// the left slot's entitlement gate, not the right-side control cluster.
+// Autosave keeps the manual save action out of control-bar fixtures.
 jest.mock("@/settings/model", () => ({
-  useSettingsValue: jest.fn().mockReturnValue({ autosaveChat: true }),
+  useSettingsValue: jest
+    .fn()
+    .mockReturnValue({ autosaveChat: true, chatHistorySortStrategy: "recent" }),
 }));
 
 const mockUseCanUseMultiAgent = useCanUseMultiAgent as jest.MockedFunction<
@@ -37,6 +38,49 @@ describe("AgentChatControls", () => {
   describe("AgentChatControls()", () => {
     beforeEach(() => {
       jest.clearAllMocks();
+    });
+
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/429 exposes live session release through the actual history popover", async () => {
+      const originalObserver = window.IntersectionObserver;
+      window.IntersectionObserver = jest.fn(() => ({
+        observe: jest.fn(),
+        disconnect: jest.fn(),
+      })) as unknown as typeof IntersectionObserver;
+      try {
+        const onCloseSession = jest.fn(async () => {});
+        const onLoadChat = jest.fn(async () => {});
+        const onDeleteChat = jest.fn(async () => {});
+        render(
+          <TooltipProvider>
+            <AgentChatControls
+              chatHistoryItems={[
+                {
+                  id: "research.md",
+                  title: "Research notes",
+                  createdAt: new Date(),
+                  lastAccessedAt: new Date(),
+                },
+              ]}
+              openChatIds={new Set(["research.md"])}
+              onCloseSession={onCloseSession}
+              onLoadChat={onLoadChat}
+              onDeleteChat={onDeleteChat}
+              onUpdateChatTitle={jest.fn(async () => {})}
+            />
+          </TooltipProvider>
+        );
+        fireEvent.click(screen.getByTitle("Chat History"));
+        expect(screen.getByLabelText("Session open")).toBeTruthy();
+        await act(async () =>
+          fireEvent.click(screen.getByRole("button", { name: "Close session" }))
+        );
+        expect(onCloseSession).toHaveBeenCalledWith("research.md");
+        expect(onLoadChat).not.toHaveBeenCalled();
+        expect(onDeleteChat).not.toHaveBeenCalled();
+        expect(screen.getByText("Research notes")).toBeTruthy();
+      } finally {
+        window.IntersectionObserver = originalObserver;
+      }
     });
 
     it("offers the multi-agent upsell when the user is not entitled", () => {

--- a/src/agentMode/ui/AgentChatControls.tsx
+++ b/src/agentMode/ui/AgentChatControls.tsx
@@ -31,6 +31,8 @@ interface AgentChatControlsProps {
   onLoadChat?: (id: string) => Promise<void>;
   onUpdateChatTitle?: (id: string, newTitle: string) => Promise<void>;
   onDeleteChat?: (id: string) => Promise<void>;
+  onCloseSession?: (id: string) => Promise<void>;
+  openChatIds?: ReadonlySet<string>;
   onOpenSourceFile?: (id: string) => Promise<void>;
   /**
    * Context-window usage meter, rendered as the first item in the right-side
@@ -66,6 +68,8 @@ export const AgentChatControls: React.FC<AgentChatControlsProps> = ({
   onLoadChat,
   onUpdateChatTitle,
   onDeleteChat,
+  onCloseSession,
+  openChatIds,
   onOpenSourceFile,
   usageMeter,
   showMultiAgentUpsell = false,
@@ -133,6 +137,8 @@ export const AgentChatControls: React.FC<AgentChatControlsProps> = ({
               chatHistory={chatHistoryItems!}
               onUpdateTitle={onUpdateChatTitle!}
               onDeleteChat={onDeleteChat!}
+              onCloseSession={onCloseSession}
+              openChatIds={openChatIds}
               onLoadChat={onLoadChat}
               onOpenSourceFile={onOpenSourceFile}
               getIcon={resolveHistoryIcon}

--- a/src/agentMode/ui/AgentHome.tsx
+++ b/src/agentMode/ui/AgentHome.tsx
@@ -26,6 +26,7 @@ import { ProjectPickerList } from "@/agentMode/ui/ProjectPickerList";
 import { RelevantNotesShelfPanel } from "@/agentMode/ui/RelevantNotesShelfPanel";
 import { useRelevantNotesPaneOpen } from "@/agentMode/ui/useRelevantNotesPaneOpen";
 import { useAgentChatRuntimeState } from "@/agentMode/ui/hooks/useAgentChatRuntimeState";
+import { useManagerSetSnapshot } from "@/agentMode/ui/hooks/useManagerSetSnapshot";
 import { useAgentHistoryControls } from "@/agentMode/ui/hooks/useAgentHistoryControls";
 import { useAgentInputDrafts } from "@/agentMode/ui/hooks/useAgentInputDrafts";
 import { useAttentionChatIds } from "@/agentMode/ui/hooks/useAttentionChatIds";
@@ -253,6 +254,7 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
     loadChat: handleLoadChat,
     updateChatTitle: handleUpdateChatTitle,
     deleteChat: handleDeleteChat,
+    closeSession: handleCloseSession,
     openSourceFile: handleOpenSourceFile,
   } = useAgentHistoryControls(manager, plugin, activeProjectId);
 
@@ -268,6 +270,7 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
   // running in the background (the session keeps streaming when its tab is
   // parked), and a live done-dot the moment that turn finishes. Shared by both
   // the global and per-project landing shelves.
+  const openChatIds = useManagerSetSnapshot(manager, (m) => m.getOpenChatIds());
   const runningChatIds = useRunningChatIds(manager);
   const attentionChatIds = useAttentionChatIds(manager);
 
@@ -570,6 +573,8 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
             onLoadChat={handleLoadChat}
             onUpdateTitle={handleUpdateChatTitle}
             onDeleteChat={handleDeleteChat}
+            onCloseSession={handleCloseSession}
+            openChatIds={openChatIds}
             onOpenSourceFile={handleOpenSourceFile}
             onLoadHistory={handleLoadChatHistorySafely}
             runningChatIds={runningChatIds}
@@ -629,6 +634,8 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
       handleDeleteChat,
       handleOpenSourceFile,
       handleLoadChatHistorySafely,
+      openChatIds,
+      handleCloseSession,
       runningChatIds,
       attentionChatIds,
       isRelevantNotesPaneOpen,
@@ -662,6 +669,8 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
             onLoadChat={handleLoadChat}
             onUpdateTitle={handleUpdateChatTitle}
             onDeleteChat={handleDeleteChat}
+            onCloseSession={handleCloseSession}
+            openChatIds={openChatIds}
             onOpenSourceFile={handleOpenSourceFile}
             onLoadHistory={handleLoadChatHistorySafely}
             runningChatIds={runningChatIds}
@@ -691,6 +700,8 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
       handleDeleteChat,
       handleOpenSourceFile,
       handleLoadChatHistorySafely,
+      openChatIds,
+      handleCloseSession,
       runningChatIds,
       attentionChatIds,
       settings.chatHistorySortStrategy,
@@ -979,6 +990,8 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
                       onLoadChat={handleLoadChat}
                       onUpdateChatTitle={handleUpdateChatTitle}
                       onDeleteChat={handleDeleteChat}
+                      onCloseSession={handleCloseSession}
+                      openChatIds={openChatIds}
                       onOpenSourceFile={handleOpenSourceFile}
                       usageMeter={<AgentContextMeter backend={backend} />}
                       showMultiAgentUpsell

--- a/src/agentMode/ui/AgentTabStrip.test.ts
+++ b/src/agentMode/ui/AgentTabStrip.test.ts
@@ -8,6 +8,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { refreshLatestVersion } from "@/hooks/useLatestVersion";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
+import { Notice } from "obsidian";
 
 jest.mock("@/hooks/useLatestVersion", () => ({ refreshLatestVersion: jest.fn() }));
 
@@ -113,6 +114,46 @@ describe("AgentTabStrip", () => {
   });
 
   describe("AgentTabStrip()", () => {
+    it("requests backend release and reports failed closes without hiding the tab for https://github.com/Brevilabs/obsidian-copilot-private/issues/429", async () => {
+      const session = {
+        internalId: "existing",
+        backendId: "test",
+        subscribe: () => () => {},
+        getLabel: () => "Existing chat",
+        getStatus: () => "idle",
+        getNeedsAttention: () => false,
+      };
+      const manager = {
+        subscribe: () => () => {},
+        getSessionsForScope: () => [session],
+        getActiveProjectId: () => null,
+        getActiveSession: () => session,
+        getIsStarting: () => false,
+        closeSession: jest.fn(async () => {}),
+      };
+      render(
+        React.createElement(
+          TooltipProvider,
+          null,
+          React.createElement(AgentTabStrip, { manager: manager as unknown as AgentSessionManager })
+        )
+      );
+      fireEvent.click(screen.getByRole("button", { name: /Close/ }));
+      await waitFor(() =>
+        expect(manager.closeSession).toHaveBeenCalledWith("existing", { releaseBackend: true })
+      );
+      manager.closeSession.mockRejectedValueOnce(
+        new Error("This agent does not support closing individual sessions.")
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Close session" }));
+      await waitFor(() =>
+        expect(Notice).toHaveBeenCalledWith(
+          "This agent does not support closing individual sessions."
+        )
+      );
+      expect(screen.getByText("Existing chat")).toBeTruthy();
+    });
+
     it("refreshes releases after the new-session button creates a tab for https://github.com/Brevilabs/obsidian-copilot-private/issues/317", async () => {
       const session = {
         internalId: "existing",

--- a/src/agentMode/ui/AgentTabStrip.test.ts
+++ b/src/agentMode/ui/AgentTabStrip.test.ts
@@ -8,7 +8,6 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { refreshLatestVersion } from "@/hooks/useLatestVersion";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
-import { Notice } from "obsidian";
 
 jest.mock("@/hooks/useLatestVersion", () => ({ refreshLatestVersion: jest.fn() }));
 
@@ -114,7 +113,7 @@ describe("AgentTabStrip", () => {
   });
 
   describe("AgentTabStrip()", () => {
-    it("requests backend release and reports failed closes without hiding the tab for https://github.com/Brevilabs/obsidian-copilot-private/issues/429", async () => {
+    it("preserves tab close without requesting backend release for https://github.com/Brevilabs/obsidian-copilot-private/issues/429", async () => {
       const session = {
         internalId: "existing",
         backendId: "test",
@@ -139,19 +138,7 @@ describe("AgentTabStrip", () => {
         )
       );
       fireEvent.click(screen.getByRole("button", { name: /Close/ }));
-      await waitFor(() =>
-        expect(manager.closeSession).toHaveBeenCalledWith("existing", { releaseBackend: true })
-      );
-      manager.closeSession.mockRejectedValueOnce(
-        new Error("This agent does not support closing individual sessions.")
-      );
-      fireEvent.click(screen.getByRole("button", { name: "Close session" }));
-      await waitFor(() =>
-        expect(Notice).toHaveBeenCalledWith(
-          "This agent does not support closing individual sessions."
-        )
-      );
-      expect(screen.getByText("Existing chat")).toBeTruthy();
+      await waitFor(() => expect(manager.closeSession).toHaveBeenCalledWith("existing"));
     });
 
     it("refreshes releases after the new-session button creates a tab for https://github.com/Brevilabs/obsidian-copilot-private/issues/317", async () => {

--- a/src/agentMode/ui/AgentTabStrip.tsx
+++ b/src/agentMode/ui/AgentTabStrip.tsx
@@ -17,7 +17,6 @@ import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManage
 import type { BackendDescriptor } from "@/agentMode/session/types";
 import { Loader2, MoreHorizontal, Plus, X } from "lucide-react";
 import React from "react";
-import { Notice } from "obsidian";
 
 interface Props {
   manager: AgentSessionManager;
@@ -191,12 +190,7 @@ export const AgentTabStrip: React.FC<Props> = ({ manager }) => {
 
   const handleClose = React.useCallback(
     (id: string) => {
-      // An explicit close must release the backend too, not leave an invisible session.
-      // https://github.com/Brevilabs/obsidian-copilot-private/issues/429
-      manager.closeSession(id, { releaseBackend: true }).catch((e) => {
-        logError("[AgentMode] closeSession failed", e);
-        new Notice(e instanceof Error ? e.message : "Could not close session.");
-      });
+      manager.closeSession(id).catch((e) => logError("[AgentMode] closeSession failed", e));
     },
     [manager]
   );

--- a/src/agentMode/ui/AgentTabStrip.tsx
+++ b/src/agentMode/ui/AgentTabStrip.tsx
@@ -17,6 +17,7 @@ import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManage
 import type { BackendDescriptor } from "@/agentMode/session/types";
 import { Loader2, MoreHorizontal, Plus, X } from "lucide-react";
 import React from "react";
+import { Notice } from "obsidian";
 
 interface Props {
   manager: AgentSessionManager;
@@ -190,7 +191,12 @@ export const AgentTabStrip: React.FC<Props> = ({ manager }) => {
 
   const handleClose = React.useCallback(
     (id: string) => {
-      manager.closeSession(id).catch((e) => logError("[AgentMode] closeSession failed", e));
+      // An explicit close must release the backend too, not leave an invisible session.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/429
+      manager.closeSession(id, { releaseBackend: true }).catch((e) => {
+        logError("[AgentMode] closeSession failed", e);
+        new Notice(e instanceof Error ? e.message : "Could not close session.");
+      });
     },
     [manager]
   );

--- a/src/agentMode/ui/GlobalRecentChatsSection.stories.tsx
+++ b/src/agentMode/ui/GlobalRecentChatsSection.stories.tsx
@@ -58,3 +58,25 @@ export const ShortList: StoryObj<GlobalRecentChatsSectionProps> = {
 export const ScrollableList: StoryObj<GlobalRecentChatsSectionProps> = {
   render: renderShelf,
 };
+
+export const OpenSessions: StoryObj<GlobalRecentChatsSectionProps> = {
+  args: {
+    items: items.slice(0, 3).map((item, index) => ({
+      ...item,
+      title: ["Idle session open", "Running session open", "Saved chat, session closed"][index],
+    })),
+    openChatIds: new Set([items[0].id, items[1].id]),
+    runningChatIds: new Set([items[1].id]),
+    onCloseSession: noop,
+  },
+  render: renderShelf,
+};
+
+export const IdleOpenSessions: StoryObj<GlobalRecentChatsSectionProps> = {
+  args: {
+    items: items.slice(0, 5),
+    openChatIds: new Set([items[0].id, items[1].id]),
+    onCloseSession: noop,
+  },
+  render: renderShelf,
+};

--- a/src/agentMode/ui/GlobalRecentChatsSection.stories.tsx
+++ b/src/agentMode/ui/GlobalRecentChatsSection.stories.tsx
@@ -67,6 +67,7 @@ export const OpenSessions: StoryObj<GlobalRecentChatsSectionProps> = {
     })),
     openChatIds: new Set([items[0].id, items[1].id]),
     runningChatIds: new Set([items[1].id]),
+    attentionChatIds: new Set([items[0].id]),
     onCloseSession: noop,
   },
   render: renderShelf,

--- a/src/agentMode/ui/GlobalRecentChatsSection.test.tsx
+++ b/src/agentMode/ui/GlobalRecentChatsSection.test.tsx
@@ -7,9 +7,15 @@ type SectionItems = React.ComponentProps<typeof GlobalRecentChatsSection>["items
 
 const noop = async () => {};
 
-function renderSection(props: Partial<React.ComponentProps<typeof GlobalRecentChatsSection>> = {}) {
+function renderSection(
+  props: Partial<React.ComponentProps<typeof GlobalRecentChatsSection>> & {
+    openChatIds?: ReadonlySet<string>;
+    onCloseSession?: (id: string) => Promise<void>;
+  } = {}
+) {
   return render(
     <GlobalRecentChatsSection
+      {...{ openChatIds: props.openChatIds, onCloseSession: props.onCloseSession }}
       items={props.items ?? []}
       variant={props.variant}
       title={props.title}
@@ -74,6 +80,31 @@ describe("GlobalRecentChatsSection", () => {
   });
 
   describe("GlobalRecentChatsSection()", () => {
+    it("https://github.com/Brevilabs/obsidian-copilot-private/issues/429 shows idle and running open sessions, retaining saved chats after close", async () => {
+      const onLoadChat = jest.fn(noop);
+      const onDeleteChat = jest.fn(noop);
+      const onCloseSession = jest.fn(noop);
+      renderSection({
+        items: [makeItem("idle"), makeItem("running"), makeItem("closed")],
+        openChatIds: new Set(["idle", "running"]),
+        runningChatIds: new Set(["running"]),
+        onCloseSession,
+        onLoadChat,
+        onDeleteChat,
+      });
+      expect(screen.getAllByLabelText("Session open")).toHaveLength(2);
+      const buttons = screen.getAllByRole("button", { name: "Close session" });
+      expect(buttons).toHaveLength(2);
+      fireEvent.keyDown(buttons[0], { key: "Enter" });
+      await act(async () => {
+        fireEvent.click(buttons[0]);
+      });
+      expect(onCloseSession).toHaveBeenCalledTimes(1);
+      expect(onLoadChat).not.toHaveBeenCalled();
+      expect(onDeleteChat).not.toHaveBeenCalled();
+      expect(screen.getByText("Chat idle")).toBeTruthy();
+    });
+
     it("defaults to the global empty-state copy", () => {
       renderSection();
       expect(screen.getByText("No recent chats")).toBeTruthy();

--- a/src/agentMode/ui/GlobalRecentChatsSection.tsx
+++ b/src/agentMode/ui/GlobalRecentChatsSection.tsx
@@ -1,3 +1,7 @@
+import {
+  OpenSessionIndicator,
+  CloseSessionButton,
+} from "@/components/chat-components/ui/OpenSessionControls";
 import { backendRegistry } from "@/agentMode/backends/registry";
 import { AgentHomePreviewList } from "@/agentMode/ui/AgentHomeSection";
 import { RecentChatProjectBadge, RecentChatTitle } from "@/agentMode/ui/RecentChatTitle";
@@ -59,6 +63,8 @@ interface GlobalRecentChatsSectionProps {
    * rows swap their relative-time chip for a spinner. Omitted means "none".
    */
   runningChatIds?: ReadonlySet<string>;
+  openChatIds?: ReadonlySet<string>;
+  onCloseSession?: (id: string) => Promise<void>;
   /**
    * Recent-list ids whose live session is flagging needs-attention. OR'd with
    * each item's baked-in `needsAttention` snapshot so the done-dot appears the
@@ -145,6 +151,8 @@ interface RecentChatRowProps {
   onOpenSourceFile: (id: string) => void;
   /** Whether this chat's backend turn is running in the background. */
   isRunning: boolean;
+  isSessionOpen: boolean;
+  onCloseSession?: (id: string) => Promise<void>;
   /** Snapshot ∪ live needs-attention — drives the icon tile's done-dot. */
   hasAttention: boolean;
 }
@@ -172,6 +180,8 @@ const RecentChatRow = memo(function RecentChatRow({
   canOpenSourceFile,
   onOpenSourceFile,
   isRunning,
+  isSessionOpen,
+  onCloseSession,
   hasAttention,
 }: RecentChatRowProps): React.ReactElement {
   const Icon = resolveChatIcon(item) ?? MessageCircle;
@@ -222,6 +232,8 @@ const RecentChatRow = memo(function RecentChatRow({
       }}
     >
       <ChatIconTile Icon={Icon} needsAttention={hasAttention} />
+      {/* Idle backends still hold resources: https://github.com/Brevilabs/obsidian-copilot-private/issues/429 */}
+      {isSessionOpen && <OpenSessionIndicator />}
       <RecentChatTitle title={item.title} />
 
       {/* Relative time by default; a backgrounded running session shows an accent
@@ -278,6 +290,9 @@ const RecentChatRow = memo(function RecentChatRow({
             </>
           ) : (
             <>
+              {isSessionOpen && onCloseSession && (
+                <CloseSessionButton chatId={item.id} onCloseSession={onCloseSession} />
+              )}
               {canOpenSourceFile && (
                 <Button
                   size="sm"
@@ -346,6 +361,8 @@ export const GlobalRecentChatsSection = memo(function GlobalRecentChatsSection({
   onOpenSourceFile,
   onLoadHistory,
   runningChatIds,
+  openChatIds,
+  onCloseSession,
   attentionChatIds,
   projectNamesById,
   sortStrategy = "recent",
@@ -494,6 +511,8 @@ export const GlobalRecentChatsSection = memo(function GlobalRecentChatsSection({
                 canOpenSourceFile={!isNativeChatId(item.id)}
                 onOpenSourceFile={handleOpenSourceFile}
                 isRunning={runningChatIds?.has(item.id) ?? false}
+                isSessionOpen={openChatIds?.has(item.id) ?? false}
+                onCloseSession={onCloseSession}
                 hasAttention={!!item.needsAttention || (attentionChatIds?.has(item.id) ?? false)}
               />
             ))}

--- a/src/agentMode/ui/GlobalRecentChatsSection.tsx
+++ b/src/agentMode/ui/GlobalRecentChatsSection.tsx
@@ -1,7 +1,4 @@
-import {
-  OpenSessionIndicator,
-  CloseSessionButton,
-} from "@/components/chat-components/ui/OpenSessionControls";
+import { CloseSessionButton } from "@/components/chat-components/ui/OpenSessionControls";
 import { backendRegistry } from "@/agentMode/backends/registry";
 import { AgentHomePreviewList } from "@/agentMode/ui/AgentHomeSection";
 import { RecentChatProjectBadge, RecentChatTitle } from "@/agentMode/ui/RecentChatTitle";
@@ -114,17 +111,17 @@ const ChatIconTile = memo(
   ({
     Icon,
     needsAttention,
+    isSessionOpen,
   }: {
     Icon: React.ComponentType<{ className?: string }>;
     needsAttention?: boolean;
+    isSessionOpen?: boolean;
   }) => (
-    <span
-      aria-hidden="true"
-      className="tw-flex tw-size-6 tw-shrink-0 tw-items-center tw-justify-center tw-rounded-md tw-bg-secondary tw-text-muted"
-    >
+    <span className="tw-flex tw-size-6 tw-shrink-0 tw-items-center tw-justify-center tw-rounded-md tw-bg-secondary tw-text-muted">
       <ChatIconWithAttention
         icon={Icon}
         needsAttention={needsAttention}
+        isSessionOpen={isSessionOpen}
         iconClassName="tw-size-4"
       />
     </span>
@@ -231,9 +228,7 @@ const RecentChatRow = memo(function RecentChatRow({
         }
       }}
     >
-      <ChatIconTile Icon={Icon} needsAttention={hasAttention} />
-      {/* Idle backends still hold resources: https://github.com/Brevilabs/obsidian-copilot-private/issues/429 */}
-      {isSessionOpen && <OpenSessionIndicator />}
+      <ChatIconTile Icon={Icon} needsAttention={hasAttention} isSessionOpen={isSessionOpen} />
       <RecentChatTitle title={item.title} />
 
       {/* Relative time by default; a backgrounded running session shows an accent

--- a/src/agentMode/ui/hooks/useAgentHistoryControls.test.tsx
+++ b/src/agentMode/ui/hooks/useAgentHistoryControls.test.tsx
@@ -12,10 +12,12 @@ function makeManager() {
     getChatHistoryItems: jest.fn(async () => [item("a"), item("b")]),
     updateChatTitle: jest.fn(async () => {}),
     deleteChatHistory: jest.fn(async () => {}),
+    closeChatSession: jest.fn(async () => {}),
   } as unknown as AgentSessionManager & {
     getChatHistoryItems: jest.Mock;
     updateChatTitle: jest.Mock;
     deleteChatHistory: jest.Mock;
+    closeChatSession: jest.Mock;
   };
 }
 
@@ -26,167 +28,190 @@ const renderControls = (manager: AgentSessionManager, scope?: string) =>
     initialProps: { s: scope },
   });
 
-describe("useAgentHistoryControls scope", () => {
-  it("regression: the global landing caller (no scope) loads ALL history", async () => {
-    // Reason: the highest-risk regression in PR2a is silently scoping the global
-    // Recent Chats list. Omitting `scope` must keep fetching every chat — the
-    // manager treats `undefined` as the flat all-chats view.
-    const manager = makeManager() as AgentSessionManager & { getChatHistoryItems: jest.Mock };
-    const { result } = renderControls(manager);
-
-    await act(async () => {
-      await result.current.loadChatHistory();
+describe("useAgentHistoryControls", () => {
+  describe("useAgentHistoryControls()", () => {
+    it("closes the selected session without deleting or removing saved history for https://github.com/Brevilabs/obsidian-copilot-private/issues/429", async () => {
+      const manager = makeManager();
+      const { result } = renderControls(manager);
+      await act(async () => {
+        await result.current.loadChatHistory();
+      });
+      await act(async () => {
+        await result.current.closeSession("a");
+      });
+      expect(manager.closeChatSession).toHaveBeenCalledWith("a");
+      expect(manager.deleteChatHistory).not.toHaveBeenCalled();
+      expect(result.current.chatHistoryItems.map((chat) => chat.id)).toEqual(["a", "b"]);
     });
 
-    expect(manager.getChatHistoryItems).toHaveBeenCalledWith(undefined);
-    expect(result.current.chatHistoryItems).toHaveLength(2);
-  });
-
-  it("loads only the active scope's chats when a project scope is passed", async () => {
-    const manager = makeManager() as AgentSessionManager & { getChatHistoryItems: jest.Mock };
-    const { result } = renderControls(manager, "project-1");
-
-    await act(async () => {
-      await result.current.loadChatHistory();
+    it("propagates a failed release to the row's retry control for https://github.com/Brevilabs/obsidian-copilot-private/issues/429", async () => {
+      const manager = makeManager();
+      manager.closeChatSession.mockRejectedValueOnce(new Error("Could not release session"));
+      const { result } = renderControls(manager);
+      await expect(result.current.closeSession("a")).rejects.toThrow("Could not release session");
     });
 
-    expect(manager.getChatHistoryItems).toHaveBeenCalledWith("project-1");
-  });
+    it("regression: the global landing caller (no scope) loads ALL history", async () => {
+      // Reason: the highest-risk regression in PR2a is silently scoping the global
+      // Recent Chats list. Omitting `scope` must keep fetching every chat — the
+      // manager treats `undefined` as the flat all-chats view.
+      const manager = makeManager() as AgentSessionManager & { getChatHistoryItems: jest.Mock };
+      const { result } = renderControls(manager);
 
-  it("GLOBAL_SCOPE behaves like the global all-chats view", async () => {
-    const manager = makeManager() as AgentSessionManager & { getChatHistoryItems: jest.Mock };
-    const { result } = renderControls(manager, GLOBAL_SCOPE);
+      await act(async () => {
+        await result.current.loadChatHistory();
+      });
 
-    await act(async () => {
-      await result.current.loadChatHistory();
+      expect(manager.getChatHistoryItems).toHaveBeenCalledWith(undefined);
+      expect(result.current.chatHistoryItems).toHaveLength(2);
     });
 
-    expect(manager.getChatHistoryItems).toHaveBeenCalledWith(GLOBAL_SCOPE);
-  });
+    it("loads only the active scope's chats when a project scope is passed", async () => {
+      const manager = makeManager() as AgentSessionManager & { getChatHistoryItems: jest.Mock };
+      const { result } = renderControls(manager, "project-1");
 
-  it("hides the previous scope's items on a scope change until the refetch lands", async () => {
-    // Reason: AgentHome feeds one shared hook to both the project-landing Project
-    // Chats and the conversation History popover. The `scope` prop flips
-    // synchronously but the reload is async, so the stored items briefly belong to
-    // the old scope — they must not flash (e.g. another project's chats, or the
-    // global flat view) before the scoped refetch completes.
-    const manager = makeManager() as AgentSessionManager & { getChatHistoryItems: jest.Mock };
-    const { result, rerender } = renderControls(manager, "project-1");
+      await act(async () => {
+        await result.current.loadChatHistory();
+      });
 
-    await act(async () => {
-      await result.current.loadChatHistory();
-    });
-    expect(result.current.chatHistoryItems).toHaveLength(2);
-
-    // Switch project before the new scope's items load → list clears, not stale.
-    rerender({ s: "project-2" });
-    expect(result.current.chatHistoryItems).toHaveLength(0);
-
-    await act(async () => {
-      await result.current.loadChatHistory();
-    });
-    expect(manager.getChatHistoryItems).toHaveBeenLastCalledWith("project-2");
-    expect(result.current.chatHistoryItems).toHaveLength(2);
-  });
-
-  it("drops a stale out-of-order load whose scope was superseded mid-flight", async () => {
-    // Reason: if the scope flips while an older fetch is still in flight and that
-    // older fetch resolves AFTER the newer one, it must not write its stale items
-    // back — otherwise the current scope's list is clobbered by the prior scope's
-    // and sticks (the visible-scope guard would then blank it permanently).
-    const resolvers: Record<string, (items: ChatHistoryItem[]) => void> = {};
-    const manager = {
-      getChatHistoryItems: jest.fn(
-        (s?: string) =>
-          new Promise<ChatHistoryItem[]>((resolve) => {
-            resolvers[s ?? GLOBAL_SCOPE] = resolve;
-          })
-      ),
-      updateChatTitle: jest.fn(async () => {}),
-      deleteChatHistory: jest.fn(async () => {}),
-    } as unknown as AgentSessionManager & { getChatHistoryItems: jest.Mock };
-
-    const { result, rerender } = renderControls(manager, "project-1");
-
-    // Start project-1's load (call A) and leave it pending.
-    let loadA!: Promise<void>;
-    act(() => {
-      loadA = result.current.loadChatHistory();
+      expect(manager.getChatHistoryItems).toHaveBeenCalledWith("project-1");
     });
 
-    // Scope flips to project-2; start its load (call B).
-    rerender({ s: "project-2" });
-    let loadB!: Promise<void>;
-    act(() => {
-      loadB = result.current.loadChatHistory();
+    it("GLOBAL_SCOPE behaves like the global all-chats view", async () => {
+      const manager = makeManager() as AgentSessionManager & { getChatHistoryItems: jest.Mock };
+      const { result } = renderControls(manager, GLOBAL_SCOPE);
+
+      await act(async () => {
+        await result.current.loadChatHistory();
+      });
+
+      expect(manager.getChatHistoryItems).toHaveBeenCalledWith(GLOBAL_SCOPE);
     });
 
-    // B lands first → project-2 items are shown.
-    await act(async () => {
-      resolvers["project-2"]([item("b1"), item("b2")]);
-      await loadB;
-    });
-    expect(result.current.chatHistoryItems).toHaveLength(2);
+    it("hides the previous scope's items on a scope change until the refetch lands", async () => {
+      // Reason: AgentHome feeds one shared hook to both the project-landing Project
+      // Chats and the conversation History popover. The `scope` prop flips
+      // synchronously but the reload is async, so the stored items briefly belong to
+      // the old scope — they must not flash (e.g. another project's chats, or the
+      // global flat view) before the scoped refetch completes.
+      const manager = makeManager() as AgentSessionManager & { getChatHistoryItems: jest.Mock };
+      const { result, rerender } = renderControls(manager, "project-1");
 
-    // A (stale project-1) resolves late → dropped, list stays on project-2's items.
-    await act(async () => {
-      resolvers["project-1"]([item("a1")]);
-      await loadA;
-    });
-    expect(result.current.chatHistoryItems).toHaveLength(2);
-  });
+      await act(async () => {
+        await result.current.loadChatHistory();
+      });
+      expect(result.current.chatHistoryItems).toHaveLength(2);
 
-  it("reports settled only after a load for the CURRENT scope completes", async () => {
-    // Reason: the project landing decides its layout (standalone Context vs the
-    // tabbed shelf) from the chat count, so it must be able to tell "not loaded
-    // yet" apart from "this project has no chats" — and a scope switch must
-    // reset the flag until the new scope's load lands.
-    const manager = makeManager() as AgentSessionManager & { getChatHistoryItems: jest.Mock };
-    const { result, rerender } = renderControls(manager, "project-1");
+      // Switch project before the new scope's items load → list clears, not stale.
+      rerender({ s: "project-2" });
+      expect(result.current.chatHistoryItems).toHaveLength(0);
 
-    expect(result.current.chatHistorySettled).toBe(false);
-    await act(async () => {
-      await result.current.loadChatHistory();
-    });
-    expect(result.current.chatHistorySettled).toBe(true);
-
-    rerender({ s: "project-2" });
-    expect(result.current.chatHistorySettled).toBe(false);
-    await act(async () => {
-      await result.current.loadChatHistory();
-    });
-    expect(result.current.chatHistorySettled).toBe(true);
-  });
-
-  it("settles even when the load fails, leaving the items empty", async () => {
-    // Reason: a failed first load must not leave the landing undecided forever
-    // (blank below the composer) — it settles with an empty list and the landing
-    // degrades to its zero-chat layout.
-    const manager = makeManager() as AgentSessionManager & { getChatHistoryItems: jest.Mock };
-    manager.getChatHistoryItems.mockRejectedValueOnce(new Error("vault read failed"));
-    const { result } = renderControls(manager, "project-1");
-
-    await act(async () => {
-      await result.current.loadChatHistory();
+      await act(async () => {
+        await result.current.loadChatHistory();
+      });
+      expect(manager.getChatHistoryItems).toHaveBeenLastCalledWith("project-2");
+      expect(result.current.chatHistoryItems).toHaveLength(2);
     });
 
-    expect(result.current.chatHistorySettled).toBe(true);
-    expect(result.current.chatHistoryItems).toHaveLength(0);
-  });
+    it("drops a stale out-of-order load whose scope was superseded mid-flight", async () => {
+      // Reason: if the scope flips while an older fetch is still in flight and that
+      // older fetch resolves AFTER the newer one, it must not write its stale items
+      // back — otherwise the current scope's list is clobbered by the prior scope's
+      // and sticks (the visible-scope guard would then blank it permanently).
+      const resolvers: Record<string, (items: ChatHistoryItem[]) => void> = {};
+      const manager = {
+        getChatHistoryItems: jest.fn(
+          (s?: string) =>
+            new Promise<ChatHistoryItem[]>((resolve) => {
+              resolvers[s ?? GLOBAL_SCOPE] = resolve;
+            })
+        ),
+        updateChatTitle: jest.fn(async () => {}),
+        deleteChatHistory: jest.fn(async () => {}),
+      } as unknown as AgentSessionManager & { getChatHistoryItems: jest.Mock };
 
-  it("refreshes within the same scope after a delete", async () => {
-    const manager = makeManager() as AgentSessionManager & {
-      getChatHistoryItems: jest.Mock;
-      deleteChatHistory: jest.Mock;
-    };
-    const { result } = renderControls(manager, "project-1");
+      const { result, rerender } = renderControls(manager, "project-1");
 
-    await act(async () => {
-      await result.current.deleteChat("a");
+      // Start project-1's load (call A) and leave it pending.
+      let loadA!: Promise<void>;
+      act(() => {
+        loadA = result.current.loadChatHistory();
+      });
+
+      // Scope flips to project-2; start its load (call B).
+      rerender({ s: "project-2" });
+      let loadB!: Promise<void>;
+      act(() => {
+        loadB = result.current.loadChatHistory();
+      });
+
+      // B lands first → project-2 items are shown.
+      await act(async () => {
+        resolvers["project-2"]([item("b1"), item("b2")]);
+        await loadB;
+      });
+      expect(result.current.chatHistoryItems).toHaveLength(2);
+
+      // A (stale project-1) resolves late → dropped, list stays on project-2's items.
+      await act(async () => {
+        resolvers["project-1"]([item("a1")]);
+        await loadA;
+      });
+      expect(result.current.chatHistoryItems).toHaveLength(2);
     });
 
-    expect(manager.deleteChatHistory).toHaveBeenCalledWith("a");
-    // The post-mutation reload must stay scoped, not fall back to global.
-    expect(manager.getChatHistoryItems).toHaveBeenCalledWith("project-1");
+    it("reports settled only after a load for the CURRENT scope completes", async () => {
+      // Reason: the project landing decides its layout (standalone Context vs the
+      // tabbed shelf) from the chat count, so it must be able to tell "not loaded
+      // yet" apart from "this project has no chats" — and a scope switch must
+      // reset the flag until the new scope's load lands.
+      const manager = makeManager() as AgentSessionManager & { getChatHistoryItems: jest.Mock };
+      const { result, rerender } = renderControls(manager, "project-1");
+
+      expect(result.current.chatHistorySettled).toBe(false);
+      await act(async () => {
+        await result.current.loadChatHistory();
+      });
+      expect(result.current.chatHistorySettled).toBe(true);
+
+      rerender({ s: "project-2" });
+      expect(result.current.chatHistorySettled).toBe(false);
+      await act(async () => {
+        await result.current.loadChatHistory();
+      });
+      expect(result.current.chatHistorySettled).toBe(true);
+    });
+
+    it("settles even when the load fails, leaving the items empty", async () => {
+      // Reason: a failed first load must not leave the landing undecided forever
+      // (blank below the composer) — it settles with an empty list and the landing
+      // degrades to its zero-chat layout.
+      const manager = makeManager() as AgentSessionManager & { getChatHistoryItems: jest.Mock };
+      manager.getChatHistoryItems.mockRejectedValueOnce(new Error("vault read failed"));
+      const { result } = renderControls(manager, "project-1");
+
+      await act(async () => {
+        await result.current.loadChatHistory();
+      });
+
+      expect(result.current.chatHistorySettled).toBe(true);
+      expect(result.current.chatHistoryItems).toHaveLength(0);
+    });
+
+    it("refreshes within the same scope after a delete", async () => {
+      const manager = makeManager() as AgentSessionManager & {
+        getChatHistoryItems: jest.Mock;
+        deleteChatHistory: jest.Mock;
+      };
+      const { result } = renderControls(manager, "project-1");
+
+      await act(async () => {
+        await result.current.deleteChat("a");
+      });
+
+      expect(manager.deleteChatHistory).toHaveBeenCalledWith("a");
+      // The post-mutation reload must stay scoped, not fall back to global.
+      expect(manager.getChatHistoryItems).toHaveBeenCalledWith("project-1");
+    });
   });
 });

--- a/src/agentMode/ui/hooks/useAgentHistoryControls.ts
+++ b/src/agentMode/ui/hooks/useAgentHistoryControls.ts
@@ -25,6 +25,7 @@ export interface AgentHistoryControls {
   loadChat: (id: string) => Promise<void>;
   updateChatTitle: (id: string, newTitle: string) => Promise<void>;
   deleteChat: (id: string) => Promise<void>;
+  closeSession: (id: string) => Promise<void>;
   openSourceFile: (id: string) => Promise<void>;
 }
 
@@ -144,6 +145,8 @@ export function useAgentHistoryControls(
     [manager, loadChatHistory, runWithNotice]
   );
 
+  const closeSession = useCallback((id: string) => manager.closeChatSession(id), [manager]);
+
   const openSourceFile = useCallback(
     async (id: string) => {
       await runWithNotice("open chat source", () => plugin.openChatSourceFile(id));
@@ -158,6 +161,7 @@ export function useAgentHistoryControls(
     loadChat,
     updateChatTitle,
     deleteChat,
+    closeSession,
     openSourceFile,
   };
 }

--- a/src/components/chat-components/ChatHistoryPopover.test.tsx
+++ b/src/components/chat-components/ChatHistoryPopover.test.tsx
@@ -1,0 +1,64 @@
+import { ChatHistoryPopover } from "@/components/chat-components/ChatHistoryPopover";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+jest.mock("@/settings/model", () => ({
+  useSettingsValue: jest.fn(() => ({ chatHistorySortStrategy: "recent" })),
+}));
+
+const issue = "https://github.com/Brevilabs/obsidian-copilot-private/issues/429";
+const history = ["Open research", "Saved research"].map((title) => ({
+  id: title,
+  title,
+  createdAt: new Date(),
+  lastAccessedAt: new Date(),
+}));
+
+describe("ChatHistoryPopover", () => {
+  beforeEach(() => {
+    window.IntersectionObserver = jest.fn(() => ({
+      observe: jest.fn(),
+      disconnect: jest.fn(),
+    })) as unknown as typeof IntersectionObserver;
+  });
+  describe("ChatHistoryPopover()", () => {
+    it(`${issue} closes an open session while preserving its saved history and leaving the popover open`, async () => {
+      const onCloseSession = jest.fn(async () => {});
+      const onLoadChat = jest.fn(async () => {});
+      const onDeleteChat = jest.fn(async () => {});
+      const props = {
+        chatHistory: history,
+        onUpdateTitle: jest.fn(),
+        onDeleteChat,
+        onLoadChat,
+        onCloseSession,
+      };
+      const { rerender } = render(
+        <ChatHistoryPopover {...props} openChatIds={new Set([history[0].id])}>
+          <button type="button">History</button>
+        </ChatHistoryPopover>
+      );
+      fireEvent.click(screen.getByText("History"));
+      expect(screen.getAllByLabelText("Session open")).toHaveLength(1);
+      const button = screen.getByRole("button", { name: "Close session" });
+      fireEvent.keyDown(button, { key: "Enter" });
+      await act(async () => fireEvent.click(button));
+      expect(onCloseSession).toHaveBeenCalledWith(history[0].id);
+      expect(onLoadChat).not.toHaveBeenCalled();
+      expect(onDeleteChat).not.toHaveBeenCalled();
+      rerender(
+        <ChatHistoryPopover {...props} openChatIds={new Set()}>
+          <button type="button">History</button>
+        </ChatHistoryPopover>
+      );
+      expect(screen.queryByLabelText("Session open")).toBeNull();
+      expect(screen.queryByRole("button", { name: "Close session" })).toBeNull();
+      expect(screen.getByText("Open research")).toBeTruthy();
+      expect(screen.getByText("Saved research")).toBeTruthy();
+      await act(async () =>
+        fireEvent.keyDown(screen.getByRole("button", { name: "Open research" }), { key: "Enter" })
+      );
+      expect(onLoadChat).toHaveBeenCalledWith(history[0].id);
+    });
+  });
+});

--- a/src/components/chat-components/ChatHistoryPopover.tsx
+++ b/src/components/chat-components/ChatHistoryPopover.tsx
@@ -1,7 +1,4 @@
-import {
-  OpenSessionIndicator,
-  CloseSessionButton,
-} from "@/components/chat-components/ui/OpenSessionControls";
+import { CloseSessionButton } from "@/components/chat-components/ui/OpenSessionControls";
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { ArrowUpRight, Check, Edit2, MessageCircle, Trash2, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -485,11 +482,9 @@ function ChatHistoryItem({
       <ChatIconWithAttention
         icon={RowIcon}
         needsAttention={chat.needsAttention}
+        isSessionOpen={isSessionOpen}
         iconClassName="tw-size-3 tw-text-muted"
       />
-
-      {/* Idle backends still hold resources: https://github.com/Brevilabs/obsidian-copilot-private/issues/429 */}
-      {isSessionOpen && <OpenSessionIndicator />}
       <span
         className="tw-block tw-min-w-0 tw-flex-1 tw-truncate tw-text-sm tw-font-medium tw-text-normal"
         title={chat.title}

--- a/src/components/chat-components/ChatHistoryPopover.tsx
+++ b/src/components/chat-components/ChatHistoryPopover.tsx
@@ -1,3 +1,7 @@
+import {
+  OpenSessionIndicator,
+  CloseSessionButton,
+} from "@/components/chat-components/ui/OpenSessionControls";
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { ArrowUpRight, Check, Edit2, MessageCircle, Trash2, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -44,6 +48,8 @@ type ChatHistoryBadgeResolver = (item: ChatHistoryItem) => React.ReactNode;
 interface ChatHistoryPopoverProps {
   children: React.ReactNode;
   chatHistory: ChatHistoryItem[];
+  openChatIds?: ReadonlySet<string>;
+  onCloseSession?: (id: string) => Promise<void>;
   onUpdateTitle: (id: string, newTitle: string) => Promise<void>;
   onDeleteChat: (id: string) => Promise<void>;
   onLoadChat?: (id: string) => Promise<void>;
@@ -70,6 +76,8 @@ interface ChatHistoryPopoverProps {
 export function ChatHistoryPopover({
   children,
   chatHistory,
+  openChatIds,
+  onCloseSession,
   onUpdateTitle,
   onDeleteChat,
   onLoadChat,
@@ -344,6 +352,8 @@ export function ChatHistoryPopover({
                           <ChatHistoryItem
                             key={chat.id}
                             chat={chat}
+                            isSessionOpen={openChatIds?.has(chat.id) ?? false}
+                            onCloseSession={onCloseSession}
                             isEditing={editingId === chat.id}
                             editingTitle={editingTitle}
                             onEditingTitleChange={setEditingTitle}
@@ -386,6 +396,8 @@ export function ChatHistoryPopover({
 
 interface ChatHistoryItemProps {
   chat: ChatHistoryItem;
+  isSessionOpen: boolean;
+  onCloseSession?: (id: string) => Promise<void>;
   isEditing: boolean;
   editingTitle: string;
   onEditingTitleChange: (title: string) => void;
@@ -404,6 +416,8 @@ interface ChatHistoryItemProps {
 
 function ChatHistoryItem({
   chat,
+  isSessionOpen,
+  onCloseSession,
   isEditing,
   editingTitle,
   onEditingTitleChange,
@@ -456,6 +470,16 @@ function ChatHistoryItem({
       className={cn(
         "tw-group tw-flex tw-cursor-pointer tw-items-center tw-gap-2 tw-rounded-md tw-p-1 tw-transition-colors hover:tw-bg-modifier-hover"
       )}
+      role="button"
+      tabIndex={0}
+      // Let keyboard users reach release controls without opening the chat.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/429
+      onKeyDown={(event) => {
+        if (event.target === event.currentTarget && (event.key === "Enter" || event.key === " ")) {
+          event.preventDefault();
+          onLoadChat(chat.id);
+        }
+      }}
       onClick={() => onLoadChat(chat.id)}
     >
       <ChatIconWithAttention
@@ -464,6 +488,8 @@ function ChatHistoryItem({
         iconClassName="tw-size-3 tw-text-muted"
       />
 
+      {/* Idle backends still hold resources: https://github.com/Brevilabs/obsidian-copilot-private/issues/429 */}
+      {isSessionOpen && <OpenSessionIndicator />}
       <span
         className="tw-block tw-min-w-0 tw-flex-1 tw-truncate tw-text-sm tw-font-medium tw-text-normal"
         title={chat.title}
@@ -476,7 +502,7 @@ function ChatHistoryItem({
       <div
         className={cn(
           "tw-flex tw-shrink-0 tw-items-center tw-gap-1.5 tw-transition-opacity",
-          isMobile ? "tw-flex" : "tw-hidden group-hover:tw-flex"
+          isMobile ? "tw-flex" : "tw-hidden group-focus-within:tw-flex group-hover:tw-flex"
         )}
       >
         {confirmDeleteId === chat.id ? (
@@ -510,6 +536,9 @@ function ChatHistoryItem({
         ) : (
           // Show edit and delete buttons
           <>
+            {isSessionOpen && onCloseSession && (
+              <CloseSessionButton chatId={chat.id} onCloseSession={onCloseSession} />
+            )}
             <Button
               size="sm"
               variant="ghost"

--- a/src/components/chat-components/ChatIconWithAttention.tsx
+++ b/src/components/chat-components/ChatIconWithAttention.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { OpenSessionIndicator } from "@/components/chat-components/ui/OpenSessionControls";
 import { cn } from "@/lib/utils";
 
 interface ChatIconWithAttentionProps {
@@ -6,6 +7,7 @@ interface ChatIconWithAttentionProps {
   icon: React.ComponentType<{ className?: string }>;
   /** Overlay the accent dot — set when a live session for this chat needs attention. */
   needsAttention?: boolean;
+  isSessionOpen?: boolean;
   /** Class for the glyph itself (size + colour); the dot positions against it. */
   iconClassName?: string;
 }
@@ -13,24 +15,28 @@ interface ChatIconWithAttentionProps {
 /**
  * Chat-row icon with the same "needs attention" accent dot the agent tab strip's
  * `BrandIcon` paints, so a backgrounded session that finished / paused for
- * permission reads identically in the history list and on its tab. Accent-only
- * (the history list has no spinner / error-dot states). The wrapper owns
+ * permission remains visible in the history list. The wrapper owns
  * positioning; callers size the glyph via `iconClassName` (rows differ: `tw-size-3`
- * in the popover, `tw-size-4` inline).
+ * in the popover, `tw-size-4` inline). Open sessions reserve the top-right
+ * corner for their status; attention stays visible at the bottom-right.
  */
 export const ChatIconWithAttention: React.FC<ChatIconWithAttentionProps> = ({
   icon: Icon,
   needsAttention,
+  isSessionOpen,
   iconClassName,
 }) => (
   <span className="tw-relative tw-inline-flex tw-shrink-0 tw-items-center tw-justify-center">
     <Icon className={iconClassName} />
+    {/* Idle backends still hold resources: https://github.com/Brevilabs/obsidian-copilot-private/issues/429 */}
+    {isSessionOpen && <OpenSessionIndicator />}
     {needsAttention && (
       <span
         aria-hidden
         className={cn(
-          "tw-absolute -tw-right-0.5 -tw-top-0.5 tw-size-1.5 tw-rounded-full tw-ring-1 tw-ring-[var(--background-primary)]",
-          "tw-bg-interactive-accent"
+          "tw-absolute -tw-right-0.5 tw-size-1.5 tw-rounded-full tw-ring-1 tw-ring-[var(--background-primary)]",
+          "tw-bg-interactive-accent",
+          isSessionOpen ? "-tw-bottom-0.5" : "-tw-top-0.5"
         )}
       />
     )}

--- a/src/components/chat-components/ui/OpenSessionControls.stories.tsx
+++ b/src/components/chat-components/ui/OpenSessionControls.stories.tsx
@@ -1,0 +1,35 @@
+import {
+  CloseSessionButton,
+  OpenSessionIndicator,
+} from "@/components/chat-components/ui/OpenSessionControls";
+import type { Meta, StoryObj } from "@/lib/story";
+import React from "react";
+
+type Props = React.ComponentProps<typeof CloseSessionButton>;
+const meta = {
+  title: "Chat/Open Session Controls",
+  component: CloseSessionButton,
+  args: { chatId: "research", onCloseSession: async () => {} },
+  parameters: { gallery: { host: "popover", layout: "padded" } },
+} satisfies Meta<Props>;
+export default meta;
+
+export const OpenIdle: StoryObj<Props> = {
+  render: (args) => (
+    <div className="tw-flex tw-items-center tw-gap-2">
+      <OpenSessionIndicator />
+      <span>Research notes</span>
+      <CloseSessionButton {...meta.args} {...args} />
+    </div>
+  ),
+};
+export const Pending: StoryObj<Props> = {
+  args: { onCloseSession: () => new Promise(() => {}) },
+};
+export const FailedClose: StoryObj<Props> = {
+  args: {
+    onCloseSession: async () => {
+      throw new Error("Backend unavailable");
+    },
+  },
+};

--- a/src/components/chat-components/ui/OpenSessionControls.stories.tsx
+++ b/src/components/chat-components/ui/OpenSessionControls.stories.tsx
@@ -4,6 +4,7 @@ import {
 } from "@/components/chat-components/ui/OpenSessionControls";
 import type { Meta, StoryObj } from "@/lib/story";
 import React from "react";
+import { MessageSquare } from "lucide-react";
 
 type Props = React.ComponentProps<typeof CloseSessionButton>;
 const meta = {
@@ -17,7 +18,10 @@ export default meta;
 export const OpenIdle: StoryObj<Props> = {
   render: (args) => (
     <div className="tw-flex tw-items-center tw-gap-2">
-      <OpenSessionIndicator />
+      <span className="tw-relative tw-inline-flex tw-shrink-0">
+        <MessageSquare className="tw-size-4 tw-text-muted" />
+        <OpenSessionIndicator />
+      </span>
       <span>Research notes</span>
       <CloseSessionButton {...meta.args} {...args} />
     </div>

--- a/src/components/chat-components/ui/OpenSessionControls.test.tsx
+++ b/src/components/chat-components/ui/OpenSessionControls.test.tsx
@@ -1,0 +1,62 @@
+import {
+  CloseSessionButton,
+  OpenSessionIndicator,
+} from "@/components/chat-components/ui/OpenSessionControls";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+const issue = "https://github.com/Brevilabs/obsidian-copilot-private/issues/429";
+
+describe("OpenSessionControls", () => {
+  describe("OpenSessionIndicator()", () => {
+    it(`${issue} labels an open session independently of turn activity`, () => {
+      render(<OpenSessionIndicator />);
+      expect(screen.getByLabelText("Session open").title).toBe("Session open");
+    });
+  });
+  describe("CloseSessionButton()", () => {
+    it(`${issue} releases the selected session once while pending without activating its row`, async () => {
+      let finish!: () => void;
+      const onCloseSession = jest.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            finish = resolve;
+          })
+      );
+      const onOpen = jest.fn();
+      render(
+        <div onClick={onOpen} onKeyDown={onOpen}>
+          <CloseSessionButton chatId="research" onCloseSession={onCloseSession} />
+        </div>
+      );
+      const button = screen.getByRole("button", { name: "Close session" });
+      fireEvent.keyDown(button, { key: "Enter" });
+      fireEvent.keyDown(button, { key: " " });
+      fireEvent.click(button);
+      expect(button.hasAttribute("disabled")).toBe(true);
+      fireEvent.click(button);
+      expect(onCloseSession).toHaveBeenCalledTimes(1);
+      expect(onCloseSession).toHaveBeenCalledWith("research");
+      expect(onOpen).not.toHaveBeenCalled();
+      await act(async () => finish());
+      expect(button.hasAttribute("disabled")).toBe(false);
+    });
+    it.each([
+      { reason: new Error("backend unavailable"), message: "backend unavailable" },
+      { reason: undefined, message: "Try again." },
+    ])(
+      `${issue} explains a failed close ($message) and permits retry`,
+      async ({ reason, message }) => {
+        const onCloseSession = jest.fn().mockRejectedValueOnce(reason).mockResolvedValue(undefined);
+        render(<CloseSessionButton chatId="research" onCloseSession={onCloseSession} />);
+        const button = screen.getByRole("button", { name: "Close session" });
+        await act(async () => fireEvent.click(button));
+        expect(screen.getByRole("alert").textContent).toBe(`Could not close session: ${message}`);
+        expect(button.hasAttribute("disabled")).toBe(false);
+        await act(async () => fireEvent.click(button));
+        expect(screen.queryByRole("alert")).toBeNull();
+        expect(onCloseSession).toHaveBeenCalledTimes(2);
+      }
+    );
+  });
+});

--- a/src/components/chat-components/ui/OpenSessionControls.tsx
+++ b/src/components/chat-components/ui/OpenSessionControls.tsx
@@ -7,7 +7,7 @@ export function OpenSessionIndicator() {
     <span
       aria-label="Session open"
       title="Session open"
-      className="tw-size-1.5 tw-shrink-0 tw-rounded-full tw-bg-error tw-opacity-60"
+      className="tw-absolute -tw-right-0.5 -tw-top-0.5 tw-size-2 tw-rounded-full tw-bg-current tw-text-success tw-ring-1 tw-ring-[var(--background-primary)]"
     />
   );
 }

--- a/src/components/chat-components/ui/OpenSessionControls.tsx
+++ b/src/components/chat-components/ui/OpenSessionControls.tsx
@@ -1,0 +1,64 @@
+import { Button } from "@/components/ui/button";
+import { Power } from "lucide-react";
+import React, { useState } from "react";
+
+export function OpenSessionIndicator() {
+  return (
+    <span
+      aria-label="Session open"
+      title="Session open"
+      className="tw-size-1.5 tw-shrink-0 tw-rounded-full tw-bg-error tw-opacity-60"
+    />
+  );
+}
+
+interface CloseSessionButtonProps {
+  chatId: string;
+  onCloseSession: (id: string) => Promise<void>;
+}
+
+export function CloseSessionButton({ chatId, onCloseSession }: CloseSessionButtonProps) {
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Disabled buttons let pointer events through; keep their clicks off the chat row.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/429
+  return (
+    <span
+      className="tw-flex tw-items-center tw-gap-1"
+      onClick={(event) => event.stopPropagation()}
+      onKeyDown={(event) => event.stopPropagation()}
+    >
+      <Button
+        size="sm"
+        variant="ghost"
+        className="tw-size-5 tw-p-0"
+        aria-label="Close session"
+        title="Close session"
+        disabled={pending}
+        onClick={(event) => {
+          event.stopPropagation();
+          setPending(true);
+          setError(null);
+          // A failed release must remain retryable without deleting saved history.
+          // https://github.com/Brevilabs/obsidian-copilot-private/issues/429
+          void onCloseSession(chatId)
+            .catch((reason: unknown) =>
+              setError(reason instanceof Error ? reason.message : "Try again.")
+            )
+            .finally(() => setPending(false));
+        }}
+      >
+        <Power className="tw-size-3" />
+      </Button>
+      {error && (
+        <span
+          role="alert"
+          title={error}
+          className="tw-max-w-32 tw-whitespace-normal tw-break-words tw-text-xs tw-text-error"
+        >
+          Could not close session: {error}
+        </span>
+      )}
+    </span>
+  );
+}


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#429

## Why

Idle agent sessions stay open after users leave their chats. Recent Chats does not identify them or offer a way to release them, and the existing tab close only removes local state.

## What

Recent Chats and Chat History show a solid green dot over the chat icon’s top-right corner for open sessions and a Close session action. Closing from history releases that session while keeping saved history and other chats available. Pending closes block new sends; failed or unsupported releases keep the chat open with an error.

## Non goal

Automatic idle eviction, session limits, closing sessions on navigation, and fan-out cleanup.

## Screenshot

Same five-chat fixture at 340 pixels, rendered in the test-vault gallery. The first two chats are open in the after state. Gallery fixtures keep the comparison deterministic without using personal conversations.

| Before | After |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/2ba7edae-d53b-48e0-8df1-62dff142af8f) | ![After](https://github.com/user-attachments/assets/6b0775d2-5595-470a-b4f2-7fc0095e9b7a) |

## Risk

**High**, because closing crosses the agent lifecycle.

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or deterministic tests cover changed behavior | ✅ | Release, retry, history identity, and sibling isolation tests |
| A defect would fail CI or be obvious on first use | ✅ | Close controls and failures have regression coverage |
| A revert fully restores prior state, including persisted data | ✅ | Saved conversations are retained; no migration |
| No auth, permissions, secrets, or input-handling changes | ❌ | New sends are rejected during pending closure |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Backend lifecycle extension is internal and optional |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Per-session release and send exclusion |
| No hot-path behavior lacks deterministic coverage | ✅ | Deferred and duplicate closure tests cover the race |
| No new dependency | ✅ | Existing SDK close method |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Indicators and error copy are visible in history |

Review: inspect `src/agentMode/session/AgentSession.ts` (`releaseBackendSession` and `sendPrompt`), `src/agentMode/session/AgentSessionManager.ts` (`closeSession`), and `closeSession` in `src/agentMode/acp/AcpBackendProcess.ts` and `src/agentMode/sdk/ClaudeSdkBackendProcess.ts`, then run the verification path including failure and concurrent-send cases.

## Verification

1. Start two agent conversations, leave one idle, and open Recent Chats. Confirm both open chats have the dot; an older closed chat does not.
2. Close one from its row. Confirm its saved history remains, its dot disappears, and the other chat remains usable. Reopen the closed conversation.
3. Repeat through Chat History, including during generation. Confirm partial saved output remains. Closing a chat tab retains its existing behavior and does not request backend release.
4. With a delayed or failed close, attempt a send and a second close. Confirm no new message is accepted while pending and failed closure leaves the chat available to retry. An agent without close support must report that limitation.

## Note

This does not establish an Obsidian memory reduction or resolution of the reported ChatGPT access conflict.
