### PR TITLE
Add visual Miyo setup and Relevant Notes tutorials

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -25,7 +25,7 @@ const sidebar = [
   },
   {
     label: "Everyday tools",
-    items: [{ slug: "custom-commands" }, { slug: "chat-interface" }],
+    items: [{ slug: "custom-commands" }, { slug: "chat-interface" }, { slug: "relevant-notes" }],
   },
   {
     label: "Models, plans, and Miyo",
@@ -33,6 +33,7 @@ const sidebar = [
       { label: "Providers and BYOK", link: "/llm-providers/" },
       { label: "Model selection", link: "/models-and-parameters/" },
       { label: "Miyo and semantic search", link: "/vault-search-and-indexing/" },
+      { slug: "miyo-setup" },
       { label: "Copilot paid plans", link: "/copilot-plus-and-self-host/" },
     ],
   },

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ For most people, opencode is the best starting point. Copilot can install and ma
 
 - [Copilot Commands and Quick Ask](custom-commands.md) reuse prompts or work with selected text without leaving the editor.
 - [Quick Chat](chat-interface.md) handles lightweight conversations and is the main chat view on mobile, where Agent Chat is unavailable.
+- [Live Relevant Notes](relevant-notes.md) shows how to preview related notes, drag links into your writing, and add chat context.
 
 ## Models, plans, and Miyo
 
@@ -31,6 +32,7 @@ For most people, opencode is the best starting point. Copilot can install and ma
 - [Models, Effort, and Permissions](models-and-parameters.md) explains model selection, defaults, approval behavior, and reasoning effort.
 - [Miyo: Local-First Search and AI Ownership](vault-search-and-indexing.md) brings more powerful local-first search and AI ownership to your knowledge.
 - [Copilot Plans, Privacy, and Self-Hosting](copilot-plus-and-self-host.md) compares free and paid access, hosted features, privacy, and self-hosting.
+- [Connect Miyo with Copilot](miyo-setup.md) walks through setup with screenshots and short videos.
 
 ## Settings
 

--- a/docs/miyo-setup.md
+++ b/docs/miyo-setup.md
@@ -1,0 +1,99 @@
+# Connect Miyo with Obsidian Copilot
+
+Miyo is the companion app that powers Copilot's search by meaning. It replaces the old index inside the plugin, helping Copilot find relevant notes even when your question uses different words.
+
+This guide connects the Obsidian vault on your computer to Miyo and walks you through your first search.
+
+## Before you start
+
+Use desktop Obsidian with Copilot 4.0.8 or newer. Download Miyo for your operating system from [miyo.md](https://www.miyo.md/) and open it. Use Miyo 0.2.27 or newer if you also want live suggestions while typing in Agent Chat.
+
+Miyo's desktop app and local-agent connection are free. You do not need Relay for this setup. Your chat model or subscription is a separate choice.
+
+## 1. Open Miyo and finish the welcome screens
+
+Click **Get started** when you first open Miyo.
+
+![Miyo welcome screen with Get started](https://pub-d0d5db63b5e446cc848d32b65229d622.r2.dev/copilot/2026-09/miyo-welcome-a20177d8edae.png)
+
+On the sources screen, you can choose **Continue** without adding a folder yet. You will register your vault from Copilot in the next step.
+
+![Miyo setup: continue without adding a folder](https://pub-d0d5db63b5e446cc848d32b65229d622.r2.dev/copilot/2026-09/miyo-setup-sources-5377d71224c1.png)
+
+The next screen separates on-device connections from remote access. Copilot uses the on-device connection for this guide; you do not need to sign in for Relay. Continue through setup, then return to Obsidian.
+
+![Miyo setup: on-device connections and optional Relay](https://pub-d0d5db63b5e446cc848d32b65229d622.r2.dev/copilot/2026-09/miyo-setup-apps-e2a425328204.png)
+
+## 2. Connect your vault
+
+In Obsidian, open **Settings → Copilot → Miyo** and click **Connect**.
+
+If Copilot asks you to register the vault, check that it is the vault you want Miyo to search, then choose **Register & connect**. This adds the vault folder to Miyo and starts indexing its contents.
+
+![Register the current Obsidian vault and connect to Miyo](https://pub-d0d5db63b5e446cc848d32b65229d622.r2.dev/copilot/2026-09/miyo-register-vault-75e305c96305.png)
+
+If the vault is already registered, Copilot can connect directly. If it cannot find Miyo, make sure the app is running and try the connection again.
+
+**What to look for:** a connected status in Copilot's Miyo settings. A running Miyo app and a registered vault are both needed.
+
+## 3. Review which notes are included
+
+Open Miyo and find your vault under its local folders. Review the folder's inclusion and exclusion settings, then let the initial scan finish.
+
+To exclude a folder, open its **Folder settings**, choose **Add** under **Indexing → Exclusions**, select **Folder**, and search for the folder name. Select it, then choose **Save** when you want to apply the rule.
+
+<video controls muted loop playsinline preload="metadata" aria-label="Choose a folder to exclude from Miyo indexing" style="width: 100%; height: auto;">
+  <source src="https://pub-d0d5db63b5e446cc848d32b65229d622.r2.dev/copilot/2026-09/miyo-folder-exclusions-live-8565a84e34cc.mp4" type="video/mp4">
+  <a href="https://pub-d0d5db63b5e446cc848d32b65229d622.r2.dev/copilot/2026-09/miyo-folder-exclusions-live-8565a84e34cc.mp4">Watch: Choose a folder to exclude from Miyo indexing</a>
+</video>
+
+Miyo controls which files it indexes. If you used Copilot's older search exclusions, review your choices in Miyo rather than assuming those settings carried over. Keep folders you do not want searched excluded.
+
+**What to look for:** your vault is listed and its indexing status has finished. A large vault can take longer on its first scan. Miyo watches registered folders for later changes.
+
+![Miyo shows the indexed vault with Watching status](https://pub-d0d5db63b5e446cc848d32b65229d622.r2.dev/copilot/2026-09/miyo-indexed-714dcce29ae0.png)
+
+In this example, the vault has finished scanning and is marked **Watching**.
+
+## 4. Enable semantic search
+
+Return to **Settings → Copilot → Miyo** and turn on **Semantic search**.
+
+This gives your Copilot agents access to Miyo search. Keep **Search scope** on **Current vault** if you only want results from the vault you are using.
+
+![Semantic search switch and Current vault search scope highlighted in Copilot settings](https://pub-d0d5db63b5e446cc848d32b65229d622.r2.dev/copilot/2026-09/miyo-semantic-search-highlight-af74bfad26c5.png)
+
+Turn on the highlighted **Semantic search** switch. Keep **Search scope** set to **Current vault**.
+
+## 5. Try a question
+
+Open Agent Chat and ask about an idea you know you have written about. Describe it as you remember it, without copying a note title.
+
+For example, if you have meeting notes, try:
+
+> Use Miyo to find my notes about making meetings more useful. Show me the matching notes before summarizing them.
+
+Read a returned note to check that it fits your question. Explicitly asking for Miyo makes this first test easier to recognize; you can then use it in your normal Copilot workflow.
+
+**You're connected when:** Copilot uses Miyo search and returns a relevant indexed note from your vault.
+
+## What a search can look like
+
+In a recorded example, an agent searched for notes about using several short-lived AI helpers instead of one long conversation. Its keyword search read six files without finding the relevant file. Asked to try Miyo, it found the on-topic file in one search call.
+
+![Agent search comparison: keyword search reads six files without a match; Miyo finds the related note in one search](https://pub-d0d5db63b5e446cc848d32b65229d622.r2.dev/copilot/2026-09/miyo-comparison-d25fc664fc25.png)
+
+The discovered file was a stub, so this example demonstrates finding a file that keyword search missed. It does not measure answer quality or a token-saving percentage.
+
+## If something is missing
+
+| What you see | What to check |
+| --- | --- |
+| Miyo is not connected | Open Miyo on the same computer, then reconnect from Copilot settings. |
+| Your vault is not registered | Register the current vault. A connected service does not mean every vault has been added. |
+| A note is still indexing | Let Miyo finish processing it, then try again. |
+| A note is excluded | Review its folder rules in Miyo. |
+| No relevant result | Confirm the expected note is indexed and contains useful text. Try describing the idea with more context. |
+| Registration fails | Review the error and the folders already registered in Miyo, including naming or overlapping-folder conflicts. |
+
+Keep Miyo running while using these features. Local indexing happens on your computer; when you use a cloud chat model, the context sent to that model follows your chat configuration. Relay is a separate remote-access feature.

--- a/docs/relevant-notes.md
+++ b/docs/relevant-notes.md
@@ -1,0 +1,82 @@
+# Use Live Relevant Notes in Copilot
+
+Relevant Notes brings related notes into view while you work. You can read a suggestion, link it into your writing, or add it to a chat before asking your question.
+
+This guide covers two workflows: discovering connections while writing a note, and finding useful context while composing a chat message.
+
+## Before you start
+
+Use desktop Copilot 4.0.8 or newer with Miyo 0.2.27 or newer, running and connected to your indexed vault. If you have not connected it yet, follow [Connect Miyo with Obsidian Copilot](miyo-setup.md).
+
+## 1. Open Relevant Notes
+
+Open Copilot's Agent Chat view and choose **Relevant Notes**. Use **Open in separate pane** if you want to keep the suggestions visible beside your editor or chat.
+
+Turn on **Live**. The source label tells you what the suggestions relate to, such as the open note or the Agent Chat context.
+
+## 2. Discover related notes while writing
+
+Open a note with some text and begin writing. As the subject develops, Relevant Notes can bring different notes into view.
+
+In this demo, a weekend plan starts with hiking, then shifts toward visiting Hong Kong. The suggestions change along with the writing.
+
+<video controls muted loop playsinline preload="metadata" aria-label="Relevant Notes changes as the note shifts from hiking to a Hong Kong visit" style="width: 100%; height: auto;">
+  <source src="https://pub-d0d5db63b5e446cc848d32b65229d622.r2.dev/copilot/2026-09/live-relevant-editor-clean-62eb5ce757a0.mp4" type="video/mp4">
+  <a href="https://pub-d0d5db63b5e446cc848d32b65229d622.r2.dev/copilot/2026-09/live-relevant-editor-clean-62eb5ce757a0.mp4">Watch: Relevant Notes changes as the note shifts from hiking to a Hong Kong visit</a>
+</video>
+
+Hover over a suggested title to preview the note. Click **Open note** when you want to read it in full.
+
+The percentage beside a suggestion describes its similarity to the source context. Use the preview to decide whether it is useful; the number is not a measure of factual accuracy.
+
+## 3. Link a suggestion into your note
+
+Keep the note you are writing open in an editable view. Drag a suggested note's title from Relevant Notes to the place in your editor where you want the reference.
+
+Obsidian inserts a link to that note. This adds a reference, not a copy of its contents.
+
+**What to look for:** the linked note title appears at the drop position in your writing.
+
+<video controls muted loop playsinline preload="metadata" aria-label="Drag Daily Notes Best Practices into the editor to insert a note link" style="width: 100%; height: auto;">
+  <source src="https://pub-d0d5db63b5e446cc848d32b65229d622.r2.dev/copilot/2026-09/relevant-notes-drag-to-note-d16596640a03.mp4" type="video/mp4">
+  <a href="https://pub-d0d5db63b5e446cc848d32b65229d622.r2.dev/copilot/2026-09/relevant-notes-drag-to-note-d16596640a03.mp4">Watch: Drag Daily Notes Best Practices into the editor to insert a note link</a>
+</video>
+
+## 4. Find context before sending a question
+
+With Live on, start typing in Agent Chat. Suggestions follow your draft and conversation, so you can discover useful context before sending the message.
+
+Try a question related to material in your vault. The demo uses:
+
+> Help me plan our next team workshop.
+
+Hover over a useful suggestion and choose **Add to Chat**. Check that the note appears in your chat context, then make your question more specific using what you found.
+
+<video controls muted loop playsinline preload="metadata" aria-label="Preview a related note and add it to Agent Chat while drafting a question" style="width: 100%; height: auto;">
+  <source src="https://pub-d0d5db63b5e446cc848d32b65229d622.r2.dev/copilot/2026-09/live-relevant-notes-clean-35f7a92dda84.mp4" type="video/mp4">
+  <a href="https://pub-d0d5db63b5e446cc848d32b65229d622.r2.dev/copilot/2026-09/live-relevant-notes-clean-35f7a92dda84.mp4">Watch: Preview a related note and add it to Agent Chat while drafting a question</a>
+</video>
+
+For example, a note about silent writing might remind you to ask for a workshop that starts with five minutes of individual thinking.
+
+Suggested notes are not all attached automatically. You choose which ones to add before sending.
+
+## Which context is being used?
+
+When chat-based Live suggestions are active, they follow your Agent Chat draft and conversation. When Live is off, Relevant Notes stays tied to the editor note.
+
+If suggestions seem unrelated to what you intended, check the source label first. Then check that the note or chat you want to work with is active.
+
+## If suggestions do not appear
+
+| Message or symptom | What to do |
+| --- | --- |
+| Miyo is not connected | Start Miyo and reconnect in Copilot settings. |
+| This vault is not registered | Add this vault to Miyo. |
+| Still indexing or note not indexed | Let indexing finish and review the note's status in Miyo. |
+| This note is excluded | Check Miyo's folder rules. |
+| No semantic matches yet | Try a note with more useful text or a more specific question. A connected index may have no related material. |
+| No usable chat context | Write a message or add an indexed note. |
+| Editor suggestions work, but chat suggestions do not | Check Copilot and Miyo versions and turn on Live. Chat suggestions require Miyo 0.2.27 support. |
+
+[Watch the full Relevant Notes demo →](https://pub-d0d5db63b5e446cc848d32b65229d622.r2.dev/copilot/releases/4.0.8/relevant-notes-demo-20260910.mp4)


### PR DESCRIPTION
## Why

Users need a visual path from installing Miyo to finding notes and using Relevant Notes in their writing and chats.

## What

Add two step-by-step tutorials with setup screenshots, a highlighted Semantic search switch, and short videos for folder exclusions, live suggestions, drag-to-note links, and Add to Chat. Both guides appear in the docs navigation. Media is hosted on Zero's R2 bucket.

## Non goal

Plugin behavior, media storage in the repository, and newsletter delivery.

## Screenshot

![Miyo setup tutorial](https://pub-d0d5db63b5e446cc848d32b65229d622.r2.dev/copilot/2026-09/miyo-docs-rendered-d1c801f29f3b.png)

![Relevant Notes tutorial](https://pub-d0d5db63b5e446cc848d32b65229d622.r2.dev/copilot/2026-09/relevant-docs-rendered-d39f5e42ae2f.png)

GitHub's attachment endpoint returned HTTP 422; the rendered captures use R2 instead.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | New content uses the existing page renderer |
| A defect would fail CI or be obvious on first use | ✅ | Missing media or broken layout is visible on the pages |
| A revert fully restores prior state, including persisted data | ✅ | No user data changes |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Public article content only |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Existing routes and contracts are unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | No runtime logic changes |
| No hot-path behavior lacks deterministic coverage | ✅ | No execution-path changes |
| No new dependency | ✅ | Existing Markdown and media support |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Content and media are visible on the article pages |

Review: follow Verification steps 2–3 and confirm CI is green.

## Verification

1. In `docs`, run `npm ci`, `npm run build`, and `npm run preview`.
2. Open `/miyo-setup/`. Check the sidebar link, onboarding images, folder-exclusion video, and highlighted Semantic search switch.
3. Open `/relevant-notes/`. Play each short video, including dragging a suggestion into the note. Follow the setup link and check both pages at phone width.

## Note

Final URLs are `https://docs.obsidiancopilot.com/miyo-setup/` and `https://docs.obsidiancopilot.com/relevant-notes/`. First-run screenshots come from the supplied Miyo material; confirm they match the release before publication.
